### PR TITLE
chore: 优化项目内的 logger 使用情况

### DIFF
--- a/core/message/fusion/cwa_eew_fusion_service.py
+++ b/core/message/fusion/cwa_eew_fusion_service.py
@@ -106,7 +106,7 @@ class CWAEewFusionService:
             cls = type(self)
             cls._apply_scale(event, earthquake, scale)
             logger.info(
-                f"[灾害预警] 融合策略: Fan CWA EEW 事件 {event.id} 命中 Wolfx 缓存并补充最大震度: {scale}"
+                f"[灾害预警] 融合策略：Fan CWA EEW 事件 {event.id} 已命中 Wolfx 缓存，补充的最大震度为 {scale}"
             )
             return await self._execute_push(
                 event,
@@ -115,7 +115,7 @@ class CWAEewFusionService:
             )
 
         logger.info(
-            f"[灾害预警] 融合策略: 拦截 Fan CWA EEW 事件 {event.id} (event_key={event_key}, report={report_num})，等待 Wolfx 最大震度补充 ({timeout}s)..."
+            f"[灾害预警] 融合策略：已拦截 Fan CWA EEW 事件 {event.id}，事件标识为 {event_key}，报数为 {report_num}，等待 Wolfx 在 {timeout} 秒内补充最大震度"
         )
 
         loop = asyncio.get_running_loop()
@@ -146,7 +146,7 @@ class CWAEewFusionService:
             store.cwa_eew_pending.pop(pending_key, None)
 
             if result == "timeout":
-                logger.info("[灾害预警] 融合策略: CWA EEW 等待超时，推送原始 Fan 事件")
+                logger.info("[灾害预警] 融合策略：CWA EEW 等待超时，推送原始 Fan 事件")
                 return await self._execute_push(
                     event,
                     target_sessions=target_sessions,
@@ -154,7 +154,7 @@ class CWAEewFusionService:
                 )
             if result == "fused":
                 logger.info(
-                    "[灾害预警] 融合策略: CWA EEW 融合完成，推送补充最大震度后的 Fan 事件"
+                    "[灾害预警] 融合策略：CWA EEW 融合完成，推送补充最大震度后的 Fan 事件"
                 )
                 return await self._execute_push(
                     event,
@@ -252,11 +252,11 @@ class CWAEewFusionService:
             if fan_earthquake.scale is None:
                 type(self)._apply_scale(fan_event, fan_earthquake, scale)
                 logger.info(
-                    f"[灾害预警] 融合策略: 成功用 Wolfx 补充 Fan CWA EEW 事件 {pending_key} 的最大震度: {scale}"
+                    f"[灾害预警] 融合策略：已使用 Wolfx 为 Fan CWA EEW 事件 {pending_key} 补充最大震度，数值为 {scale}"
                 )
             else:
                 logger.info(
-                    f"[灾害预警] 融合策略: Fan CWA EEW 事件 {pending_key} 已自带最大震度，保留 Fan 数值 {fan_earthquake.scale}"
+                    f"[灾害预警] 融合策略：Fan CWA EEW 事件 {pending_key} 已自带最大震度，保留 Fan 的数值 ({fan_earthquake.scale})"
                 )
 
             if future is not None and hasattr(future, "done") and not future.done():

--- a/core/message/push/session_sender.py
+++ b/core/message/push/session_sender.py
@@ -6,6 +6,10 @@
 from __future__ import annotations
 
 
+class SessionSendFailedError(RuntimeError):
+    """会话消息发送失败。"""
+
+
 class SessionSender:
     """会话发送器。"""
 
@@ -13,7 +17,16 @@ class SessionSender:
         # 发送器只包装 AstrBot 上下文，不额外持有复杂发送状态。
         self.context = context
 
-    async def send(self, session: str, message):
-        """发送消息到指定会话。"""
+    async def send(self, session: str, message) -> None:
+        """发送消息到指定会话。
+
+        AstrBot 的 context.send_message 会在找不到目标平台实例时返回 False，
+        但不会抛出异常。这里将该返回值显式转换为发送失败异常，避免上层把
+        “框架未实际投递”的场景误统计为成功。
+        """
         # 所有消息最终都从这里落到具体会话发送能力，便于后续集中扩展重试或限速。
-        await self.context.send_message(session, message)
+        sent = await self.context.send_message(session, message)
+        if sent is False:
+            raise SessionSendFailedError(
+                f"AstrBot 未找到可处理会话 {session} 的平台实例，消息未发送"
+            )

--- a/core/network/admin/api/config_routes.py
+++ b/core/network/admin/api/config_routes.py
@@ -42,7 +42,9 @@ def register_config_routes(app, *, config):
                 status_code=404,
             )
         except Exception as e:
