### PR TITLE
fix: 修复配置热重载时 Web 管理端端口冲突拖垮 AstrBot

### DIFF
--- a/core/network/admin/host/web_server.py
+++ b/core/network/admin/host/web_server.py
@@ -207,8 +207,22 @@ class WebAdminServer:
 
         logger.info(f"[灾害预警] Web 管理端已启动: http://{host}:{port}")
 
+        async def _serve():
+            try:
+                await self.server.serve()
+            except asyncio.CancelledError:
+                # 正常停止时会取消该任务，需放行以保持取消语义。
+                raise
+            except (SystemExit, Exception) as e:
+                # Uvicorn 绑定端口失败会调用 sys.exit() 抛出 SystemExit（属
+                # BaseException 而非 Exception）。该任务由 create_task 起、从不
+                # 被 await，若不在此拦截，异常会作为未检索的任务异常冒泡到事件
+                # 循环根部，拖垮整个 AstrBot 进程。这里显式只拦 SystemExit 与
+                # Exception，不波及 KeyboardInterrupt。
+                logger.exception(f"[灾害预警] Web 管理端运行异常: {e!r}")
+
         # 将服务进程、心跳/延迟检测循环与广播事件的协程单独开启 Task 挂载
-        self._server_task = asyncio.create_task(self.server.serve())
+        self._server_task = asyncio.create_task(_serve())
         self._broadcast_task = asyncio.create_task(self._broadcast_loop())
         self._ping_task = asyncio.create_task(self._background_ping_loop())
 
@@ -242,9 +256,23 @@ class WebAdminServer:
         # 5. 退出 Uvicorn Web 服务器实例并等待服务 Task 彻底终止
         if self.server:
             self.server.should_exit = True
+            # 强制退出：避免存在未关闭的长连接（如 WebSocket）时优雅关闭
+            # 永久挂起，确保监听 socket 能被释放，防止热重载时端口冲突。
+            self.server.force_exit = True
             if self._server_task:
                 try:
                     await asyncio.wait_for(self._server_task, timeout=5.0)
                 except asyncio.TimeoutError:
+                    logger.warning(
+                        "[灾害预警] Web 管理端未在 5 秒内停止，正在强制取消以释放端口。"
+                    )
                     self._server_task.cancel()
+                    # 等待取消真正完成，确保 stop 返回前监听 socket 已释放，
+                    # 避免热重载时新实例绑定同端口失败。
+                    try:
+                        await self._server_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                except Exception as e:
+                    logger.warning(f"[灾害预警] 停止 Web 管理端时出现异常: {e!r}")
             logger.info("[灾害预警] Web 管理端已停止")

--- a/core/network/admin/host/web_server.py
+++ b/core/network/admin/host/web_server.py
@@ -213,13 +213,14 @@ class WebAdminServer:
             except asyncio.CancelledError:
                 # 正常停止时会取消该任务，需放行以保持取消语义。
                 raise
-            except (SystemExit, Exception) as e:
+            except (SystemExit, Exception):
                 # Uvicorn 绑定端口失败会调用 sys.exit() 抛出 SystemExit（属
                 # BaseException 而非 Exception）。该任务由 create_task 起、从不
                 # 被 await，若不在此拦截，异常会作为未检索的任务异常冒泡到事件
                 # 循环根部，拖垮整个 AstrBot 进程。这里显式只拦 SystemExit 与
                 # Exception，不波及 KeyboardInterrupt。
-                logger.exception(f"[灾害预警] Web 管理端运行异常: {e!r}")
+                # logger.exception 已含异常类型与堆栈，无需再拼接异常对象。
+                logger.exception("[灾害预警] Web 管理端运行异常")
 
         # 将服务进程、心跳/延迟检测循环与广播事件的协程单独开启 Task 挂载
         self._server_task = asyncio.create_task(_serve())
@@ -271,8 +272,16 @@ class WebAdminServer:
                     # 避免热重载时新实例绑定同端口失败。
                     try:
                         await self._server_task
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                    except asyncio.CancelledError:
+                        # 区分两种取消：若是 _server_task 自身被上面 cancel（预期
+                        # 内），吞掉即可；若是 stop() 协程本身被外部取消，则需
+                        # 放行以保持取消语义，不可静默吞掉。
+                        if not self._server_task.cancelled():
+                            raise
+                    except Exception as e:
+                        logger.debug(
+                            f"[灾害预警] 等待 Web 管理端任务取消时出现异常: {e!r}"
+                        )
                 except Exception as e:
                     logger.warning(f"[灾害预警] 停止 Web 管理端时出现异常: {e!r}")
             logger.info("[灾害预警] Web 管理端已停止")


### PR DESCRIPTION
## 📝 描述 / Description

修复在 AstrBot 主面板（WebUI）保存本插件配置时，整个 AstrBot 进程崩溃的问题。

根本原因是两个缺陷叠加，缺一不会崩：

1. **进程崩溃源**：保存插件配置会触发 AstrBot 热重载（串行执行 `terminate` → `initialize`）。`initialize` 时新实例会在端口（默认 `8089`）重新启动内嵌 Uvicorn；若此时旧端口尚未释放，Uvicorn 绑定失败会调用 `sys.exit()` 抛出 `SystemExit`。本插件的 serve 任务由 `asyncio.create_task(self.server.serve())` 直接起、从不被 `await`，且**没有任何 try/except 包裹**；`SystemExit` 继承自 `BaseException`，便作为“未检索的任务异常”冒泡到事件循环根部（`run_until_complete`），最终拖垮整个 AstrBot 进程。

