### PR TITLE
fix: prevent websocket reconnect after plugin shutdown | issue#73

### DIFF
--- a/core/disaster_service.py
+++ b/core/disaster_service.py
@@ -42,6 +42,8 @@ class DisasterWarningService:
         self.context = context
         self.running = False
         self._start_lock = asyncio.Lock()  # 防止并发启动的锁
+        self._stop_lock = asyncio.Lock()  # 防止并发停止导致的竞态
+        self._stopping = False
 
         # 初始化消息记录器
         self.message_logger = MessageLogger(config, "disaster_warning")
@@ -268,6 +270,7 @@ class DisasterWarningService:
 
             try:
                 self.running = True
+                self._stopping = False
                 self.start_time = datetime.now(timezone.utc)  # 记录启动时间
                 logger.info("[灾害预警] 正在启动灾害预警服务...")
 
@@ -308,50 +311,58 @@ class DisasterWarningService:
                     )
                 raise
 
+    async def _cancel_and_wait(self, tasks: list[asyncio.Task]) -> None:
+        """取消并等待任务结束。"""
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def stop(self):
         """停止服务"""
-        try:
-            logger.info("[灾害预警] 正在停止灾害预警服务...")
-            # 先标记为停止，阻止新任务进入
-            was_running = self.running
-            self.running = False
+        async with self._stop_lock:
+            if self._stopping:
+                logger.debug("[灾害预警] 停止流程已在执行中，跳过重复调用")
+                return
+            self._stopping = True
+            try:
+                logger.info("[灾害预警] 正在停止灾害预警服务...")
+                # 先标记为停止，阻止新任务进入
+                was_running = self.running
+                self.running = False
 
-            # 仅在服务实际运行过时保存缓存
-            if was_running:
-                self._save_earthquake_lists_cache()
+                # 仅在服务实际运行过时保存缓存
+                if was_running:
+                    self._save_earthquake_lists_cache()
 
-            # 取消并等待所有连接任务退出
-            connection_tasks = list(self.connection_tasks)
-            for task in connection_tasks:
-                task.cancel()
-            if connection_tasks:
-                await asyncio.gather(*connection_tasks, return_exceptions=True)
-            self.connection_tasks.clear()
+                # 取消并等待所有连接任务退出
+                connection_tasks = list(self.connection_tasks)
+                await self._cancel_and_wait(connection_tasks)
+                self.connection_tasks.clear()
 
-            # 取消并等待所有定时任务退出
-            scheduled_tasks = list(self.scheduled_tasks)
-            for task in scheduled_tasks:
-                task.cancel()
-            if scheduled_tasks:
-                await asyncio.gather(*scheduled_tasks, return_exceptions=True)
-            self.scheduled_tasks.clear()
+                # 取消并等待所有定时任务退出
+                scheduled_tasks = list(self.scheduled_tasks)
+                await self._cancel_and_wait(scheduled_tasks)
+                self.scheduled_tasks.clear()
 
-            # 停止WebSocket管理器
-            await self.ws_manager.stop()
+                # 停止WebSocket管理器
+                await self.ws_manager.stop()
 
-            # 关闭HTTP获取器
-            if self.http_fetcher:
-                await self.http_fetcher.close()  # 修改点：调用显式的 close()
+                # 关闭HTTP获取器
+                if self.http_fetcher:
+                    await self.http_fetcher.close()  # 修改点：调用显式的 close()
 
-            logger.info("[灾害预警] 灾害预警服务已停止")
+                logger.info("[灾害预警] 灾害预警服务已停止")
 
-        except Exception as e:
-            logger.error(f"[灾害预警] 停止服务时出错: {e}")
-            # 上报停止服务错误到遥测
-            if self._telemetry and self._telemetry.enabled:
-                await self._telemetry.track_error(
-                    e, module="core.disaster_service.stop"
-                )
+            except Exception as e:
+                logger.error(f"[灾害预警] 停止服务时出错: {e}")
+                # 上报停止服务错误到遥测
+                if self._telemetry and self._telemetry.enabled:
+                    await self._telemetry.track_error(
+                        e, module="core.disaster_service.stop"
+                    )
+            finally:
+                self._stopping = False
 
     async def _establish_websocket_connections(self):
         """建立WebSocket连接 - 使用WebSocket管理器功能"""

