### PR TITLE
fix: 修复震级和深度的格式化逻辑，确保深度为 None 时不进行四舍五入

### DIFF
--- a/core/filters/local_intensity.py
+++ b/core/filters/local_intensity.py
@@ -49,7 +49,7 @@ class LocalIntensityFilter:
         intensity = IntensityCalculator.calculate_estimated_intensity(
             earthquake.magnitude or 0.0,
             distance,
-            earthquake.depth or 10.0,
+            earthquake.depth if earthquake.depth is not None else 10.0,
             event_longitude=earthquake.longitude,  # 传入经度以区分东西部
         )
 

--- a/core/handlers/global_sources.py
+++ b/core/handlers/global_sources.py
@@ -110,7 +110,7 @@ class GlobalQuakeHandler(BaseDataHandler):
 
             # 格式化震级和深度
             magnitude = round(eq_data.magnitude, 1) if eq_data.magnitude else None
-            depth = round(eq_data.depth, 1) if eq_data.depth else None
+            depth = round(eq_data.depth, 1) if eq_data.depth is not None else None
 
             # 翻译地名
             place_name = translate_place_name(


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的总结

在处理地震数据时正确处理深度，以避免对缺失的深度值进行四舍五入或误读。

错误修复：
- 当在全局源解析中地震深度被显式设为 `None` 时，防止对地震深度值进行四舍五入。
- 确保烈度计算只在地震深度确实为 `None` 时才使用默认深度，而不是在任何假值（falsy value）时都使用默认深度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct depth handling when processing earthquake data to avoid rounding or misinterpreting missing depth values.

Bug Fixes:
- Prevent rounding of earthquake depth values when the depth is explicitly None in global source parsing.
- Ensure intensity calculations use a default depth only when the earthquake depth is truly None, rather than any falsy value.

</details>