2. **端口冲突源**：`stop()` 仅设置 `should_exit = True`。当存在未关闭的长连接（如 WebUI 的 WebSocket）时，Uvicorn 的优雅关闭会一直等待连接断开而永久挂起，导致 `await asyncio.wait_for(..., timeout=5)` 必然超时；而超时后仅 `cancel()` 但未 `await` 取消完成，监听 socket 未必释放。于是热重载时新实例绑定同端口必然失败。

## 🛠️ 改动点 / Modifications

仅修改 `core/network/admin/host/web_server.py` 一个文件（`WebAdminServer.start` / `stop`，+29 / -1）：

- **`start()`**：将裸的 `asyncio.create_task(self.server.serve())` 包入内部协程 `_serve()`，单独 `except asyncio.CancelledError: raise` 放行取消信号以保持取消语义，并以 `except (SystemExit, Exception)` 拦住 Uvicorn 绑定失败抛出的 `SystemExit`，避免拖垮宿主进程。
- **`stop()`**：补充 `self.server.force_exit = True`，跳过对未关闭长连接的等待、确保监听 socket 被释放；超时分支由“仅 cancel”改为记录告警 + `cancel()` + `await` 等待取消真正完成后再返回，避免热重载时端口未释放。

**影响 / Impact**：保存配置触发热重载时 AstrBot 不再崩溃；即便偶发端口未及时释放，最多导致本次 Web 管理端启动失败（仅 Web 端不可用，插件主体功能不受影响）；`stop()` 现在能可靠释放端口。正常启动/停止流程不变，仅在异常路径上更健壮。

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.

## 📸 运行截图或测试结果 / Screenshots or Test Results

在**真实 AstrBot 环境**（AstrBot v4.25.1，本仓库 shipped 的 `WebAdminServer` 代码本身，非 mock/复刻）中复现并验证。插件以 `data.plugins.astrbot_plugin_disaster_warning` 包形式加载，搭配真实 Uvicorn 0.48.0 与真实 astrbot logger。

测试脚本驱动真实 `WebAdminServer.start()` / `stop()`，复刻配置热重载时的端口竞争：

- **场景 A（崩溃修复）**：实例1 正常启动占住端口（模拟旧实例 socket 未释放），实例2 在同端口 `start()`，使真实 Uvicorn 触发 `bind` 失败 → `server.py:182 sys.exit(1)` → 真实 `SystemExit`。断言宿主事件循环存活。
- **场景 B（端口释放）**：实例1 `stop()` 后探测端口可否重新绑定，验证 `force_exit` 真正释放 socket。
- **对照实验**：将 `web_server.py` 还原为修复前版本（`main` 分支），同一真实环境同一脚本下，进程被 `SystemExit` 拖垮、异常退出（EXIT=1）；切回修复版后宿主存活、正常退出（EXIT=0）。

修复版测试输出（真实 Uvicorn 抛出 `SystemExit: 1` 后被 `_serve` 拦下，宿主存活）：

```
[1] 实例1 启动（模拟热重载前的旧实例）...
    实例1 已监听端口 18089: True
[A] 实例2 在被占用端口启动（模拟热重载新实例抢端口）...
   ... uvicorn server.py:182 sys.exit(1) -> SystemExit: 1 ...
    -> 宿主事件循环存活（未被 SystemExit 拖垮）: PASS
    实例2 的 serve task 已结束（异常被 _serve 拦下）: True
[B] 实例1 stop() -> 端口释放验证...
    stop 后端口 18089 可重新绑定: True
    -> PASS
结论: 崩溃修复=PASS  端口释放=PASS
进程正常退出 —— 真实 uvicorn 的 SystemExit 未拉崩事件循环。
```

对照（修复前 `main` 版本，同一真实环境）：进程以 `SystemExit: 1` 异常终止，与 AstrBot 保存配置时崩溃的现象一致。

另：`python -m ruff check` 通过。

## ✅ 检查清单 / Checklist

- [x] 😊 本 PR 为 bug 修复，无新增功能。
- [x] 👀 我的更改经过了良好的测试，并已在上方提供了测试日志。
- [x] 🤓 我确保没有引入新依赖库。
- [x] 😮 我的更改没有引入恶意代码。

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的贡献指南。

## Summary by Sourcery

加固 Web 管理端服务器的启动和关闭流程，以防止 AstrBot 在配置热重载期间崩溃或因管理端口未释放而导致端口被占用。

Bug Fixes:
- 防止 Web 管理端在端口被占用时触发的 `SystemExit` 冒泡至事件循环并拖垮 AstrBot 进程。
- 确保 Web 管理端在停止时可靠释放监听端口，避免热重载期间的端口冲突导致新实例启动失败。

Enhancements:
- 将 Web 管理端的 `serve` 任务包装在带日志的受监督协程中，使运行时错误被隔离并记录，而不会影响宿主进程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the Web admin server startup and shutdown to prevent AstrBot from crashing or leaving the admin port occupied during configuration hot reloads.

Bug Fixes:
- Prevent Web 管理端在端口被占用时触发的 SystemExit 冒泡至事件循环并拖垮 AstrBot 进程。
- Ensure Web 管理端在停止时可靠释放监听端口，避免热重载期间的端口冲突导致新实例启动失败。

Enhancements:
- Wrap the Web 管理端 serve 任务 in a supervised coroutine with logging so runtime errors are contained and reported without affecting the host process.

</details>