### PR TITLE
feat: 新增插件内部日志分级，微调 GQ 卡片最终报样式

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -792,6 +792,26 @@
     "type": "object",
     "hint": "用于开发和排查问题",
     "items": {
+      "log_mode": {
+        "description": "插件日志输出选项",
+        "type": "string",
+        "options": [
+          "全量",
+          "简洁"
+        ],
+        "default": "全量",
+        "hint": "全量模式下输出所有数据接收、解析、去重和推送日志；简洁模式下会根据降级行为设置，降级或屏蔽高频的事件流日志。"
+      },
+      "log_downgrade_behavior": {
+        "description": "简洁模式日志处理行为",
+        "type": "string",
+        "options": [
+          "降级为DEBUG",
+          "完全屏蔽"
+        ],
+        "default": "降级为DEBUG",
+        "hint": "仅在日志输出选项为“简洁”时生效。降级为DEBUG：事件流日志均以 DEBUG 级别在 AstrBot 控制台输出；完全屏蔽：彻底过滤除 ERROR 外的事件流日志，不论 AstrBot 控制台为什么级别均不输出。"
+      },
       "enable_raw_message_logging": {
         "description": "启用原始消息格式记录",
         "type": "bool",

--- a/core/message/fusion/cenc_fusion_service.py
+++ b/core/message/fusion/cenc_fusion_service.py
@@ -10,6 +10,7 @@ import time
 
 from astrbot.api import logger
 
+from ....utils.plugin_logger import plugin_logger
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...domain.event_payload import SourcePayload
 
@@ -130,8 +131,9 @@ class CENCFusionService:
         ):
             intensity = cached_payload["intensity"]
             type(self)._apply_intensity(event, earthquake, intensity)
-            logger.info(
-                f"[灾害预警] 融合策略: Fan CENC 事件 {event.id} 命中 Wolfx 缓存并补充烈度: {earthquake.intensity}"
+            plugin_logger.info(
+                f"[灾害预警] 融合策略: Fan CENC 事件 {event.id} 命中 Wolfx 缓存并补充烈度: {earthquake.intensity}",
+                is_event_linked=True,
             )
             return await self._execute_push(
                 event,
@@ -139,8 +141,9 @@ class CENCFusionService:
                 session_config_getter=session_config_getter,
             )
 
-        logger.info(
-            f"[灾害预警] 融合策略: 拦截 Fan CENC 事件 {event.id}，事件标识为 {event_key}，兼容槽位序号为 {report_num}，测定类型为 {measurement_type}，等待 Wolfx 补充（{timeout} 秒）..."
+        plugin_logger.info(
+            f"[灾害预警] 融合策略: 拦截 Fan CENC 事件 {event.id}，事件标识为 {event_key}，兼容槽位序号为 {report_num}，测定类型为 {measurement_type}，等待 Wolfx 补充（{timeout} 秒）...",
+            is_event_linked=True,
         )
 
         loop = asyncio.get_running_loop()
@@ -174,14 +177,20 @@ class CENCFusionService:
             store.cenc_pending.pop(pending_key, None)
 
             if result == "timeout":
-                logger.info("[灾害预警] 融合策略: CENC 等待超时，推送原始 Fan 事件")
+                plugin_logger.info(
+                    "[灾害预警] 融合策略: CENC 等待超时，推送原始 Fan 事件",
+                    is_event_linked=True,
+                )
                 return await self._execute_push(
                     event,
                     target_sessions=target_sessions,
                     session_config_getter=session_config_getter,
                 )
             if result == "fused":
-                logger.info("[灾害预警] 融合策略: CENC 融合完成，推送补充后的 Fan 事件")
+                plugin_logger.info(
+                    "[灾害预警] 融合策略: CENC 融合完成，推送补充后的 Fan 事件",
+                    is_event_linked=True,
+                )
                 return await self._execute_push(
                     event,
                     target_sessions=target_sessions,
@@ -263,8 +272,9 @@ class CENCFusionService:
                 return
 
             type(self)._apply_intensity(fan_event, fan_earthquake, intensity)
-            logger.info(
-                f"[灾害预警] 融合策略: 成功用 Wolfx 补充 Fan CENC 事件 {pending_key} 的烈度: {intensity}"
+            plugin_logger.info(
+                f"[灾害预警] 融合策略: 成功用 Wolfx 补充 Fan CENC 事件 {pending_key} 的烈度: {intensity}",
+                is_event_linked=True,
             )
 
             if future is not None and hasattr(future, "done") and not future.done():

--- a/core/message/fusion/cwa_eew_fusion_service.py
+++ b/core/message/fusion/cwa_eew_fusion_service.py
@@ -12,6 +12,7 @@ from typing import Any
 from astrbot.api import logger
 
 from ....utils.converters import ScaleConverter
+from ....utils.plugin_logger import plugin_logger
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...domain.event_payload import SourcePayload
 
@@ -105,8 +106,9 @@ class CWAEewFusionService:
             scale = cached_payload["scale"]
             cls = type(self)
             cls._apply_scale(event, earthquake, scale)
-            logger.info(
-                f"[灾害预警] 融合策略：Fan CWA EEW 事件 {event.id} 已命中 Wolfx 缓存，补充的最大震度为 {scale}"
+            plugin_logger.info(
+                f"[灾害预警] 融合策略：Fan CWA EEW 事件 {event.id} 已命中 Wolfx 缓存，补充的最大震度为 {scale}",
+                is_event_linked=True,
             )
             return await self._execute_push(
                 event,
@@ -114,8 +116,9 @@ class CWAEewFusionService:
                 session_config_getter=session_config_getter,
             )
 
-        logger.info(
-            f"[灾害预警] 融合策略：已拦截 Fan CWA EEW 事件 {event.id}，事件标识为 {event_key}，报数为 {report_num}，等待 Wolfx 在 {timeout} 秒内补充最大震度"
+        plugin_logger.info(
+            f"[灾害预警] 融合策略：已拦截 Fan CWA EEW 事件 {event.id}，事件标识为 {event_key}，报数为 {report_num}，等待 Wolfx 在 {timeout} 秒内补充最大震度",
+            is_event_linked=True,
         )
 
         loop = asyncio.get_running_loop()
@@ -146,15 +149,19 @@ class CWAEewFusionService:
             store.cwa_eew_pending.pop(pending_key, None)
 
             if result == "timeout":
-                logger.info("[灾害预警] 融合策略：CWA EEW 等待超时，推送原始 Fan 事件")
+                plugin_logger.info(
+                    "[灾害预警] 融合策略：CWA EEW 等待超时，推送原始 Fan 事件",
+                    is_event_linked=True,
+                )
                 return await self._execute_push(
                     event,
                     target_sessions=target_sessions,
                     session_config_getter=session_config_getter,
                 )
             if result == "fused":
-                logger.info(
-                    "[灾害预警] 融合策略：CWA EEW 融合完成，推送补充最大震度后的 Fan 事件"
+                plugin_logger.info(
+                    "[灾害预警] 融合策略：CWA EEW 融合完成，推送补充最大震度后的 Fan 事件",
+                    is_event_linked=True,
                 )
                 return await self._execute_push(
                     event,
@@ -251,12 +258,14 @@ class CWAEewFusionService:
 
             if fan_earthquake.scale is None:
                 type(self)._apply_scale(fan_event, fan_earthquake, scale)
-                logger.info(
-                    f"[灾害预警] 融合策略：已使用 Wolfx 为 Fan CWA EEW 事件 {pending_key} 补充最大震度，数值为 {scale}"
+                plugin_logger.info(
+                    f"[灾害预警] 融合策略：已使用 Wolfx 为 Fan CWA EEW 事件 {pending_key} 补充最大震度，数值为 {scale}",
+                    is_event_linked=True,
                 )
             else:
-                logger.info(
-                    f"[灾害预警] 融合策略：Fan CWA EEW 事件 {pending_key} 已自带最大震度，保留 Fan 的数值 ({fan_earthquake.scale})"
+                plugin_logger.info(
+                    f"[灾害预警] 融合策略：Fan CWA EEW 事件 {pending_key} 已自带最大震度，保留 Fan 的数值 ({fan_earthquake.scale})",
+                    is_event_linked=True,
                 )
 
             if future is not None and hasattr(future, "done") and not future.done():

--- a/core/message/push/push_flow_handler.py
+++ b/core/message/push/push_flow_handler.py
@@ -10,8 +10,7 @@ import asyncio
 import json
 from typing import Any
 
-from astrbot.api import logger
-
+from ....utils.plugin_logger import plugin_logger
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...services.identity.event_identity import resolve_report_num
 from ...services.telemetry.telemetry_utils import track_feature_safely
@@ -37,11 +36,11 @@ class PushFlowHandler:
         return_details: bool = False,
     ) -> bool | dict[str, Any]:
         """执行完整推送流程：去重、会话执行、后处理与异常遥测。"""
-        logger.debug(f"[灾害预警] 执行事件推送流程: {event.id}")
+        plugin_logger.debug(f"[灾害预警] 执行事件推送流程: {event.id}")
 
         # 地震重复与烈度/警报合并过滤判断
         if not skip_dedup and not self.manager.deduplicator.should_push_event(event):
-            logger.debug(f"[灾害预警] 事件 {event.id} 被去重器过滤")
+            plugin_logger.debug(f"[灾害预警] 事件 {event.id} 被去重器过滤")
             return False
 
         try:
@@ -59,7 +58,7 @@ class PushFlowHandler:
                 return execution_result
             return success
         except Exception as e:
-            logger.error(f"[灾害预警] 推送事件失败: {e}")
+            plugin_logger.error(f"[灾害预警] 推送事件失败: {e}")
             if self.manager._telemetry and self.manager._telemetry.enabled:
                 await self.manager._telemetry.track_error(
                     e,
@@ -190,7 +189,7 @@ class PushFlowHandler:
         if not should_gen_map or not passed_sessions:
             return
 
-        logger.debug(f"[灾害预警] 触发异步地图渲染 (第 {current_report} 报)")
+        plugin_logger.debug(f"[灾害预警] 触发异步地图渲染 (第 {current_report} 报)")
         grouped_sessions: dict[str, list[str]] = {}
         grouped_config: dict[str, dict[str, Any]] = {}
         for session in passed_sessions:
@@ -258,20 +257,24 @@ class PushFlowHandler:
                 for reason, count in sorted(filter_reason_stats.items())
             )
             if push_success_count > 0:
-                logger.info(
-                    f"[灾害预警] 事件 {event.id} 已完成会话筛选，{push_success_count} 个会话通过，另有 {summary} 被拦截{failure_suffix}"
+                plugin_logger.info(
+                    f"[灾害预警] 事件 {event.id} 已完成会话筛选，{push_success_count} 个会话通过，另有 {summary} 被拦截{failure_suffix}",
+                    is_event_linked=True,
                 )
             else:
-                logger.info(
-                    f"[灾害预警] 事件 {event.id} 未通过任何会话的推送条件，拦截情况：{summary}{failure_suffix}"
+                plugin_logger.info(
+                    f"[灾害预警] 事件 {event.id} 未通过任何会话的推送条件，拦截情况：{summary}{failure_suffix}",
+                    is_event_linked=True,
                 )
         elif push_success_count > 0:
-            logger.info(
-                f"[灾害预警] 事件 {event.id} 已通过全部会话的推送条件，共 {push_success_count} 个会话{failure_suffix}"
+            plugin_logger.info(
+                f"[灾害预警] 事件 {event.id} 已通过全部会话的推送条件，共 {push_success_count} 个会话{failure_suffix}",
+                is_event_linked=True,
             )
         elif failure_summary:
-            logger.info(
-                f"[灾害预警] 事件 {event.id} 已通过发送前筛选，但发送阶段全部失败：{failure_summary}"
+            plugin_logger.info(
+                f"[灾害预警] 事件 {event.id} 已通过发送前筛选，但发送阶段全部失败：{failure_summary}",
+                is_event_linked=True,
             )
 
     def _log_push_completion(
@@ -291,23 +294,29 @@ class PushFlowHandler:
                 f"{reason}×{count}"
                 for reason, count in sorted(filter_reason_stats.items())
             )
-            logger.debug(f"[灾害预警] 事件 {event.id} 部分会话被过滤: {summary}")
+            plugin_logger.debug(f"[灾害预警] 事件 {event.id} 部分会话被过滤: {summary}")
             detailed_summary = "，".join(
                 f"{reason}×{count}" for reason, count in sorted(detailed_stats.items())
             )
-            logger.debug(f"[灾害预警] 事件 {event.id} 过滤明细: {detailed_summary}")
+            plugin_logger.debug(
+                f"[灾害预警] 事件 {event.id} 过滤明细: {detailed_summary}"
+            )
         if send_failure_stats:
             summary = "，".join(
                 f"{reason}×{count}"
                 for reason, count in sorted(send_failure_stats.items())
             )
-            logger.debug(f"[灾害预警] 事件 {event.id} 部分会话发送失败: {summary}")
+            plugin_logger.debug(
+                f"[灾害预警] 事件 {event.id} 部分会话发送失败: {summary}"
+            )
 
         if push_success_count > 0:
-            logger.info(
-                f"[灾害预警] 事件 {event.id} 推送完成，成功推送到 {push_success_count} 个会话"
+            plugin_logger.info(
+                f"[灾害预警] 事件 {event.id} 推送完成，成功推送到 {push_success_count} 个会话",
+                is_event_linked=True,
             )
         elif send_failure_stats:
-            logger.warning(
-                f"[灾害预警] 事件 {event.id} 推送完成，但没有任何会话发送成功"
+            plugin_logger.warning(
+                f"[灾害预警] 事件 {event.id} 推送完成，但没有任何会话发送成功",
+                is_event_linked=True,
             )

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -16,6 +16,8 @@ from playwright.async_api import Browser, Page, async_playwright
 
 from astrbot.api import logger
 
+from ....utils.plugin_logger import plugin_logger
+
 
 class BrowserManager:
     """浏览器管理器。"""
@@ -405,7 +407,10 @@ class BrowserManager:
                             logger.warning(
                                 f"[灾害预警] 卡片渲染虽成功，但捕获到页面脚本异常: {' | '.join(page_errors[-3:])}"
                             )
-                        logger.info(f"[灾害预警] 卡片渲染成功，耗时 {elapsed:.3f}秒")
+                        plugin_logger.info(
+                            f"[灾害预警] 卡片渲染成功，耗时 {elapsed:.3f}秒",
+                            is_event_linked=True,
+                        )
                         return output_path
                     else:
                         logger.warning("[灾害预警] 截图未生成文件")

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 
-from astrbot.api import logger
-
+from ...utils.plugin_logger import plugin_logger
 from ..services.telemetry.telemetry_utils import track_error_safely
 from ..sources.source_catalog import get_source_entry, get_source_ids_by_dispatch_family
 from ..sources.source_entry import ProviderFamily
@@ -117,13 +116,15 @@ class SourceMessageRouter:
         config_key = _resolve_config_key(source_id)
         # 校验：1. 数据源是否在当前配置中被启用
         if not self._source_runtime_query.is_source_enabled(source_id):
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] 数据源 {config_key} ({source_label}) 未启用，忽略"
             )
             return False
         # 校验：2. 相应的消息解析器是否存在，避免解析抛错
         if not self._has_parser(source_id):
-            logger.warning(f"[灾害预警] 未找到解析器: {source_id}")
+            plugin_logger.warning(
+                f"[灾害预警] 未找到解析器: {source_id}", is_event_linked=True
+            )
             return False
         return True
 
@@ -156,7 +157,7 @@ class SourceMessageRouter:
             source_channel=source_channel,
         )
         log_label = parser_log_label or source_label or source_id
-        logger.debug(f"[灾害预警] {log_label} 解析成功: {event.id}")
+        plugin_logger.debug(f"[灾害预警] {log_label} 解析成功: {event.id}")
 
         # 将解析好的事件丢给分发流水线处理
         await self._dispatch_event(
@@ -210,13 +211,8 @@ class SourceMessageRouter:
                 connection_uri = (
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
-                logger.error(
-                    "[灾害预警] %s 解析器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
-                    source_id,
-                    connection_name or "未知连接",
-                    connection_uri,
-                    error,
-                    exc_info=True,
+                plugin_logger.error(
+                    f"[灾害预警] {source_id} 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
                 )
                 # 对捕获到的具体解析异常进行遥测跟踪，保证健壮性
                 await self._track_router_error(
@@ -232,9 +228,10 @@ class SourceMessageRouter:
         # 遍历静态数据源配置中的所有 fan studio 定义，校验其解析器是否存在
         for source_name, source_id in FAN_STUDIO_PROVIDER_SOURCE_MAP.items():
             if source_id and not self._has_parser(source_id):
-                logger.warning(
+                plugin_logger.warning(
                     f"[灾害预警] Source ID '{source_id}' (源: {source_name}) 未注册解析器，"
-                    f"请检查 core/app/disaster_service.py 中的初始化。"
+                    f"请检查 core/app/disaster_service.py 中的初始化。",
+                    is_event_linked=True,
                 )
         self._parser_map_checked = True
 
@@ -256,7 +253,7 @@ class SourceMessageRouter:
                     data = json.loads(message)
                 except json.JSONDecodeError as error:
                     # 避免非 JSON 报文引起程序崩溃
-                    logger.error(f"[灾害预警] JSON解析失败: {error}")
+                    plugin_logger.error(f"[灾害预警] JSON解析失败: {error}")
                     return None
 
                 # 先校验路由映射，再把一条总线消息拆成多个候选数据源消息
@@ -274,8 +271,9 @@ class SourceMessageRouter:
                     if not self._is_source_routable(source_id, source):
                         continue
 
-                    logger.info(
-                        f"[灾害预警] 处理 {source} 数据 ({_resolve_config_key(source_id)})"
+                    plugin_logger.info(
+                        f"[灾害预警] 处理 {source} 数据 ({_resolve_config_key(source_id)})",
+                        is_event_linked=True,
                     )
                     dispatched = await self._parse_and_dispatch(
                         source_id=source_id,
@@ -302,12 +300,8 @@ class SourceMessageRouter:
                         has_data = "Data" in data or "data" in data
                         is_unhandled_initial = msg_type == "initial_all"
                         if has_data or is_unhandled_initial:
-                            logger.debug(
-                                "[灾害预警] 收到一条尚未处理的消息，连接为 %s，消息类型为 %s，来源为 %s，数据摘要：%s",
-                                connection_name,
-                                msg_type,
-                                data.get("source", "unknown"),
-                                str(data)[:100],
+                            plugin_logger.debug(
+                                f"[灾害预警] 收到一条尚未处理的消息，连接为 {connection_name}，消息类型为 {msg_type}，来源为 {data.get('source', 'unknown')}，数据摘要：{str(data)[:100]}"
                             )
 
                 return None
@@ -321,13 +315,8 @@ class SourceMessageRouter:
                     if connection_info
                     else "未知类型"
                 )
-                logger.error(
-                    "[灾害预警] FAN Studio 处理器解析来自 %s 的消息失败，连接地址为 %s，连接类型为 %s，错误为 %s",
-                    connection_name or "未知连接",
-                    connection_uri,
-                    connection_type,
-                    error,
-                    exc_info=True,
+                plugin_logger.error(
+                    f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，连接类型为 {connection_type}，错误为 {error}"
                 )
                 # 路由异常遥测
                 await self._track_router_error(
@@ -355,8 +344,9 @@ class SourceMessageRouter:
                 code = str(data.get("code") or "").strip()
                 # 556 代表紧急地震速报 EEW
                 if code == "556":
-                    logger.info(
-                        "[灾害预警] P2P 处理器收到紧急地震速报，业务码为 556，准备解析"
+                    plugin_logger.info(
+                        "[灾害预警] P2P 处理器收到紧急地震速报，业务码为 556，准备解析",
+                        is_event_linked=True,
                     )
             except (json.JSONDecodeError, AttributeError, TypeError):
                 data = {}
@@ -384,7 +374,7 @@ class SourceMessageRouter:
                 source_channel=code or None,
             )
             if not dispatched:
-                logger.debug("[灾害预警] P2P处理器返回None，无有效事件")
+                plugin_logger.debug("[灾害预警] P2P处理器返回None，无有效事件")
 
         return p2p_handler
 
@@ -403,7 +393,7 @@ class SourceMessageRouter:
                 try:
                     data = json.loads(message)
                 except json.JSONDecodeError as error:
-                    logger.error(f"[灾害预警] Wolfx JSON解析失败: {error}")
+                    plugin_logger.error(f"[灾害预警] Wolfx JSON解析失败: {error}")
                     return None
 
                 msg_type = data.get("type")
@@ -414,7 +404,7 @@ class SourceMessageRouter:
                 # 获取 Wolfx 当前子报文类型对应的系统内 source_id
                 source_id = get_wolfx_source_id(msg_type)
                 if source_id is None:
-                    logger.debug(
+                    plugin_logger.debug(
                         f"[灾害预警] Wolfx 消息类型 {msg_type} 暂未识别，来源连接为 {connection_name}"
                     )
                     return None
@@ -422,7 +412,7 @@ class SourceMessageRouter:
                 if not self._is_source_routable(source_id, msg_type):
                     return None
 
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] 将使用 Wolfx 解析器 {source_id} 处理类型为 {msg_type} 的消息"
                 )
                 # 某些 Wolfx 消息在正式解析前需要先触发旁路副作用（比如缓存 eqlist）
@@ -449,12 +439,8 @@ class SourceMessageRouter:
                 connection_uri = (
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
-                logger.error(
-                    "[灾害预警] Wolfx 处理器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
-                    connection_name or "未知连接",
-                    connection_uri,
-                    error,
-                    exc_info=True,
+                plugin_logger.error(
+                    f"[灾害预警] Wolfx 处理器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
                 )
                 # 遥测路由层异常
                 await self._track_router_error(
@@ -480,7 +466,7 @@ class SourceMessageRouter:
 
             # 校验是否配备了 global_quake 对应专有 protobuf 解析模块
             if not self._has_parser("global_quake"):
-                logger.warning("[灾害预警] 未找到 Global Quake 解析器")
+                plugin_logger.warning("[灾害预警] 未找到 Global Quake 解析器")
                 return
 
             try:
@@ -499,12 +485,8 @@ class SourceMessageRouter:
                 connection_uri = (
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
-                logger.error(
-                    "[灾害预警] Global Quake 解析器处理来自 %s 的消息失败，连接地址为 %s，错误为 %s",
-                    connection_name or "未知连接",
-                    connection_uri,
-                    error,
-                    exc_info=True,
+                plugin_logger.error(
+                    f"[灾害预警] Global Quake 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
                 )
                 # 异常遥测
                 await self._track_router_error(

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -212,7 +212,8 @@ class SourceMessageRouter:
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
                 plugin_logger.error(
-                    f"[灾害预警] {source_id} 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
+                    f"[灾害预警] {source_id} 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}",
+                    exc_info=True,
                 )
                 # 对捕获到的具体解析异常进行遥测跟踪，保证健壮性
                 await self._track_router_error(
@@ -316,7 +317,8 @@ class SourceMessageRouter:
                     else "未知类型"
                 )
                 plugin_logger.error(
-                    f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，连接类型为 {connection_type}，错误为 {error}"
+                    f"[灾害预警] FAN Studio 处理器解析来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，连接类型为 {connection_type}，错误为 {error}",
+                    exc_info=True,
                 )
                 # 路由异常遥测
                 await self._track_router_error(
@@ -440,7 +442,8 @@ class SourceMessageRouter:
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
                 plugin_logger.error(
-                    f"[灾害预警] Wolfx 处理器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
+                    f"[灾害预警] Wolfx 处理器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}",
+                    exc_info=True,
                 )
                 # 遥测路由层异常
                 await self._track_router_error(
@@ -486,7 +489,8 @@ class SourceMessageRouter:
                     connection_info.get("uri") if connection_info else "未知地址"
                 )
                 plugin_logger.error(
-                    f"[灾害预警] Global Quake 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}"
+                    f"[灾害预警] Global Quake 解析器处理来自 {connection_name or '未知连接'} 的消息失败，连接地址为 {connection_uri}，错误为 {error}",
+                    exc_info=True,
                 )
                 # 异常遥测
                 await self._track_router_error(

--- a/core/parsers/base_parser.py
+++ b/core/parsers/base_parser.py
@@ -12,8 +12,7 @@ import traceback
 from datetime import datetime
 from typing import Any
 
-from astrbot.api import logger
-
+from ...utils.plugin_logger import plugin_logger
 from ...utils.time_converter import TimeConverter
 from ..sources.source_catalog import get_source_entry
 
@@ -49,11 +48,11 @@ class BaseParser:
             payload = self.decode_message(message)
             return self.build_event(payload)
         except json.JSONDecodeError as exc:
-            logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
             return None
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
-            logger.error(f"[灾害预警] 异常堆栈: {traceback.format_exc()}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
+            plugin_logger.error(f"[灾害预警] 异常堆栈: {traceback.format_exc()}")
             return None
 
     def decode_message(self, message: str | bytes) -> Any:
@@ -84,14 +83,14 @@ class BaseParser:
         """提取实际业务数据，兼容多种外层包装格式。"""
         # 兼容首字母大写的 "Data" 键
         if "Data" in data:
-            logger.debug(f"[灾害预警] {self.source_id} 使用 Data 字段获取数据")
+            plugin_logger.debug(f"[灾害预警] {self.source_id} 使用 Data 字段获取数据")
             return data["Data"] or {}
         # 兼容小写的 "data" 键
         if "data" in data:
-            logger.debug(f"[灾害预警] {self.source_id} 使用 data 字段获取数据")
+            plugin_logger.debug(f"[灾害预警] {self.source_id} 使用 data 字段获取数据")
             return data["data"] or {}
         # 无包装时，直接视整个载荷为数据体
-        logger.debug(f"[灾害预警] {self.source_id} 使用整个消息作为数据")
+        plugin_logger.debug(f"[灾害预警] {self.source_id} 使用整个消息作为数据")
         return data
 
     def _is_heartbeat_message(self, msg_data: dict[str, Any]) -> bool:
@@ -111,7 +110,7 @@ class BaseParser:
             lat = msg_data.get("latitude")
             lon = msg_data.get("longitude")
             if lat == 0 and lon == 0:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 检测到空坐标心跳包，静默过滤"
                 )
                 return True
@@ -134,7 +133,7 @@ class BaseParser:
 
             # 若有一半以上的核心必填字段为空，视为无实际有效业务内容的心跳空包
             if missing_count >= len(required_fields) / 2:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 检测到空数据心跳包，静默过滤"
                 )
                 return True
@@ -167,5 +166,7 @@ class BaseParser:
         # 调用时间转换工具进行多格式兼容解析
         dt = TimeConverter.parse_datetime(time_str)
         if dt is None and time_str:
-            logger.warning(f"[灾害预警] 时间解析失败: '{time_str}'")
+            plugin_logger.warning(
+                f"[灾害预警] 时间解析失败: '{time_str}'", is_event_linked=True
+            )
         return dt

--- a/core/parsers/china_earthquake_parser.py
+++ b/core/parsers/china_earthquake_parser.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ...utils.converters import safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -103,12 +102,14 @@ class CencEarthquakeParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 这类消息至少应具备情报类型与事件标识，否则通常不是正式测定数据
             if "infoTypeName" not in msg_data or "eventId" not in msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 非 CENC 地震测定数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 CENC 地震测定数据，跳过"
+                )
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -119,12 +120,13 @@ class CencEarthquakeParser(BaseParser):
             )
 
             domain_event = envelope.event
-            logger.info(
-                f"[灾害预警] 地震数据解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] 地震数据解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None
 
 
@@ -146,10 +148,12 @@ class CencEarthquakeWolfxParser(BaseParser):
                 if key.startswith("No") and isinstance(value, dict)
             ]
             if raw_type and raw_type != "cenc_eqlist":
-                logger.debug(f"[灾害预警] {self.source_id} 非 CENC 地震列表数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 CENC 地震列表数据，跳过"
+                )
                 return None
             if not raw_type and not no_keys:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 未识别到 Wolfx CENC 列表结构，跳过"
                 )
                 return None
@@ -162,7 +166,7 @@ class CencEarthquakeWolfxParser(BaseParser):
                     break
 
             if not eq_info:
-                logger.warning(
+                plugin_logger.warning(
                     f"[灾害预警] {self.source_id} 这次收到的 Wolfx CENC 列表里没有找到可解析的地震条目"
                 )
                 return None
@@ -246,11 +250,11 @@ class CencEarthquakeWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/china_eew_parser.py
+++ b/core/parsers/china_eew_parser.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ...utils.converters import safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -109,12 +108,12 @@ class CEAEEWParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 中国地震预警数据至少应携带预计烈度字段，否则大概率不是目标消息
             if "epiIntensity" not in msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 非地震预警数据，跳过")
+                plugin_logger.debug(f"[灾害预警] {self.source_id} 非地震预警数据，跳过")
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -139,12 +138,13 @@ class CEAEEWParser(BaseParser):
             )
 
             domain_event = envelope.event
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None
 
 
@@ -166,7 +166,9 @@ class CEAEEWWolfxParser(BaseParser):
         try:
             # Wolfx 会混发多类消息，这里只接收中国地震预警类型
             if data.get("type") != "cenc_eew":
-                logger.debug(f"[灾害预警] {self.source_id} 非 CENC 地震预警数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 CENC 地震预警数据，跳过"
+                )
                 return None
 
             raw_report_num = data.get("ReportNum", 1)
@@ -243,11 +245,12 @@ class CEAEEWWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -9,10 +9,9 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ...models.websocket_message_pb2 import MessageAction, MessageType, WsMessage
 from ...utils.converters import ScaleConverter, safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -57,17 +56,17 @@ class GlobalQuakeParser(BaseParser):
             if ws_msg.type == MessageType.HEARTBEAT:
                 return None
             if ws_msg.type == MessageType.STATUS:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 收到状态消息，服务器状态为 {ws_msg.status_data.server_status}"
                 )
                 return None
 
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] {self.source_id} 收到未知类型的消息，类型值为 {ws_msg.type}"
             )
             return None
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} Protobuf 解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} Protobuf 解析失败: {exc}")
             return None
 
     def _parse_json_message(self, message: str) -> EventEnvelope | None:
@@ -79,7 +78,7 @@ class GlobalQuakeParser(BaseParser):
 
             # JSON 通道当前主要关心地震消息，其余类型直接忽略。
             if msg_type == "earthquake":
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 收到 JSON 地震消息，动作为 {action}"
                 )
                 # 适配新 API 中的 cancelled (取消报) 动作
@@ -87,10 +86,12 @@ class GlobalQuakeParser(BaseParser):
                     return self._parse_earthquake_removal_json(data)
                 return self._parse_earthquake_data(data)
 
-            logger.debug(f"[灾害预警] {self.source_id} 已忽略类型为 {msg_type} 的消息")
+            plugin_logger.debug(
+                f"[灾害预警] {self.source_id} 已忽略类型为 {msg_type} 的消息"
+            )
             return None
         except json.JSONDecodeError as exc:
-            logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
             return None
 
     def _build_removal_envelope(
@@ -171,10 +172,13 @@ class GlobalQuakeParser(BaseParser):
                 event_id, raw_payload, source_entry, "protobuf"
             )
 
-            logger.info(f"[灾害预警] Global Quake 收到地震取消广播: ID={event_id}")
+            plugin_logger.info(
+                f"[灾害预警] Global Quake 收到地震取消广播: ID={event_id}",
+                is_event_linked=True,
+            )
             return envelope
         except Exception as exc:
-            logger.error(
+            plugin_logger.error(
                 f"[灾害预警] {self.source_id} 解析 Protobuf 取消消息失败: {exc}"
             )
             return None
@@ -194,12 +198,15 @@ class GlobalQuakeParser(BaseParser):
                 event_id, dict(data), source_entry, "earthquake"
             )
 
-            logger.info(
-                f"[灾害预警] Global Quake 收到地震取消广播 (JSON): ID={event_id}"
+            plugin_logger.info(
+                f"[灾害预警] Global Quake 收到地震取消广播 (JSON): ID={event_id}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析 JSON 取消消息失败: {exc}")
+            plugin_logger.error(
+                f"[灾害预警] {self.source_id} 解析 JSON 取消消息失败: {exc}"
+            )
             return None
 
     def _parse_earthquake_protobuf(self, ws_msg: WsMessage) -> EventEnvelope | None:
@@ -336,15 +343,16 @@ class GlobalQuakeParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
+            plugin_logger.info(
                 f"[灾害预警] Global Quake地震解析成功: {domain_event.place_name} "
                 f"(M {domain_event.magnitude or 0.0:.1f}), 烈度: {eq_data.intensity}, "
-                f"时间: {domain_event.occurred_at}"
+                f"时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(
+            plugin_logger.error(
                 f"[灾害预警] {self.source_id} 解析 Protobuf 地震数据失败: {exc}"
             )
             return None
@@ -354,7 +362,7 @@ class GlobalQuakeParser(BaseParser):
         try:
             eq_data = self._extract_data(data)
             if not eq_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # JSON 格式同样兼容两种时间表达，优先用更明确的字符串时间
@@ -465,20 +473,21 @@ class GlobalQuakeParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
+            plugin_logger.info(
                 f"[灾害预警] Global Quake地震解析成功: {domain_event.place_name} "
                 f"(M {domain_event.magnitude or 0.0:.1f}), 烈度: {intensity_str}, "
-                f"时间: {domain_event.occurred_at}"
+                f"时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析地震数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析地震数据失败: {exc}")
             return None
 
     def _parse_text_message(self, message: str) -> EventEnvelope | None:
         """保留文本消息兼容处理。"""
-        logger.debug(f"[灾害预警] {self.source_id} 文本消息: {message}")
+        plugin_logger.debug(f"[灾害预警] {self.source_id} 文本消息: {message}")
         return None
 
     def _parse_data(self, data: dict[str, Any]) -> EventEnvelope | None:
@@ -502,7 +511,7 @@ class UsgsEarthquakeParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 过滤空心跳包
@@ -523,7 +532,7 @@ class UsgsEarthquakeParser(BaseParser):
                 ):
                     missing_fields.append(field)
             if missing_fields:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 数据缺少部分字段: {missing_fields}，继续处理..."
                 )
 
@@ -549,7 +558,7 @@ class UsgsEarthquakeParser(BaseParser):
                 if not self._is_heartbeat_message(msg_data):
                     warning_msg = f"[灾害预警] {self.source_id} 缺少地震ID，跳过处理"
                     if self._should_log_warning("missing_usgs_id", warning_msg):
-                        logger.warning(warning_msg)
+                        plugin_logger.warning(warning_msg)
                 return None
 
             if usgs_latitude == 0 and usgs_longitude == 0:
@@ -563,7 +572,7 @@ class UsgsEarthquakeParser(BaseParser):
                     if self._should_log_warning(
                         "missing_usgs_place_magnitude", warning_msg
                     ):
-                        logger.warning(warning_msg)
+                        plugin_logger.warning(warning_msg)
                 return None
 
             # 翻译全球震中地点英文名称为中文
@@ -637,11 +646,12 @@ class UsgsEarthquakeParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude or 0.0}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude or 0.0}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/japan_earthquake_parser.py
+++ b/core/parsers/japan_earthquake_parser.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from astrbot.api import logger
-
 from ...utils.converters import ScaleConverter, safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -33,16 +32,20 @@ class JmaEarthquakeP2PParser(BaseParser):
 
             # P2P 中 551 表示日本地震情报，其余业务码直接忽略。
             if code == 551:
-                logger.debug(f"[灾害预警] {self.source_id} 收到地震情报(code:551)")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 收到地震情报(code:551)"
+                )
                 return self._parse_earthquake_data(data)
 
-            logger.debug(f"[灾害预警] {self.source_id} 非地震情报数据，code: {code}")
+            plugin_logger.debug(
+                f"[灾害预警] {self.source_id} 非地震情报数据，code: {code}"
+            )
             return None
         except json.JSONDecodeError as exc:
-            logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
             return None
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
             return None
 
     def _parse_earthquake_data(self, data: dict[str, Any]) -> EventEnvelope | None:
@@ -66,7 +69,7 @@ class JmaEarthquakeP2PParser(BaseParser):
 
             # 仅在非震度速报场景下把震级视为硬性字段，兼容日本震度速报消息
             if magnitude is None and issue_type != "ScalePrompt":
-                logger.error(
+                plugin_logger.error(
                     f"[灾害预警] {self.source_id} 震级解析失败: {magnitude_raw}"
                 )
                 return None
@@ -79,7 +82,7 @@ class JmaEarthquakeP2PParser(BaseParser):
                 lon = None
 
             if (lat is None or lon is None) and issue_type != "ScalePrompt":
-                logger.error(
+                plugin_logger.error(
                     f"[灾害预警] {self.source_id} 经纬度解析失败: lat={latitude}, lon={longitude}"
                 )
                 return None
@@ -197,13 +200,14 @@ class JmaEarthquakeP2PParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析地震情报失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析地震情报失败: {exc}")
             return None
 
 
@@ -219,7 +223,9 @@ class JmaEarthquakeWolfxParser(BaseParser):
         try:
             # Wolfx 中只对日本地震列表消息做处理，其余类型直接跳过
             if data.get("type") != "jma_eqlist":
-                logger.debug(f"[灾害预警] {self.source_id} 非 JMA 地震列表数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 JMA 地震列表数据，跳过"
+                )
                 return None
 
             eq_info = None
@@ -344,11 +350,12 @@ class JmaEarthquakeWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/japan_eew_parser.py
+++ b/core/parsers/japan_eew_parser.py
@@ -9,9 +9,8 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ...utils.converters import ScaleConverter, safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -109,17 +108,22 @@ class JmaEewFanStudioParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 预计震度与情报类型至少应命中其一，否则通常不是正式预警消息
             if "epiIntensity" not in msg_data and "infoTypeName" not in msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过"
+                )
                 return None
 
             # 取消报在当前推送链中不作为正式地震事件继续向后处理
             if msg_data.get("cancel", False):
-                logger.info(f"[灾害预警] {self.source_id} 收到取消报，跳过")
+                plugin_logger.info(
+                    f"[灾害预警] {self.source_id} 收到取消报，跳过",
+                    is_event_linked=True,
+                )
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -139,12 +143,13 @@ class JmaEewFanStudioParser(BaseParser):
                 }
             )
 
-            logger.info(
-                f"[灾害预警] JMA地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] JMA地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None
 
 
@@ -162,21 +167,25 @@ class JmaEewP2PParser(BaseParser):
 
             # P2P 用业务码区分不同类型，其中 556 才是正式紧急地震速报
             if code == 556:
-                logger.debug(f"[灾害预警] {self.source_id} 收到紧急地震速报（警报）")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 收到紧急地震速报（警报）"
+                )
                 return self._parse_eew_data(data)
             if code == 554:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 收到紧急地震速报发布检测消息，忽略"
                 )
                 return None
 
-            logger.debug(f"[灾害预警] {self.source_id} 非地震预警数据，code: {code}")
+            plugin_logger.debug(
+                f"[灾害预警] {self.source_id} 非地震预警数据，code: {code}"
+            )
             return None
         except json.JSONDecodeError as exc:
-            logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
             return None
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
             return None
 
     def _parse_eew_data(self, data: dict[str, Any]) -> EventEnvelope | None:
@@ -214,7 +223,7 @@ class JmaEewP2PParser(BaseParser):
 
                 max_scale_raw = max(raw_scales) if raw_scales else -1
                 if max_scale_raw > 0:
-                    logger.warning(
+                    plugin_logger.warning(
                         f"[灾害预警] {self.source_id} 使用areas计算maxScale: {max_scale_raw}"
                     )
 
@@ -231,7 +240,7 @@ class JmaEewP2PParser(BaseParser):
             elif "originTime" in earthquake_info:
                 shock_time = self._parse_datetime(earthquake_info.get("originTime", ""))
             else:
-                logger.warning(f"[灾害预警] {self.source_id} 缺少地震时间信息")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 缺少地震时间信息")
 
             # 校验关键字段完整度
             required_hypocenter_fields = ["latitude", "longitude", "name"]
@@ -241,18 +250,24 @@ class JmaEewP2PParser(BaseParser):
                     missing_fields.append(field)
 
             if missing_fields:
-                logger.warning(
+                plugin_logger.warning(
                     f"[灾害预警] {self.source_id} 缺少震源必填字段: {missing_fields}，继续处理..."
                 )
 
             # 取消报、测试报与假定震源判定
             is_cancelled = data.get("cancelled", False)
             if is_cancelled:
-                logger.info(f"[灾害预警] {self.source_id} 收到取消的EEW事件")
+                plugin_logger.info(
+                    f"[灾害预警] {self.source_id} 收到取消的EEW事件",
+                    is_event_linked=True,
+                )
 
             is_test = data.get("test", False)
             if is_test:
-                logger.info(f"[灾害预警] {self.source_id} 收到测试模式的EEW事件")
+                plugin_logger.info(
+                    f"[灾害预警] {self.source_id} 收到测试模式的EEW事件",
+                    is_event_linked=True,
+                )
 
             is_plum = earthquake_info.get("condition") == "仮定震源要素"
             if not is_plum:
@@ -368,13 +383,14 @@ class JmaEewP2PParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析EEW数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析EEW数据失败: {exc}")
             return None
 
 
@@ -390,7 +406,9 @@ class JmaEewWolfxParser(BaseParser):
         try:
             # Wolfx 会混发多类日本消息，这里只接收日本地震预警类型
             if data.get("type") != "jma_eew":
-                logger.debug(f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过"
+                )
                 return None
 
             report_num = (
@@ -486,11 +504,12 @@ class JmaEewWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/taiwan_earthquake_parser.py
+++ b/core/parsers/taiwan_earthquake_parser.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from astrbot.api import logger
-
 from ...utils.converters import safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -95,12 +94,14 @@ class CwaReportParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 台湾地震报告类消息至少应具备发震时间与报告图片地址，否则通常不是来自 CWA 的地震报告
             if "shockTime" not in msg_data or "imageURI" not in msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 非 CWA 地震报告数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 CWA 地震报告数据，跳过"
+                )
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -113,10 +114,11 @@ class CwaReportParser(BaseParser):
             )
 
             domain_event = envelope.event
-            logger.info(
-                f"[灾害预警] CWA 地震报告解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] CWA 地震报告解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/taiwan_eew_parser.py
+++ b/core/parsers/taiwan_eew_parser.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ...utils.converters import ScaleConverter, safe_float_convert
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EarthquakeEvent, EventEnvelope
 from ..domain.event_payload import SourcePayload
@@ -45,7 +44,7 @@ class CwaEewParser(BaseParser):
             place_key = str(place_name or "").strip()
             # 拼合规则：发震时间_经度（三位精度）_纬度（三位精度）_地点
             event_id = f"cwa_fan_{shock_key}_{(latitude or 0.0):.3f}_{(longitude or 0.0):.3f}_{place_key}"
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] {self.source_id} 缺少 eventId，已使用稳定回退ID: {event_id}"
             )
 
@@ -129,12 +128,12 @@ class CwaEewParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.warning(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 报次或事件标识至少应命中其一，否则通常不是正式台湾地震预警消息
             if "updates" not in msg_data and "eventId" not in msg_data:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 非CWA地震预警数据(缺少updates/eventId)，跳过"
                 )
                 return None
@@ -142,12 +141,13 @@ class CwaEewParser(BaseParser):
             envelope = self._build_envelope(msg_data)
             domain_event = envelope.event
 
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None
 
 
@@ -163,7 +163,9 @@ class CwaEewWolfxParser(BaseParser):
         try:
             # Wolfx 中只接收台湾地震预警类型，其余类型直接忽略。
             if data.get("type") != "cwa_eew":
-                logger.debug(f"[灾害预警] {self.source_id} 非 CWA 地震预警数据，跳过")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 非 CWA 地震预警数据，跳过"
+                )
                 return None
 
             raw_origin_time = data.get("OriginTime", "")
@@ -210,7 +212,7 @@ class CwaEewWolfxParser(BaseParser):
                 event_id = (
                     f"cwa_wolfx_{shock_key}_{latitude:.3f}_{longitude:.3f}_{place_key}"
                 )
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 缺少 EventID，已使用稳定回退ID: {event_id}"
                 )
 
@@ -297,11 +299,12 @@ class CwaEewWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析数据失败: {exc}")
             return None

--- a/core/parsers/tsunami_parser.py
+++ b/core/parsers/tsunami_parser.py
@@ -9,8 +9,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EventEnvelope, TsunamiEvent
 from ..domain.event_payload import SourcePayload
@@ -71,7 +70,7 @@ class TsunamiParser(BaseParser):
         if not title:
             warning_msg = f"[灾害预警] {self.source_id} 海啸消息缺少标题，跳过处理"
             if self._should_log_warning("missing_tsunami_title", warning_msg):
-                logger.debug(warning_msg)
+                plugin_logger.debug(warning_msg)
             return None
 
         # 收集预报地区列表、海啸波位水位监测站及分布图附件
@@ -98,7 +97,7 @@ class TsunamiParser(BaseParser):
                 if stable_parts
                 else "tsunami_unknown"
             )
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] {self.source_id} 海啸消息缺少稳定id，已使用回退事件ID: {event_id}"
             )
 
@@ -205,7 +204,7 @@ class TsunamiParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             if self._is_heartbeat_message(msg_data):
@@ -225,12 +224,13 @@ class TsunamiParser(BaseParser):
             if envelope is None:
                 return None
 
-            logger.info(
-                f"[灾害预警] 海啸预警解析成功: {getattr(envelope.event, 'title', '')} ({getattr(envelope.event, 'level', '')}), 发布时间: {getattr(envelope.event, 'issued_at', None)}"
+            plugin_logger.info(
+                f"[灾害预警] 海啸预警解析成功: {getattr(envelope.event, 'title', '')} ({getattr(envelope.event, 'level', '')}), 发布时间: {getattr(envelope.event, 'issued_at', None)}",
+                is_event_linked=True,
             )
             return envelope
         except Exception as exc:
-            logger.error(
+            plugin_logger.error(
                 f"[灾害预警] {self.source_id} 解析海啸预警数据失败: {exc}, 数据内容: {data}"
             )
             return None
@@ -251,16 +251,18 @@ class JmaTsunamiP2PParser(BaseParser):
 
             # P2P 中 552 业务码专指日本津波予報（海啸警报），其余直接跳过
             if code == 552:
-                logger.debug(f"[灾害预警] {self.source_id} 收到津波予報(code:552)")
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 收到津波予報(code:552)"
+                )
                 return self._parse_tsunami_data(data)
 
-            logger.debug(f"[灾害预警] {self.source_id} 非海啸数据，code: {code}")
+            plugin_logger.debug(f"[灾害预警] {self.source_id} 非海啸数据，code: {code}")
             return None
         except json.JSONDecodeError as exc:
-            logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
             return None
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
             return None
 
     def _parse_tsunami_data(self, data: dict[str, Any]) -> EventEnvelope | None:
@@ -367,11 +369,12 @@ class JmaTsunamiP2PParser(BaseParser):
                 metadata=metadata,
             )
 
-            logger.info(
-                f"[灾害预警] JMA海啸预报解析成功: {domain_event.title}, 时间: {domain_event.issued_at}"
+            plugin_logger.info(
+                f"[灾害预警] JMA海啸预报解析成功: {domain_event.title}, 时间: {domain_event.issued_at}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(f"[灾害预警] {self.source_id} 解析海啸数据失败: {exc}")
+            plugin_logger.error(f"[灾害预警] {self.source_id} 解析海啸数据失败: {exc}")
             return None

--- a/core/parsers/weather_parser.py
+++ b/core/parsers/weather_parser.py
@@ -9,8 +9,7 @@ from collections import deque
 from datetime import datetime
 from typing import Any
 
-from astrbot.api import logger
-
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EventEnvelope, WeatherEvent
 from ..domain.event_payload import SourcePayload
@@ -33,7 +32,7 @@ class WeatherAlarmParser(BaseParser):
             # 提取数据负载中的实际业务字段
             msg_data = self._extract_data(data)
             if not msg_data:
-                logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
+                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 过滤心跳包
@@ -41,10 +40,12 @@ class WeatherAlarmParser(BaseParser):
                 return None
 
             # 内存中判定当前事件ID是否已被处理过，避免同一预警短时多次派发
+            # 这里也属于去重阶段的日志，如果提示检测到重复，应由 plugin_logger 输出
             weather_id = msg_data.get("id")
             if weather_id and weather_id in self._processed_weather_ids:
-                logger.info(
-                    f"[灾害预警] {self.source_id} 检测到重复的气象预警ID: {weather_id}，忽略"
+                plugin_logger.info(
+                    f"[灾害预警] {self.source_id} 检测到重复的气象预警ID: {weather_id}，忽略",
+                    is_event_linked=True,
                 )
                 return None
 
@@ -56,7 +57,7 @@ class WeatherAlarmParser(BaseParser):
                 if field not in msg_data or msg_data[field] is None
             ]
             if missing_fields:
-                logger.debug(
+                plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 气象预警数据缺少关键字段: {missing_fields}"
                 )
 
@@ -92,7 +93,7 @@ class WeatherAlarmParser(BaseParser):
                 if not self._is_heartbeat_message(msg_data):
                     warning_msg = f"[灾害预警] {self.source_id} 气象预警缺少标题、名称和描述信息，跳过处理"
                     if self._should_log_warning("missing_weather_fields", warning_msg):
-                        logger.debug(warning_msg)
+                        plugin_logger.debug(warning_msg)
                 return None
 
             source_entry = get_source_entry(self.source_id)
@@ -175,13 +176,14 @@ class WeatherAlarmParser(BaseParser):
             if envelope.id:
                 self._processed_weather_ids.append(envelope.id)
 
-            logger.info(
-                f"[灾害预警] 气象预警解析成功: {domain_event.title or domain_event.headline}, 生效时间: {issue_time}"
+            plugin_logger.info(
+                f"[灾害预警] 气象预警解析成功: {domain_event.title or domain_event.headline}, 生效时间: {issue_time}",
+                is_event_linked=True,
             )
 
             return envelope
         except Exception as exc:
-            logger.error(
+            plugin_logger.error(
                 f"[灾害预警] {self.source_id} 解析气象预警数据失败: {exc}, 数据内容: {data}"
             )
             return None

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from astrbot.api import logger
-
+from ....utils.plugin_logger import plugin_logger
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...sources.source_catalog import get_source_entry
 from .event_identity import EventIdentityService
@@ -99,7 +98,9 @@ class EventDeduplicationService:
         event_fingerprint = self.generate_event_fingerprint(event, domain_eq, source_id)
         current_time = self._to_utc(domain_eq.occurred_at, source_id)
 
-        logger.debug(f"[灾害预警] 检查事件: {source_id}, 指纹: {event_fingerprint}")
+        plugin_logger.debug(
+            f"[灾害预警] 检查事件: {source_id}, 指纹: {event_fingerprint}"
+        )
 
         # 指纹命中说明近期已有相近事件，需要进一步区分是重复还是合法更新。
         if event_fingerprint in self.recent_events:
@@ -123,7 +124,9 @@ class EventDeduplicationService:
                         source_id,
                         metadata=metadata,
                     ):
-                        logger.debug(f"[灾害预警] 允许同一数据源更新: {source_id}")
+                        plugin_logger.debug(
+                            f"[灾害预警] 允许同一数据源更新: {source_id}"
+                        )
                         current_report = self._resolve_report_num(event, metadata)
                         # 将当前的报数加入历史已处理的报数集合中，规避重复推送
                         existing_event["processed_reports"].add(current_report)
@@ -132,11 +135,16 @@ class EventDeduplicationService:
                             metadata.get("is_final", False)
                         )
                         return True
-                    logger.info(f"[灾害预警] 同一数据源重复事件，过滤: {source_id}")
+                    plugin_logger.info(
+                        f"[灾害预警] 同一数据源重复事件，过滤: {source_id}",
+                        is_event_linked=True,
+                    )
                     return False
 
             # 同一指纹但来自不同数据源的事件允许继续入链，便于后续融合策略处理。
-            logger.info(f"[灾害预警] 不同数据源，允许推送: {source_id}")
+            plugin_logger.info(
+                f"[灾害预警] 不同数据源，允许推送: {source_id}", is_event_linked=True
+            )
             current_report = self._resolve_report_num(event, metadata)
             issue_type = self._extract_issue_type_from_earthquake(domain_eq, metadata)
             self.recent_events[event_fingerprint][source_id] = {
@@ -171,7 +179,7 @@ class EventDeduplicationService:
                 "is_final": bool(metadata.get("is_final", False)),
             }
         }
-        logger.debug(f"[灾害预警] 事件通过基础去重检查: {source_id}")
+        plugin_logger.debug(f"[灾害预警] 事件通过基础去重检查: {source_id}")
         return True
 
     def generate_event_fingerprint(
@@ -233,16 +241,19 @@ class EventDeduplicationService:
         # 新报数到达允许放行更新，例如第 1 报 -> 第 2 报
         if current_report not in processed_reports:
             current_is_final = bool(active_metadata.get("is_final", False))
-            logger.info(
+            plugin_logger.info(
                 f"[灾害预警] 新报数: 第 {current_report} 报 {'(最终报)' if current_is_final else ''}"
-                f" (已处理: {sorted(processed_reports)})"
+                f" (已处理: {sorted(processed_reports)})",
+                is_event_linked=True,
             )
             return True
 
         # 若是最终报，且历史已推送记录中未判定为最终报，则放行更新
         current_is_final = bool(active_metadata.get("is_final", False))
         if current_is_final and not existing_event.get("is_final", False):
-            logger.info("[灾害预警] 最终报更新: 非最终报 -> 最终报")
+            plugin_logger.info(
+                "[灾害预警] 最终报更新: 非最终报 -> 最终报", is_event_linked=True
+            )
             return True
 
         current_info_type = str(
@@ -253,7 +264,9 @@ class EventDeduplicationService:
         if source_id == "usgs_fanstudio":
             existing_info_type = (existing_event.get("info_type", "") or "").lower()
             if existing_info_type == "automatic" and current_info_type == "reviewed":
-                logger.debug("[灾害预警] 允许USGS状态升级: automatic -> reviewed")
+                plugin_logger.debug(
+                    "[灾害预警] 允许USGS状态升级: automatic -> reviewed"
+                )
                 return True
 
         jma_types = ["ScalePrompt", "Destination", "ScaleAndDestination", "DetailScale"]
@@ -267,7 +280,7 @@ class EventDeduplicationService:
                 prev_idx = jma_types.index(existing_issue_type)
                 # 情报优先级提升时（例如震度速报 -> 地震报告），允许放行更新
                 if curr_idx > prev_idx:
-                    logger.debug(
+                    plugin_logger.debug(
                         f"[灾害预警] 允许JMA情报升级: {existing_issue_type} -> {current_issue_type}"
                     )
                     return True
@@ -277,12 +290,12 @@ class EventDeduplicationService:
         existing_info_type = (existing_event.get("info_type", "") or "").lower()
         # 允许由“自动测定”状态跃升为“正式测定”状态的更新推送
         if "自动" in existing_info_type and "正式" in current_info_type:
-            logger.debug(
+            plugin_logger.debug(
                 f"[灾害预警] 允许状态升级: {existing_info_type} -> {current_info_type}"
             )
             return True
 
-        logger.debug(f"[灾害预警] 报数 {current_report} 已处理过，跳过")
+        plugin_logger.debug(f"[灾害预警] 报数 {current_report} 已处理过，跳过")
         return False
 
     def cleanup_old_events(self):

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from .plugin.commands.plugin_admin_command_service import PluginAdminCommandServ
 from .plugin.commands.plugin_query_command_service import PluginQueryCommandService
 from .plugin.plugin_command_support_service import PluginCommandSupportService
 from .plugin.plugin_lifecycle_service import PluginLifecycleService
+from .utils.plugin_logger import plugin_logger
 
 
 class DisasterWarningPlugin(Star):
@@ -40,6 +41,8 @@ class DisasterWarningPlugin(Star):
         """初始化插件"""
         try:
             logger.info("[灾害预警] 正在初始化灾害预警插件...")
+
+            plugin_logger.set_config(self.config)
 
             # 初始化期先处理配置与管理员同步，再装配 disaster_service / telemetry / web_admin。
             self._lifecycle_service.sync_admin_users_from_global()

--- a/resources/card_templates/Aurora/global_quake.html
+++ b/resources/card_templates/Aurora/global_quake.html
@@ -310,7 +310,7 @@
                     <div class="time-label">{{ time_str }}</div>
                 </div>
                 <div>
-                    {% if is_final %}<div class="status-pill" style="background: #fef2f2; color: #dc2626; border: 1px solid #fecaca; box-shadow: 0 4px 12px rgba(220, 38, 38, 0.08); font-weight: 800; font-size: 13px; padding: 6px 18px; border-radius: 100px; text-transform: uppercase; letter-spacing: 0.5px;">Final Report</div>
+                    {% if is_final %}<div class="status-pill pill-update">Update {{ revision }} (Final Report)</div>
                     {% elif is_update %}<div class="status-pill pill-update">Update {{ revision }}</div>
                     {% else %}<div class="status-pill pill-new">New Event</div>{% endif %}
                 </div>

--- a/resources/card_templates/DarkNight/global_quake.html
+++ b/resources/card_templates/DarkNight/global_quake.html
@@ -255,7 +255,7 @@
                 <div style="flex: 1;">
                     <span class="region-text">{{ region }}</span>
                     {% if is_final %}
-                    <span class="action-tag" style="background-color: rgba(239, 68, 68, 0.15); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3);">FINAL REPORT</span>
+                    <span class="action-tag tag-update">UPDATE (Rev.{{ revision }} / FINAL REPORT)</span>
                     {% elif is_update %}
                     <span class="action-tag tag-update">UPDATE (Rev.{{ revision }})</span>
                     {% else %}

--- a/utils/plugin_logger.py
+++ b/utils/plugin_logger.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+from astrbot.api import logger
+
+
+class PluginLogger:
+    """插件日志代理，用于控制事件流相关日志的分级、降级和屏蔽。"""
+
+    def __init__(self) -> None:
+        self._config: dict[str, Any] | None = None
+
+    def set_config(self, config: dict[str, Any]) -> None:
+        """注入最新的插件配置。"""
+        self._config = config
+
+    def _should_suppress_or_downgrade(self, is_event_linked: bool) -> tuple[bool, str]:
+        """
+        判断是否需要对当前日志进行处理。
+        返回 (是否拦截/降级, 具体行为: "debug" | "mute" | "none")
+        """
+        if not is_event_linked or not self._config:
+            return False, "none"
+
+        # 无论在 config 直属还是在 debug_config 下，均尝试兼容获取
+        debug_config = (
+            self._config.get("debug_config", {})
+            if isinstance(self._config, dict)
+            else {}
+        )
+        if not isinstance(debug_config, dict):
+            debug_config = {}
+
+        log_mode = debug_config.get("log_mode", self._config.get("log_mode", "全量"))
+        if log_mode != "简洁":
+            return False, "none"
+
+        # 简洁模式下，获取降级行为
+        behavior = debug_config.get(
+            "log_downgrade_behavior",
+            self._config.get("log_downgrade_behavior", "降级为DEBUG"),
+        )
+        if behavior == "完全屏蔽":
+            return True, "mute"
+        return True, "debug"
+
+    def info(
+        self, msg: str, *args: Any, is_event_linked: bool = False, **kwargs: Any
+    ) -> None:
+        """记录 INFO 级别日志。"""
+        should_process, action = self._should_suppress_or_downgrade(is_event_linked)
+        if should_process:
+            if action == "debug":
+                logger.debug(msg, *args, **kwargs)
+            # action == "mute" 则直接屏蔽，什么都不做
+        else:
+            logger.info(msg, *args, **kwargs)
+
+    def warning(
+        self, msg: str, *args: Any, is_event_linked: bool = False, **kwargs: Any
+    ) -> None:
+        """记录 WARNING 级别日志。"""
+        should_process, action = self._should_suppress_or_downgrade(is_event_linked)
+        if should_process:
+            if action == "debug":
+                logger.debug(msg, *args, **kwargs)
+        else:
+            logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        """记录 ERROR 级别日志。错误日志由于其关键性，不受简洁模式限制。"""
+        logger.error(msg, *args, **kwargs)
+
+    def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        """记录 DEBUG 级别日志。"""
+        logger.debug(msg, *args, **kwargs)
+
+
+# 全局单例对象
+plugin_logger = PluginLogger()

--- a/utils/plugin_logger.py
+++ b/utils/plugin_logger.py
@@ -21,13 +21,12 @@ class PluginLogger:
         if not is_event_linked or not self._config:
             return False, "none"
 
-        # 无论在 config 直属还是在 debug_config 下，均尝试兼容获取
-        debug_config = (
-            self._config.get("debug_config", {})
-            if isinstance(self._config, dict)
-            else {}
-        )
-        if not isinstance(debug_config, dict):
+        # 使用 hasattr 安全判断以兼容 AstrBotConfig 的 get 访问方法
+        if not hasattr(self._config, "get"):
+            return False, "none"
+
+        debug_config = self._config.get("debug_config", {})
+        if not hasattr(debug_config, "get"):
             debug_config = {}
 
         log_mode = debug_config.get("log_mode", self._config.get("log_mode", "全量"))


### PR DESCRIPTION
## 📝 描述 / Description

feat #107 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

通过可配置的插件级日志记录器统一灾害预警插件的日志，并优化 Global Quake 卡片状态徽标，以更准确地体现更新和最终报告信息。

新功能：
- 引入插件级日志记录器，可根据插件配置有选择地屏蔽或降级与事件相关的日志。

增强：
- 将所有灾害预警插件日志统一通过新的插件日志记录器输出，并将关键的事件流程日志标记为可链入，以便更精细地控制日志详尽程度。
- 调整 Global Quake 卡片模板，在 Aurora 和 DarkNight 主题中以更清晰的方式展示更新/最终报告状态以及修订信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize disaster warning plugin logging through a configurable plugin logger and refine Global Quake card status badges to better reflect update and final report information.

New Features:
- Introduce a plugin-level logger that supports configurable suppression or downgrading of event-related logs based on plugin configuration.

Enhancements:
- Route all disaster warning plugin logs through the new plugin logger and mark key event-flow logs as linkable for finer control of verbosity.
- Adjust Global Quake card templates to display clearer update/final report status with revision information in Aurora and DarkNight themes.

</details>