### PR TITLE
refactor: 移除获取 AstrBot 版本的静态方法，改为使用独立函数获取版本信息

### DIFF
--- a/core/telemetry_manager.py
+++ b/core/telemetry_manager.py
@@ -14,7 +14,6 @@ import base64
 import copy
 import platform
 import re
-import tomllib
 import traceback
 import uuid
 from datetime import datetime, timezone
@@ -22,10 +21,11 @@ from pathlib import Path
 from typing import Any
 
 import aiohttp
-import astrbot
 
 from astrbot.api import logger
 from astrbot.api.star import StarTools
+
+from ..utils.version import get_astrbot_version
 
 
 class TelemetryManager:
@@ -51,7 +51,7 @@ class TelemetryManager:
         self._plugin_version = plugin_version
         
         # 获取 AstrBot 版本号
-        self._astrbot_version = self._get_astrbot_version()
+        self._astrbot_version = get_astrbot_version()
 
         # 从配置中读取遥测开关
         telemetry_config = config.get("telemetry_config", {})
@@ -321,35 +321,6 @@ class TelemetryManager:
         message = re.sub(r"[A-Za-z]:\\Users\\[^\\\s]+\\", r"<USER_HOME>\\", message)
 
         return message
-
-
-    @staticmethod
-    def _get_astrbot_version() -> str:
-        """
-        从 pyproject.toml 获取 AstrBot 版本号
-        
-        Returns:
-            str: AstrBot 版本号,获取失败则返回 "unknown"
-        """
-        try:
-            # 从 astrbot 包路径定位 pyproject.toml
-            astrbot_path = Path(astrbot.__file__).parent.parent
-            pyproject_path = astrbot_path / 'pyproject.toml'
-            
-            if pyproject_path.exists():
-                with open(pyproject_path, 'rb') as f:
-                    data = tomllib.load(f)
-                    version_str = data.get('project', {}).get('version', 'unknown')
-                    if version_str != 'unknown':
-                        logger.debug(f"[灾害预警] ✅ 从 pyproject.toml 获取到 AstrBot 版本: {version_str}")
-                        return version_str
-            
-            logger.debug(f"[灾害预警] ⚠️  无法读取 AstrBot 版本,pyproject.toml 不存在: {pyproject_path}")
-            return "unknown"
-            
-        except Exception as e:
-            logger.debug(f"[灾害预警] ❌ 获取 AstrBot 版本时出错: {e}")
-            return "unknown"
 
 
     async def close(self):

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,4 +1,10 @@
 import os
+import re
+import tomllib
+from pathlib import Path
+
+import astrbot
+from astrbot.api import logger
 
 
 def get_plugin_version() -> str:
@@ -16,11 +22,41 @@ def get_plugin_version() -> str:
 
         if os.path.exists(metadata_path):
             with open(metadata_path, encoding="utf-8") as f:
-                # 简单解析 YAML，避免引入 yaml 依赖
+                # 轻量级 YAML 解析，使用正则提取版本号并去除注释
                 for line in f:
-                    if line.strip().startswith("version:"):
-                        return line.split(":", 1)[1].strip()
+                    # 匹配 "version: <值>" 并去除行尾注释
+                    match = re.match(r'^\s*version:\s*([^#\n]+)', line)
+                    if match:
+                        return match.group(1).strip()
     except Exception:
         pass
 
     return "unknown"
+
+
+def get_astrbot_version() -> str:
+    """
+    从 pyproject.toml 获取 AstrBot 版本号
+    
+    Returns:
+        str: AstrBot 版本号,获取失败则返回 "unknown"
+    """
+    try:
+        # 从 astrbot 包路径定位 pyproject.toml
+        astrbot_path = Path(astrbot.__file__).parent.parent
+        pyproject_path = astrbot_path / 'pyproject.toml'
+        
+        if pyproject_path.exists():
+            with open(pyproject_path, 'rb') as f:
+                data = tomllib.load(f)
+                version_str = data.get('project', {}).get('version', 'unknown')
+                if version_str != 'unknown':
+                    logger.debug(f"[灾害预警] ✅ 从 pyproject.toml 获取到 AstrBot 版本: {version_str}")
+                    return version_str
+        
+        logger.debug(f"[灾害预警] ⚠️  无法读取 AstrBot 版本,pyproject.toml 不存在: {pyproject_path}")
+        return "unknown"
+        
+    except Exception as e:
+        logger.debug(f"[灾害预警] ❌ 获取 AstrBot 版本时出错: {e}")
+        return "unknown"


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