-            logger.error(f"[灾害预警] 获取配置结构定义失败: {e}, path: {schema_path}")
+            logger.error(
+                f"[灾害预警] 获取配置结构定义失败，文件路径为 {schema_path}，错误为 {e}"
+            )
             return ApiResponse.error(
                 f"{str(e)}, path: {schema_path}, trace: {traceback.format_exc()}",
                 status_code=500,

--- a/core/network/admin/host/web_server_runtime_service.py
+++ b/core/network/admin/host/web_server_runtime_service.py
@@ -196,7 +196,7 @@ class WebServerRuntimeService:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.debug(f"[灾害预警] 广播循环异常: {e}")
+                logger.debug(f"[灾害预警] 管理端广播循环执行异常，错误为 {e}")
 
     async def close_all_websockets(self) -> None:
         """关闭所有 WebSocket 连接。"""

--- a/core/network/monitoring/source_health_monitor.py
+++ b/core/network/monitoring/source_health_monitor.py
@@ -58,7 +58,16 @@ class SourceHealthMonitor:
                 pass
 
             return (end_time - start_time) * 1000
-        except (asyncio.TimeoutError, OSError, Exception):
+        except (asyncio.TimeoutError, OSError):
+            return None
+        except Exception as e:
+            logger.error(
+                "[灾害预警] TCP 延迟探测发生非预期异常，主机为 %s，端口为 %s，错误为 %s",
+                host,
+                port,
+                e,
+                exc_info=True,
+            )
             return None
 
     async def run_background_ping_loop(self, interval_seconds: float = 30.0):

--- a/core/network/monitoring/source_health_monitor.py
+++ b/core/network/monitoring/source_health_monitor.py
@@ -58,8 +58,7 @@ class SourceHealthMonitor:
                 pass
 
             return (end_time - start_time) * 1000
-        except (asyncio.TimeoutError, OSError, Exception) as e:
-            logger.debug(f"[灾害预警] TCP 延迟探测异常 {host}:{port}: {e}")
+        except (asyncio.TimeoutError, OSError, Exception):
             return None
 
     async def run_background_ping_loop(self, interval_seconds: float = 30.0):
@@ -96,7 +95,6 @@ class SourceHealthMonitor:
                             ping_failures[source_name] = 0
                             self.latency_cache[source_name] = result
 
-                logger.debug(f"[灾害预警] 延迟缓存已更新: {self.latency_cache}")
                 await asyncio.sleep(interval_seconds)
 
             except asyncio.CancelledError:

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -278,7 +278,9 @@ class SourceMessageRouter:
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
                 connection_type = (
-                    connection_info.get("connection_type") if connection_info else "未知类型"
+                    connection_info.get("connection_type")
+                    if connection_info
+                    else "未知类型"
                 )
                 logger.error(
                     f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，"

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -98,17 +98,8 @@ class SourceMessageRouter:
         connection_name=None,
         connection_info=None,
     ) -> None:
-        if connection_info:
-            logger.debug(
-                f"[灾害预警] {provider_name}处理器收到消息 - 连接: {connection_name}, URI: {connection_info.get('uri', 'unknown')}, 长度: {len(message) if hasattr(message, '__len__') else 'unknown'}"
-            )
-            established_time = connection_info.get("established_time")
-            if established_time:
-                logger.debug(f"[灾害预警] 连接建立时间: {established_time}")
-            return
-        logger.debug(
-            f"[灾害预警] {provider_name}处理器收到消息 - 连接: {connection_name}, 长度: {len(message) if hasattr(message, '__len__') else 'unknown'}"
-        )
+        # 原始 WebSocket 消息由 message_logger 负责落盘；这里避免对高频消息逐条输出 DEBUG。
+        return
 
     def _has_parser(self, source_id: str) -> bool:
         """检查 source 是否已装配 parser。"""
@@ -192,13 +183,13 @@ class SourceMessageRouter:
                 if dispatched:
                     return True
             except Exception as error:
-                logger.error(
-                    f"[灾害预警] {source_id}解析器解析失败 - 连接: {connection_name}, 错误: {error}"
+                connection_uri = (
+                    connection_info.get("uri") if connection_info else "未知地址"
                 )
-                if connection_info:
-                    logger.error(
-                        f"[灾害预警] 连接信息 - URI: {connection_info.get('uri')}"
-                    )
+                logger.error(
+                    f"[灾害预警] {source_id} 解析器处理来自 {connection_name or '未知连接'} 的消息失败，"
+                    f"连接地址为 {connection_uri}，错误为 {error}"
+                )
         return False
 
     def _ensure_fan_studio_parser_mapping(self) -> None:
@@ -275,22 +266,24 @@ class SourceMessageRouter:
                         is_unhandled_initial = msg_type == "initial_all"
                         if has_data or is_unhandled_initial:
                             logger.debug(
-                                f"[灾害预警] 未处理的消息，连接: {connection_name}, "
-                                f"类型: {msg_type}, "
-                                f"源: {data.get('source', 'unknown')}, "
+                                f"[灾害预警] 收到一条尚未处理的消息，连接为 {connection_name}，"
+                                f"消息类型为 {msg_type}，来源为 {data.get('source', 'unknown')}，"
                                 f"数据摘要: {str(data)[:100]}"
                             )
 
                 return None
 
             except Exception as error:
-                logger.error(
-                    f"[灾害预警] FAN Studio处理器解析消息失败 - 连接: {connection_name}, 错误: {error}"
+                connection_uri = (
+                    connection_info.get("uri") if connection_info else "未知地址"
                 )
-                if connection_info:
-                    logger.error(
-                        f"[灾害预警] 连接信息 - URI: {connection_info.get('uri')}, 类型: {connection_info.get('connection_type')}"
-                    )
+                connection_type = (
+                    connection_info.get("connection_type") if connection_info else "未知类型"
+                )
+                logger.error(
+                    f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，"
+                    f"连接地址为 {connection_uri}，连接类型为 {connection_type}，错误为 {error}"
+                )
                 raise
 
         return fan_studio_handler
@@ -312,7 +305,7 @@ class SourceMessageRouter:
                 code = str(data.get("code") or "").strip()
                 if code == "556":
                     logger.info(
-                        "[灾害预警] P2P处理器收到紧急地震速报(code:556)，准备解析..."
+                        "[灾害预警] P2P 处理器收到紧急地震速报，业务码为 556，准备解析"
                     )
             except (json.JSONDecodeError, AttributeError, TypeError):
                 data = {}
@@ -366,7 +359,7 @@ class SourceMessageRouter:
                 source_id = get_wolfx_source_id(msg_type)
                 if source_id is None:
                     logger.debug(
-                        f"[灾害预警] 未识别的 Wolfx 消息类型: {msg_type}, 连接: {connection_name}"
+                        f"[灾害预警] Wolfx 消息类型 {msg_type} 暂未识别，来源连接为 {connection_name}"
                     )
                     return None
 
@@ -374,7 +367,7 @@ class SourceMessageRouter:
                     return None
 
                 logger.debug(
-                    f"[灾害预警] 使用 Wolfx 解析器: {source_id} 处理 {msg_type}"
+                    f"[灾害预警] 将使用 Wolfx 解析器 {source_id} 处理类型为 {msg_type} 的消息"
                 )
                 # 某些 Wolfx 消息在正式解析前需要先触发附带状态更新等副作用处理。
                 await self._side_effect_service.process_message(

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -187,8 +187,12 @@ class SourceMessageRouter:
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
                 logger.error(
-                    f"[灾害预警] {source_id} 解析器处理来自 {connection_name or '未知连接'} 的消息失败，"
-                    f"连接地址为 {connection_uri}，错误为 {error}"
+                    "[灾害预警] %s 解析器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
+                    source_id,
+                    connection_name or "未知连接",
+                    connection_uri,
+                    error,
+                    exc_info=True,
                 )
         return False
 
@@ -266,9 +270,11 @@ class SourceMessageRouter:
                         is_unhandled_initial = msg_type == "initial_all"
                         if has_data or is_unhandled_initial:
                             logger.debug(
-                                f"[灾害预警] 收到一条尚未处理的消息，连接为 {connection_name}，"
-                                f"消息类型为 {msg_type}，来源为 {data.get('source', 'unknown')}，"
-                                f"数据摘要: {str(data)[:100]}"
+                                "[灾害预警] 收到一条尚未处理的消息，连接为 %s，消息类型为 %s，来源为 %s，数据摘要：%s",
+                                connection_name,
+                                msg_type,
+                                data.get("source", "unknown"),
+                                str(data)[:100],
                             )
 
                 return None
@@ -283,8 +289,12 @@ class SourceMessageRouter:
                     else "未知类型"
                 )
                 logger.error(
-                    f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，"
-                    f"连接地址为 {connection_uri}，连接类型为 {connection_type}，错误为 {error}"
+                    "[灾害预警] FAN Studio 处理器解析来自 %s 的消息失败，连接地址为 %s，连接类型为 %s，错误为 %s",
+                    connection_name or "未知连接",
+                    connection_uri,
+                    connection_type,
+                    error,
+                    exc_info=True,
                 )
                 raise
 
@@ -391,13 +401,16 @@ class SourceMessageRouter:
                 return None
 
             except Exception as error:
-                logger.error(
-                    f"[灾害预警] Wolfx处理器处理失败 - 连接: {connection_name}, 错误: {error}"
+                connection_uri = (
+                    connection_info.get("uri") if connection_info else "未知地址"
                 )
-                if connection_info:
-                    logger.error(
-                        f"[灾害预警] 连接信息 - URI: {connection_info.get('uri')}"
-                    )
+                logger.error(
+                    "[灾害预警] Wolfx 处理器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
+                    connection_name or "未知连接",
+                    connection_uri,
+                    error,
+                    exc_info=True,
+                )
                 return None
 
         return wolfx_handler
@@ -431,13 +444,16 @@ class SourceMessageRouter:
                     parser_log_label="Global Quake",
                 )
             except Exception as error:
-                logger.error(
-                    f"[灾害预警] Global Quake解析器解析消息失败 - 连接: {connection_name}, 错误: {error}"
+                connection_uri = (
+                    connection_info.get("uri") if connection_info else "未知地址"
                 )
-                if connection_info:
-                    logger.error(
-                        f"[灾害预警] 连接信息 - URI: {connection_info.get('uri')}"
-                    )
+                logger.error(
+                    "[灾害预警] Global Quake 解析器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
+                    connection_name or "未知连接",
+                    connection_uri,
+                    error,
+                    exc_info=True,
+                )
 
         return global_quake_handler
 

--- a/core/network/websocket/websocket_dispatch_service.py
+++ b/core/network/websocket/websocket_dispatch_service.py
@@ -155,7 +155,9 @@ class WebSocketDispatchService:
 
         # 关闭码策略显式区分：正常关闭、不应重连的协议错误、以及需要重连的异常关闭。
         if close_code in self._NORMAL_CLOSE_CODES:
-            logger.info(f"[灾害预警] WebSocket {name} 的连接已正常关闭，关闭码为 {close_code}")
+            logger.info(
+                f"[灾害预警] WebSocket {name} 的连接已正常关闭，关闭码为 {close_code}"
+            )
             return
 
         if close_code in self._NO_RECONNECT_CODES:

--- a/core/network/websocket/websocket_dispatch_service.py
+++ b/core/network/websocket/websocket_dispatch_service.py
@@ -65,8 +65,8 @@ class WebSocketDispatchService:
                 elif msg.type == WSMsgType.ERROR:
                     raise msg.data
                 elif msg.type == WSMsgType.CLOSED:
-                    logger.info(
-                        f"[灾害预警] WebSocket连接已关闭: {name}, code={websocket.close_code}"
+                    logger.debug(
+                        f"[灾害预警] WebSocket {name} 的连接已收到关闭帧，关闭码为 {websocket.close_code}"
                     )
                     break
                 elif msg.type in {WSMsgType.PING, WSMsgType.PONG}:
@@ -84,7 +84,7 @@ class WebSocketDispatchService:
             logger.error(f"[灾害预警] WebSocket消息循环异常 {name}: {e}")
             raise
 
-        logger.info(f"[灾害预警] 连接断开: {name}")
+        logger.debug(f"[灾害预警] WebSocket 连接 {name} 的消息循环已结束")
 
     def log_message(self, name: str, message: Any, uri: str) -> None:
         """记录原始 WebSocket 消息。"""
@@ -155,7 +155,7 @@ class WebSocketDispatchService:
 
         # 关闭码策略显式区分：正常关闭、不应重连的协议错误、以及需要重连的异常关闭。
         if close_code in self._NORMAL_CLOSE_CODES:
-            logger.info(f"[灾害预警] WebSocket正常关闭: {name}, code={close_code}")
+            logger.info(f"[灾害预警] WebSocket {name} 的连接已正常关闭，关闭码为 {close_code}")
             return
 
         if close_code in self._NO_RECONNECT_CODES:
@@ -163,7 +163,7 @@ class WebSocketDispatchService:
 
         if close_code == 1006:
             logger.warning(
-                f"[灾害预警] WebSocket异常关闭，准备重连: {name}, code={close_code}"
+                f"[灾害预警] WebSocket {name} 的连接异常关闭，关闭码为 {close_code}，准备重连"
             )
             self.manager._handle_connection_error(
                 name,
@@ -201,7 +201,7 @@ class WebSocketDispatchService:
                     connection_info=connection_info,
                 )
             else:
-                logger.warning(f"[灾害预警] 未找到消息处理器 - 连接: {name}")
+                logger.warning(f"[灾害预警] 连接 {name} 没有匹配到可用的消息处理器")
         except Exception as e:
             logger.error(f"[灾害预警] {error_label} {name}: {e}")
             logger.debug(f"[灾害预警] 异常堆栈: {traceback.format_exc()}")

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -256,7 +256,9 @@ class WebSocketManager:
             try:
                 await self.connections[name].send_str(message)
             except Exception as e:
-                logger.error(f"[灾害预警] WebSocket 管理器向 {name} 发送消息失败，错误为 {e}")
+                logger.error(
+                    f"[灾害预警] WebSocket 管理器向 {name} 发送消息失败，错误为 {e}"
+                )
         else:
             logger.warning(f"[灾害预警] WebSocket 管理器尝试向未连接的 {name} 发送消息")
 

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -255,11 +255,10 @@ class WebSocketManager:
         if name in self.connections:
             try:
                 await self.connections[name].send_str(message)
-                logger.debug(f"[灾害预警] 消息已发送到 {name}: {message[:100]}...")
             except Exception as e:
-                logger.error(f"[灾害预警] WebSocket管理器发送消息失败 {name}: {e}")
+                logger.error(f"[灾害预警] WebSocket 管理器向 {name} 发送消息失败，错误为 {e}")
         else:
-            logger.warning(f"[灾害预警] WebSocket管理器尝试发送到未连接的连接: {name}")
+            logger.warning(f"[灾害预警] WebSocket 管理器尝试向未连接的 {name} 发送消息")
 
     def get_connection_status(self, name: str) -> dict[str, Any]:
         """获取单个连接的状态摘要。"""

--- a/core/network/websocket/websocket_runtime_service.py
+++ b/core/network/websocket/websocket_runtime_service.py
@@ -37,7 +37,9 @@ class WebSocketRuntimeService:
                     try:
                         await websocket.ping()
                     except Exception as e:
-                        logger.warning(f"[灾害预警] WebSocket {name} 的 Ping 保活失败，错误为 {e}")
+                        logger.warning(
+                            f"[灾害预警] WebSocket {name} 的 Ping 保活失败，错误为 {e}"
+                        )
                         await websocket.close(code=1001, message=b"Heartbeat timeout")
                         break
         except asyncio.CancelledError:

--- a/core/network/websocket/websocket_runtime_service.py
+++ b/core/network/websocket/websocket_runtime_service.py
@@ -35,10 +35,9 @@ class WebSocketRuntimeService:
                 # 若超过两个心跳周期仍无活跃信号，则主动发送 ping 做保活探测。
                 if current_time - last_time > interval * 2:
                     try:
-                        logger.debug(f"[灾害预警] 发送应用层 Ping: {name}")
                         await websocket.ping()
                     except Exception as e:
-                        logger.warning(f"[灾害预警] Ping 失败 {name}: {e}")
+                        logger.warning(f"[灾害预警] WebSocket {name} 的 Ping 保活失败，错误为 {e}")
                         await websocket.close(code=1001, message=b"Heartbeat timeout")
                         break
         except asyncio.CancelledError:
@@ -51,9 +50,9 @@ class WebSocketRuntimeService:
         if name in self.manager.connections:
             try:
                 await self.manager.connections[name].close()
-                logger.info(f"[灾害预警] WebSocket连接已关闭: {name}")
+                logger.debug(f"[灾害预警] WebSocket {name} 的连接句柄已关闭")
             except Exception as e:
-                logger.error(f"[灾害预警] WebSocket断开连接时出错 {name}: {e}")
+                logger.error(f"[灾害预警] WebSocket {name} 断开连接时出错，错误为 {e}")
             finally:
                 # 断开后同步清理连接句柄、元数据与心跳任务，避免残留脏状态。
                 self.manager.connections.pop(name, None)

--- a/core/parsers/base_parser.py
+++ b/core/parsers/base_parser.py
@@ -37,8 +37,6 @@ class BaseParser:
 
     def parse_message(self, message: str | bytes) -> Any | None:
         """解析原始消息。"""
-        logger.debug(f"[{self.source_id}] 收到原始消息，长度: {len(message)}")
-
         try:
             # 统一先做解码，再交给领域事件构建入口，便于子类按需覆写其中某一步。
             payload = self.decode_message(message)

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -58,7 +58,9 @@ class GlobalQuakeParser(BaseParser):
                 )
                 return None
 
-            logger.debug(f"[灾害预警] {self.source_id} 收到未知类型的消息，类型值为 {ws_msg.type}")
+            logger.debug(
+                f"[灾害预警] {self.source_id} 收到未知类型的消息，类型值为 {ws_msg.type}"
+            )
             return None
         except Exception as exc:
             logger.error(f"[灾害预警] {self.source_id} Protobuf 解析失败: {exc}")

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -49,18 +49,16 @@ class GlobalQuakeParser(BaseParser):
 
             # 二进制通道会混发地震、心跳和状态消息，这里只把地震消息送入正式解析链。
             if ws_msg.type == MessageType.EARTHQUAKE:
-                logger.debug(f"[灾害预警] {self.source_id} 收到地震消息")
                 return self._parse_earthquake_protobuf(ws_msg)
             if ws_msg.type == MessageType.HEARTBEAT:
-                logger.debug(f"[灾害预警] {self.source_id} 心跳消息")
                 return None
             if ws_msg.type == MessageType.STATUS:
                 logger.debug(
-                    f"[灾害预警] {self.source_id} 状态消息: {ws_msg.status_data.server_status}"
+                    f"[灾害预警] {self.source_id} 收到状态消息，服务器状态为 {ws_msg.status_data.server_status}"
                 )
                 return None
 
-            logger.debug(f"[灾害预警] {self.source_id} 未知消息类型: {ws_msg.type}")
+            logger.debug(f"[灾害预警] {self.source_id} 收到未知类型的消息，类型值为 {ws_msg.type}")
             return None
         except Exception as exc:
             logger.error(f"[灾害预警] {self.source_id} Protobuf 解析失败: {exc}")
@@ -76,11 +74,11 @@ class GlobalQuakeParser(BaseParser):
             # JSON 通道当前主要关心地震消息，其余类型直接忽略。
             if msg_type == "earthquake":
                 logger.debug(
-                    f"[灾害预警] {self.source_id} 收到地震消息 (JSON)，action: {action}"
+                    f"[灾害预警] {self.source_id} 收到 JSON 地震消息，动作为 {action}"
                 )
                 return self._parse_earthquake_data(data)
 
-            logger.debug(f"[灾害预警] {self.source_id} 忽略消息类型: {msg_type}")
+            logger.debug(f"[灾害预警] {self.source_id} 已忽略类型为 {msg_type} 的消息")
             return None
         except json.JSONDecodeError as exc:
             logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -68,6 +68,6 @@ class ConnectionPlanBuilder:
             elif group_key == "global_quake":
                 logger.info("[灾害预警] Global Quake 数据源已启用")
             else:
-                logger.info(f"[灾害预警] 已配置数据连接: {group_key}")
+                logger.info(f"[灾害预警] 已配置数据连接，连接分组为 {group_key}")
 
         return connections

--- a/core/services/geo/weather_region_resolver.py
+++ b/core/services/geo/weather_region_resolver.py
@@ -137,7 +137,9 @@ class WeatherRegionResolver:
             ) as resp:
                 payload = await resp.json(content_type=None)
         except Exception as exc:
-            logger.debug(f"[灾害预警] 行政区划查询失败: {place_name}, 错误: {exc}")
+            logger.debug(
+                f"[灾害预警] 行政区划查询失败，地点为 {place_name}，错误为 {exc}"
+            )
             self._location_province_cache[place_name] = None
             self._cache_expire[place_name] = now + self._failure_ttl
             return None

--- a/core/services/telemetry/telemetry_service.py
+++ b/core/services/telemetry/telemetry_service.py
@@ -70,7 +70,7 @@ class TelemetryManager:
 
         if self._enabled:
             logger.debug(
-                f"[灾害预警] 已启用匿名遥测 (Instance ID: {self._instance_id}, AstrBot: {self._astrbot_version})"
+                f"[灾害预警] 已启用匿名遥测，实例标识为 {self._instance_id}，AstrBot 版本为 {self._astrbot_version}"
             )
         else:
             logger.debug("[灾害预警] 遥测功能未启用")
@@ -155,7 +155,6 @@ class TelemetryManager:
                 self._ENDPOINT, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    logger.debug(f"[灾害预警] 遥测事件 '{event_name}' 发送成功")
                     return True
                 if response.status == 401:
                     logger.warning("[灾害预警] App Key 无效或项目已禁用")
@@ -171,13 +170,13 @@ class TelemetryManager:
             logger.debug(f"[灾害预警] 遥测连接失败: {e}")
             return False
         except aiohttp.ClientPayloadError as e:
-            logger.debug(f"[灾害预警] 遥测数据负载错误: {e}")
+            logger.debug(f"[灾害预警] 遥测数据负载异常，错误为 {e}")
             return False
         except aiohttp.ClientError as e:
-            logger.debug(f"[灾害预警] 遥测网络错误: {e}")
+            logger.debug(f"[灾害预警] 遥测网络请求异常，错误为 {e}")
             return False
         except Exception as e:
-            logger.debug(f"[灾害预警] 遥测未知错误: {e}")
+            logger.debug(f"[灾害预警] 遥测发送遇到未知异常，错误为 {e}")
             return False
 
         return False
@@ -212,7 +211,6 @@ class TelemetryManager:
 
         参数 `uptime_seconds` 表示当前累计运行秒数。
         """
-        logger.debug(f"[灾害预警] 准备发送心跳: uptime_seconds={uptime_seconds}")
         return await self.track(
             "heartbeat",
             {
@@ -279,8 +277,8 @@ class TelemetryManager:
         raw_message = str(exception)
         if self._should_skip_error_telemetry(exception, raw_message, module):
             logger.debug(
-                "[灾害预警] 命中遥测噪声过滤规则，跳过错误上报: "
-                f"{type(exception).__name__} | module={module} | message={raw_message[:200]}"
+                "[灾害预警] 命中遥测噪声过滤规则，跳过错误上报："
+                f"异常类型为 {type(exception).__name__}，模块为 {module}，消息摘要：{raw_message[:200]}"
             )
             return False
 


### PR DESCRIPTION
## 📝 描述 / Description

feat #107 

更详细的插件内部日志分级将于 v1.6.0 加入。

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

在网络和融合组件中收紧日志和遥测行为，并强化会话消息投递语义。

Bug 修复：
- 当没有可用的目标平台实例时，将 AstrBot 上下文消息投递失败视为明确错误，通过引入专用的 `SessionSendFailedError`，避免将未发送的消息错误计为发送成功。

增强：
- 减少围绕 WebSocket 流量、解析器、遥测、健康监控和管理广播的嘈杂或冗余调试日志，同时改进错误和关键事件的日志措辞及上下文信息。
- 调整 WebSocket 生命周期日志，更好地区分正常关闭、异常终止和连接拆除，同时避免在 info 级日志中产生过多噪音。
- 优化融合组件、解析器和地理区域解析器的日志消息，为操作和错误场景提供更清晰、更结构化的上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten logging and telemetry behavior across networking and fusion components and harden session message delivery semantics.

Bug Fixes:
- Treat failed AstrBot context message deliveries as explicit errors by introducing a dedicated SessionSendFailedError when no target platform instance is available, avoiding miscounting unsent messages as successful.

Enhancements:
- Reduce noisy or redundant debug logging around WebSocket traffic, parsers, telemetry, health monitoring, and admin broadcasting while improving log wording and contextual information for errors and key events.
- Adjust WebSocket lifecycle logs to better distinguish normal closures, abnormal terminations, and connection teardown without flooding info-level logs.
- Refine fusion, parser, and geo region resolver log messages to provide clearer, more structured context for operations and error cases.

</details>