--- a/core/websocket_manager.py
+++ b/core/websocket_manager.py
@@ -30,6 +30,8 @@ class WebSocketManager:
         self.connection_info: dict[str, dict] = {}  # 新增：存储连接信息
         self.running = False
         self.session: aiohttp.ClientSession | None = None
+        self._stop_lock = asyncio.Lock()
+        self._stopping = False
 
     def register_handler(self, connection_name: str, handler: Callable):
         """注册消息处理器"""
@@ -535,6 +537,7 @@ class WebSocketManager:
     async def start(self):
         """启动管理器"""
         self.running = True
+        self._stopping = False
 
         # 初始化 Shared Session
         if not self.session or self.session.closed:
@@ -546,35 +549,47 @@ class WebSocketManager:
         if not self.message_handlers:
             logger.warning("[灾害预警] 没有注册任何消息处理器")
 
+    async def _cancel_and_wait(self, tasks: list[asyncio.Task]) -> None:
+        """取消并等待任务结束。"""
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def stop(self):
         """停止管理器"""
-        logger.info("[灾害预警] WebSocket管理器正在停止...")
-        self.running = False
+        async with self._stop_lock:
+            if self._stopping:
+                logger.debug("[灾害预警] WebSocket管理器已在停止流程中，跳过重复调用")
+                return
+            self._stopping = True
+            try:
+                logger.info("[灾害预警] WebSocket管理器正在停止...")
+                self.running = False
 
-        # 取消并等待所有重连任务退出，避免停机后重连复活连接
-        reconnect_tasks = list(self.reconnect_tasks.values())
-        for task in reconnect_tasks:
-            task.cancel()
-        if reconnect_tasks:
-            await asyncio.gather(*reconnect_tasks, return_exceptions=True)
-        self.reconnect_tasks.clear()
+                # 取消并等待所有重连任务退出，避免停机后重连复活连接
+                reconnect_tasks = list(self.reconnect_tasks.values())
+                await self._cancel_and_wait(reconnect_tasks)
+                self.reconnect_tasks.clear()
 
-        # 断开所有连接
-        for name in list(self.connections.keys()):
-            await self.disconnect(name)
+                # 断开所有连接
+                for name in list(self.connections.keys()):
+                    await self.disconnect(name)
 
-        # 关闭 Session
-        if self.session:
-            await self.session.close()
-            self.session = None
+                # 关闭 Session
+                if self.session:
+                    await self.session.close()
+                    self.session = None
 
-        # 清理所有状态
-        self.connections.clear()
-        self.connection_info.clear()
-        self.connection_retry_counts.clear()
-        self.fallback_retry_counts.clear()
+                # 清理所有状态
+                self.connections.clear()
+                self.connection_info.clear()
+                self.connection_retry_counts.clear()
+                self.fallback_retry_counts.clear()
 
-        logger.info("[灾害预警] WebSocket管理器已停止")
+                logger.info("[灾害预警] WebSocket管理器已停止")
+            finally:
+                self._stopping = False
 
     def _find_handler_by_prefix(self, connection_name: str) -> str | None:
         """通过前缀匹配查找处理器名称"""


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
修复灾害预警插件在停止时的并发竞态问题，避免插件显示“已停止”后仍有 WebSocket 重连并继续处理消息。

Closes #73 

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
 ### 修改文件
  - `core/websocket_manager.py`
  - `core/disaster_service.py`

  ### 主要改动
  - 重构 WebSocket 重连任务调度，避免同一连接并发创建多个重连任务。
  - 所有重连任务统一纳入 `reconnect_tasks` 管理，补充停机阶段的 `cancel + await gather +
  clear`。
  - 在重连关键路径增加 `running` 状态守卫（sleep 前后、connect 前），防止停机后连接“复
  活”。
  - 服务 stop 流程改为对连接任务、定时任务执行 `cancel + await gather + clear`，确保任务真
  正退出。
  - 增加任务命名（`dw_reconnect_*`、`dw_ws_connect_*`、`dw_http_fetch_wolfx`、
  `dw_cleanup`）以提升排障可观测性。
- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->
```
[07:08:11] [Core] [INFO] [star.star_manager:1018]: 正在终止插件 astrbot_plugin_disaster_warning ... 
 [07:08:11] [Plug] [INFO] [astrbot_plugin_disaster_warning.main:150]: [灾害预警] 正在停止灾害预警插件... 
 [07:08:11] [Plug] [DBUG] [astrbot_plugin_disaster_warning.main:313]: [灾害预警] 心跳任务已取消 
 [07:08:11] [Plug] [DBUG] [astrbot_plugin_disaster_warning.main:159]: [灾害预警] 已停止心跳任务 
 [07:08:11] [Plug] [DBUG] [astrbot_plugin_disaster_warning.main:166]: [灾害预警] 已恢复全局异常处理器 
 [07:08:11] [Plug] [INFO] [core.disaster_service:314]: [灾害预警] 正在停止灾害预警服务... 
 [07:08:11] [Plug] [INFO] [core.disaster_service:572]: [灾害预警] Wolfx 地震列表缓存已保存 
 [07:08:11] [Plug] [INFO] [core.websocket_manager:224]: [灾害预警] WebSocket连接任务被取消: fan_studio_all 
 [07:08:11] [Plug] [INFO] [core.websocket_manager:224]: [灾害预警] WebSocket连接任务被取消: p2p_main 
 [07:08:11] [Plug] [INFO] [core.websocket_manager:224]: [灾害预警] WebSocket连接任务被取消: wolfx_all 
 [07:08:11] [Plug] [INFO] [core.websocket_manager:551]: [灾害预警] WebSocket管理器正在停止... 
 [07:08:11] [Plug] [INFO] [core.websocket_manager:577]: [灾害预警] WebSocket管理器已停止 
 [07:08:11] [Plug] [INFO] [core.disaster_service:346]: [灾害预警] 灾害预警服务已停止 
 [07:08:11] [Plug] [INFO] [core.browser_manager:249]: [灾害预警] 正在关闭浏览器... 
 [07:08:11] [Plug] [INFO] [core.browser_manager:254]: [灾害预警] 浏览器已关闭 
 [07:08:11] [Plug] [DBUG] [core.message_manager:838]: [灾害预警] 浏览器管理器已关闭 
 [07:08:11] [Plug] [DBUG] [core.telemetry_manager:349]: [灾害预警] 遥测会话已关闭 
 [07:08:11] [Plug] [INFO] [astrbot_plugin_disaster_warning.main:197]: [灾害预警] 灾害预警插件已停止 
 [07:08:11] [Core] [INFO] [routes.plugin:560]: 停用插件 astrbot_plugin_disaster_warning 。 
```
## ✅ 检查清单 / Checklist

<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

通过收紧关闭与重连的控制，防止在灾害预警插件停止后，WebSocket 连接及相关任务被重新激活。

Bug Fixes:
- 确保在管理器或服务已被标记为停止后，不再为 WebSocket 安排重连。
- 避免为同一个 WebSocket 连接创建多个并发的重连任务。

Enhancements:
- 在服务关闭期间，优雅地取消、等待并清理所有连接、已计划任务以及重连任务，以确保干净退出。
- 为关键的异步任务添加显式名称，以提升对连接、HTTP 获取以及清理流程的可观测性和调试能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent WebSocket connections and related tasks from reviving after the disaster warning plugin is stopped by tightening shutdown and reconnection control.

Bug Fixes:
- Ensure WebSocket reconnection is not scheduled after the manager or service has been marked as stopped.
- Avoid multiple concurrent reconnect tasks being created for the same WebSocket connection.

Enhancements:
- Gracefully cancel, await, and clear all connection, scheduled, and reconnect tasks during service shutdown to guarantee clean exit.
- Add explicit names to key async tasks to improve observability and debugging of connection, HTTP fetch, and cleanup flows.

</details>