将 AstrBot 版本获取集中到共享工具中，并增强插件版本解析的健壮性。

改进内容：
- 在 `utils.version` 中新增可复用的 `get_astrbot_version` 辅助函数，并在 `TelemetryManager` 中使用它替代原先的类静态方法。
- 强化用于插件版本元数据的轻量级 YAML 解析逻辑，确保在忽略注释的情况下正确提取 `version` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize AstrBot version retrieval into a shared utility and improve robustness of plugin version parsing.

Enhancements:
- Introduce a reusable get_astrbot_version helper in utils.version and use it in TelemetryManager instead of a class static method.
- Harden lightweight YAML parsing for plugin version metadata to correctly extract the version field while ignoring comments.

</details>

增强内容：
- 将 AstrBot 版本查询集中到 `utils.version` 中，并在 `TelemetryManager` 中使用它来替代静态方法。
- 改进用于插件版本元数据的轻量级 YAML 解析，更加健壮地提取 `version` 字段并忽略注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 AstrBot 版本获取集中到共享工具中，并增强插件版本解析的健壮性。

改进内容：
- 在 `utils.version` 中新增可复用的 `get_astrbot_version` 辅助函数，并在 `TelemetryManager` 中使用它替代原先的类静态方法。
- 强化用于插件版本元数据的轻量级 YAML 解析逻辑，确保在忽略注释的情况下正确提取 `version` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize AstrBot version retrieval into a shared utility and improve robustness of plugin version parsing.

Enhancements:
- Introduce a reusable get_astrbot_version helper in utils.version and use it in TelemetryManager instead of a class static method.
- Harden lightweight YAML parsing for plugin version metadata to correctly extract the version field while ignoring comments.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 AstrBot 版本获取集中到共享工具中，并增强插件版本解析的健壮性。

改进内容：
- 在 `utils.version` 中新增可复用的 `get_astrbot_version` 辅助函数，并在 `TelemetryManager` 中使用它替代原先的类静态方法。
- 强化用于插件版本元数据的轻量级 YAML 解析逻辑，确保在忽略注释的情况下正确提取 `version` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize AstrBot version retrieval into a shared utility and improve robustness of plugin version parsing.

Enhancements:
- Introduce a reusable get_astrbot_version helper in utils.version and use it in TelemetryManager instead of a class static method.
- Harden lightweight YAML parsing for plugin version metadata to correctly extract the version field while ignoring comments.

</details>

增强内容：
- 将 AstrBot 版本查询集中到 `utils.version` 中，并在 `TelemetryManager` 中使用它来替代静态方法。
- 改进用于插件版本元数据的轻量级 YAML 解析，更加健壮地提取 `version` 字段并忽略注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 AstrBot 版本获取集中到共享工具中，并增强插件版本解析的健壮性。

改进内容：
- 在 `utils.version` 中新增可复用的 `get_astrbot_version` 辅助函数，并在 `TelemetryManager` 中使用它替代原先的类静态方法。
- 强化用于插件版本元数据的轻量级 YAML 解析逻辑，确保在忽略注释的情况下正确提取 `version` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize AstrBot version retrieval into a shared utility and improve robustness of plugin version parsing.

Enhancements:
- Introduce a reusable get_astrbot_version helper in utils.version and use it in TelemetryManager instead of a class static method.
- Harden lightweight YAML parsing for plugin version metadata to correctly extract the version field while ignoring comments.

</details>

</details>

</details>