### PR TITLE
fix(deps): 修复 fastapi/starlette 版本与 AstrBot 核心不兼容的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
 2. **安装依赖**: 本插件的核心依赖大多已包含在 AstrBot 的默认依赖中，且在插件下载安装时会自动安装插件所需的依赖，通常无需额外安装。如果你的环境中确实缺少相关依赖，请安装：
 
    ```bash
-   pip install python-dateutil asyncio-mqtt jinja2 playwright tzdata fastapi uvicorn protobuf
+   pip install python-dateutil jinja2 playwright tzdata fastapi uvicorn protobuf
    # Python < 3.11 额外安装
    pip install "tomli>=2.0.1; python_version < '3.11'"
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 aiohttp>=3.8.0
 pydantic>=2.0.0
 python-dateutil>=2.8.0
-asyncio-mqtt>=0.13.0
 jinja2>=3.0.0
 playwright>=1.30.0
 tzdata>=2023.3
 tomli>=2.0.1; python_version < "3.11"
-fastapi>=0.100.0
+fastapi>=0.134.0
 uvicorn>=0.23.0
 protobuf>=6.33.1
 aiosqlite>=0.19.0


### PR DESCRIPTION
## 问题描述

在 AstrBot v4.x 环境中安装本插件时，pip 依赖解析失败，报错类似：

```
fastapi 0.110.3 depends on starlette<0.38.0
vs
starlette==1.0.0 (required by sse-starlette via mcp)
```

## 原因分析

AstrBot 核心的依赖链：
```
mcp>=1.8.0 → sse-starlette>=1.6.1 → starlette>=0.49.1
```

pip 会将 starlette 解析到 1.x（当前最新 1.1.0）。

本插件之前声明 `fastapi>=0.100.0`，pip 可能解析到 fastapi 0.110.x，而该版本要求 `starlette>=0.36.3,<0.38.0`——与 starlette 1.x 直接冲突，无法共存。

## 修复方案

将 `fastapi>=0.100.0` 提升为 `fastapi>=0.134.0`。

fastapi 0.134.0 是第一个移除 `starlette<1.0.0` 上界约束的版本，其依赖为 `starlette>=0.46.0`（无上限），可以与 starlette 1.x 正常共存。

## 修复前后行为对比

| 状态 | fastapi 约束 | pip 可能解析到 | starlette 要求 | 与 AstrBot 核心兼容 |
|------|-------------|--------------|---------------|-------------------|
| 修复前 | `>=0.100.0` | 0.110.3 | `>=0.36.3,<0.38.0` | ❌ 冲突 |
| 修复后 | `>=0.134.0` | 0.136.3 | `>=0.46.0` | ✅ 兼容 |

## 附带清理

移除了 `asyncio-mqtt>=0.13.0` 依赖：
- 该包在整个代码库中**没有任何 import 引用**（grep 确认）
- 该包已被废弃，官方已更名为 `aiomqtt`
- 且仅声明支持 Python 3.7-3.11，不兼容 AstrBot 要求的 Python >=3.12

## 可能的影响

- **Web 管理端功能**：无影响。fastapi 0.134.0+ 的 API 与 0.100.0+ 完全向后兼容，插件中使用的 FastAPI/Starlette 特性（路由、中间件、WebSocket、StaticFiles）在新版本中均正常工作。
- **其他插件**：修复后本插件不再与 `astrbot_plugin_proactive_chat` 等同样依赖 starlette 的插件产生版本冲突。
- **asyncio-mqtt 移除**：无功能影响（代码中未使用）。

## 测试验证

依赖解析验证：
```
mcp -> sse-starlette -> starlette>=0.49.1  ✓
fastapi>=0.134.0 -> starlette>=0.46.0      ✓
解析结果: starlette 1.x 同时满足两者
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

更新依赖约束以恢复与 AstrBot 核心的兼容性，并清理未使用的包。

Bug Fixes（错误修复）:
- 提高 fastapi 的最低版本要求，以避免与 AstrBot 核心依赖中 starlette 版本产生冲突。

Build（构建）:
- 从运行时依赖中移除未使用的 asyncio-mqtt 依赖。

Documentation（文档）:
- 更新安装说明，将 asyncio-mqtt 从列出的手动依赖中移除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update dependency constraints to restore compatibility with AstrBot core and clean up unused packages.

Bug Fixes:
- Raise the minimum fastapi version to avoid starlette version conflicts with AstrBot core dependencies.

Build:
- Remove the unused asyncio-mqtt dependency from runtime requirements.

Documentation:
- Update installation instructions to drop asyncio-mqtt from the listed manual dependencies.

</details>