### PR TITLE
feat: 会话备注名展示

### DIFF
--- a/admin/js/components/config/ConfigModeToolbar.jsx
+++ b/admin/js/components/config/ConfigModeToolbar.jsx
@@ -51,11 +51,15 @@ function ConfigModeToolbar({
                             onChange={(e) => setSelectedSession(e.target.value)} 
                             className="config-mode-toolbar__session-field"
                         >
-                            {sessions.map((item) => (
-                                <MenuItem key={item.session} value={item.session}>
-                                    {item.session}
-                                </MenuItem>
-                            ))}
+                            {sessions.map((item) => {
+                                const name = item.session_name;
+                                const label = name ? `${item.session} (${name})` : item.session;
+                                return (
+                                    <MenuItem key={item.session} value={item.session}>
+                                        {label}
+                                    </MenuItem>
+                                );
+                            })}
                         </TextField>
 
                         {/* 如果该会话已经保存了覆盖项，显式用高亮 Chip 提醒 */}
@@ -76,7 +80,7 @@ function ConfigModeToolbar({
             {/* 次行：仅在会话差异化配置模式且已选中会话时渲染，展示当前会话详细覆写状态说明 */}
             {mode === 'session' && selectedSessionMeta && (
                 <Typography variant="caption" color="text.secondary" className="config-mode-toolbar__meta">
-                    当前会话：{selectedSessionMeta.session} ｜ push_enabled：{selectedSessionMeta.push_enabled ? '开启' : '关闭'} ｜ override字段：{(selectedSessionMeta.override_keys || []).join(', ') || '无'}
+                    当前会话：{selectedSessionMeta.session_name ? `${selectedSessionMeta.session} (${selectedSessionMeta.session_name})` : selectedSessionMeta.session} ｜ push_enabled：{selectedSessionMeta.push_enabled ? '开启' : '关闭'} ｜ override字段：{(selectedSessionMeta.override_keys || []).join(', ') || '无'}
                 </Typography>
             )}
         </Box>

--- a/admin/js/components/config/ConfigRenderer.jsx
+++ b/admin/js/components/config/ConfigRenderer.jsx
@@ -114,6 +114,9 @@ function ConfigRenderer() {
         return 0;
     });
 
+    // 会话模式下的备注名当前值
+    const sessionNameValue = (mode === 'session' && config) ? (config.session_name || '') : '';
+
     return (
         <Box className="config-renderer-shell">
             {/* 顶栏：全局配置与特定会话筛选切换条 */}
@@ -130,6 +133,25 @@ function ConfigRenderer() {
             {/* 中间：带有滚动持久化的可拖拽表单滚动区域 */}
             <Box ref={scrollContainerRef} className="config-renderer-scroll-area">
                 <Box className="config-renderer-field-list">
+                    {/* 会话差异配置模式：置顶渲染备注名输入框 */}
+                    {mode === 'session' && (
+                        <Box className="config-renderer-field-item config-renderer-field-item--session-name">
+                            <ConfigField
+                                fieldKey="session_name"
+                                schema={{
+                                    type: 'string',
+                                    description: '🏷️ 会话备注名',
+                                    hint: '用于日志和管理端展示。为空时将回退显示原始 UMO。',
+                                    default: '',
+                                }}
+                                value={sessionNameValue}
+                                onChange={(newValue) => setConfig((prev) => ({ ...prev, session_name: newValue }))}
+                                path=""
+                                expandedKeys={expandedKeys}
+                                onToggleExpand={handleToggleExpand}
+                            />
+                        </Box>
+                    )}
                     {visibleSchemaEntries.map(([key, subSchema]) => (
                         <Box key={key} className="config-renderer-field-item">
                             <ConfigField

--- a/admin/js/components/status/SimulationModal.jsx
+++ b/admin/js/components/status/SimulationModal.jsx
@@ -7,7 +7,7 @@ const { useState, useEffect } = React;
  * 可用于实时校准群组卡片消息推送、防灾模版排版测试。
  * 
  * 核心流程与功能：
- * 1. 模拟参数拉取：启动后从服务端 `/api/simulation/params` 获取支持的模拟格式、预选数据源模版与默认经纬度值。
+ * 1. 模拟参数拉取：启动后从服务端 /api/simulation/params 获取支持的模拟格式、预选数据源模版与默认经纬度值。
  * 2. 目标会话限制：允许定向群组测试或全网默认群组分流测试。
  * 3. 智能关联联动：切换测试格式（数据源模版）时，自动同步重设下方“数据源” key，并拉取该格式下的地理极值 defaults。
  * 4. 原生 IP 定位：提供 GPS 定位辅助功能，调取宿主 geoIP 服务，一键解析定位并填充经纬度与位置文本，无需手动输入。
@@ -195,7 +195,32 @@ function SimulationModal({ open, onClose }) {
 
     const getTargetSessionOptions = () => {
         if (!params || !params.target_sessions) return [];
+        // 兼容字符串数组和对象数组两种格式
         return params.target_sessions;
+    };
+
+    /**
+     * 获取会话的展示名称（UMO + 备注名括号，无备注名时仅显示UMO）
+     */
+    const getSessionDisplayName = (session) => {
+        if (typeof session === 'string') return session;
+        if (session && typeof session === 'object') {
+            const umo = session.session || String(session);
+            const name = session.session_name;
+            return name ? `${umo} (${name})` : umo;
+        }
+        return String(session);
+    };
+
+    /**
+     * 获取会话的原始UMO值（用于提交请求）
+     */
+    const getSessionValue = (session) => {
+        if (typeof session === 'string') return session;
+        if (session && typeof session === 'object') {
+            return session.session || String(session);
+        }
+        return String(session);
     };
 
     return (
@@ -217,8 +242,8 @@ function SimulationModal({ open, onClose }) {
                                 <em>默认 (第一个配置的会话)</em>
                             </MenuItem>
                             {getTargetSessionOptions().map((session, index) => (
-                                <MenuItem key={index} value={session}>
-                                    {session}
+                                <MenuItem key={index} value={getSessionValue(session)}>
+                                    {getSessionDisplayName(session)}
                                 </MenuItem>
                             ))}
                         </Select>

--- a/admin/js/components/status/SimulationModal.jsx
+++ b/admin/js/components/status/SimulationModal.jsx
@@ -200,19 +200,6 @@ function SimulationModal({ open, onClose }) {
     };
 
     /**
-     * 获取会话的展示名称（UMO + 备注名括号，无备注名时仅显示UMO）
-     */
-    const getSessionDisplayName = (session) => {
-        if (typeof session === 'string') return session;
-        if (session && typeof session === 'object') {
-            const umo = session.session || String(session);
-            const name = session.session_name;
-            return name ? `${umo} (${name})` : umo;
-        }
-        return String(session);
-    };
-
-    /**
      * 获取会话的原始UMO值（用于提交请求）
      */
     const getSessionValue = (session) => {
@@ -221,6 +208,18 @@ function SimulationModal({ open, onClose }) {
             return session.session || String(session);
         }
         return String(session);
+    };
+
+    /**
+     * 获取会话的展示名称（UMO + 备注名括号，无备注名时仅显示UMO）
+     */
+    const getSessionDisplayName = (session) => {
+        const umo = getSessionValue(session);
+        if (session && typeof session === 'object') {
+            const name = session.session_name;
+            return name ? `${umo} (${name})` : umo;
+        }
+        return umo;
     };
 
     return (

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -5,8 +5,8 @@
         'web_admin', 'notification_settings', 'websocket_config', 'debug_config', 'telemetry_config'
     ]);
     
-    // 定义会话覆写专属的局部参数 Key（如单群推送开关）
-    const CONFIG_SESSION_ONLY_KEYS = new Set(['push_enabled']);
+    // 定义会话覆写专属的局部参数 Key（如单群推送开关、会话备注名）
+    const CONFIG_SESSION_ONLY_KEYS = new Set(['push_enabled', 'session_name']);
 
     /**
      * 递归获取 Schema 下所有可折叠对象节点的分支路径列表

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -116,6 +116,8 @@ class DisasterWarningService:
         self.message_manager = MessagePushManager(
             config, context, telemetry=self._telemetry
         )
+        # 注入会话配置管理器引用，使推送链路可查询会话备注名等展示信息。
+        self.message_manager.set_session_config_manager(self.session_config_manager)
         # 用于离线通知节流，避免同一连接异常在短时间内反复刷屏。
         self._offline_notification_state: dict[str, dict[str, float]] = {}
 

--- a/core/message/message_manager.py
+++ b/core/message/message_manager.py
@@ -54,11 +54,28 @@ class MessagePushManager:
         # 远程媒体抓取会话由消息子系统统一复用，减少重复建连开销。
         self._remote_media_session = None
         self._remote_media_session_timeout_seconds = 30
+        # 会话配置管理器引用，由上层 DisasterService 注入，
+        # 供推送执行链与构建服务获取会话备注名等展示信息。
+        self.session_config_manager = None
 
         # 装配顺序遵循“运行时基础设施 -> 消息构建能力 -> 推送执行链”。
         self._setup_runtime_infrastructure(config, telemetry)
         self._setup_message_infrastructure()
         self._setup_push_pipeline()
+
+    def set_session_config_manager(self, mgr) -> None:
+        """注入会话配置管理器引用，供下游服务查询备注名等展示信息。"""
+        self.session_config_manager = mgr
+
+    def _get_session_log_str(self, session: str) -> str:
+        """获取统一格式的会话日志字符串（私聊/群聊 ID (备注名)）。
+
+        当会话配置管理器不可用时回退到原始 UMO。
+        """
+        mgr = self.session_config_manager
+        if mgr:
+            return mgr.get_session_log_str(session)
+        return session
 
     def _setup_runtime_infrastructure(
         self,

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -287,11 +287,12 @@ class MessageBuildService:
             map_message = MessageChain([Comp.Image.fromBase64(b64_data)])
             # 循环向各个订阅了地图分离的会话推送地图图片消息
             for session in target_sessions:
+                session_log = self.manager._get_session_log_str(session)
                 try:
                     await self.manager.session_sender.send(session, map_message)
-                    logger.debug(f"[灾害预警] 分离地图已发送到 {session}")
+                    logger.debug(f"[灾害预警] 分离地图已发送到 {session_log}")
                 except Exception as e:
-                    logger.error(f"[灾害预警] 分离地图发送到 {session} 失败: {e}")
+                    logger.error(f"[灾害预警] 分离地图发送到 {session_log} 失败: {e}")
         except Exception as e:
             logger.error(f"[灾害预警] 异步地图渲染任务失败: {e}")
 

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -200,6 +200,8 @@ class PushExecutionService:
             session: str,
             runtime_config: dict[str, Any],
         ) -> tuple[bool, str, dict[str, Any] | None, str | None]:
+            # 获取统一格式的会话日志字符串（私聊/群聊 ID (备注名)）
+            session_log = self.manager._get_session_log_str(session)
             try:
                 # 预筛通过后，在真正发送前再次复核；真实推送提交报数状态，
                 # 模拟推送只复用筛选与渲染链路，不污染运行时规则状态。
@@ -213,22 +215,22 @@ class PushExecutionService:
                 if not decision.accepted:
                     if decision.detail:
                         logger.debug(
-                            f"[灾害预警] 事件 {event.id} 在会话 {session} 发送前复核未通过，原因：{decision.reason}（{decision.detail}）"
+                            f"[灾害预警] 事件 {event.id} 在 {session_log} 发送前复核未通过，原因：{decision.reason}（{decision.detail}）"
                         )
                     else:
                         logger.debug(
-                            f"[灾害预警] 事件 {event.id} 在会话 {session} 发送前复核未通过，原因：{decision.reason}"
+                            f"[灾害预警] 事件 {event.id} 在 {session_log} 发送前复核未通过，原因：{decision.reason}"
                         )
                     return False, session, None, "发送前复核未通过"
 
                 logger.debug(
-                    f"[灾害预警] 事件 {event.id} 通过会话 {session} 的发送前复核，准备发送消息"
+                    f"[灾害预警] 事件 {event.id} 通过 {session_log} 的发送前复核，准备发送消息"
                 )
                 # 获取复用或动态渲染的图片/卡片消息链
                 message = await get_or_build_message(runtime_config)
                 # 调用底座 Session 发送器下发消息
                 await self.manager.session_sender.send(session, message)
-                logger.debug(f"[灾害预警] 事件 {event.id} 已推送到 {session}")
+                logger.debug(f"[灾害预警] 事件 {event.id} 已推送到 {session_log}")
                 return True, session, runtime_config.get("message_format", {}), None
             except Exception as e:
                 error_name = type(e).__name__
@@ -257,13 +259,13 @@ class PushExecutionService:
 
                 if is_timeout:
                     logger.warning(
-                        f"[灾害预警] 推送到会话 {session} 时疑似超时，但实际推送成功却返回失败，为防止重复，跳过降级重发: {e}"
+                        f"[灾害预警] 推送到 {session_log} 时疑似超时，但实际推送成功却返回失败，为防止重复，跳过降级重发: {e}"
                     )
                     # 遇到超时时，为了避免被外层统计为彻底失败，可认为其成功送达了，或者至少不能再降级重发。
                     # 这里返回 True，认为该会话已处理完毕，不再次投递。
                     return True, session, runtime_config.get("message_format", {}), None
 
-                logger.error(f"[灾害预警] 推送到 {session} 失败: {e}")
+                logger.error(f"[灾害预警] 推送到 {session_log} 失败: {e}")
 
                 # 如果富媒体发送失败，则尝试从原消息链中提取纯文本进行降级重发。
                 fallback_message = self._build_plaintext_fallback_message(
@@ -275,7 +277,7 @@ class PushExecutionService:
                             session, fallback_message
                         )
                         logger.warning(
-                            f"[灾害预警] 会话 {session} 富媒体发送失败，已自动降级重发: {error_name}"
+                            f"[灾害预警] {session_log} 富媒体发送失败，已自动降级重发: {error_name}"
                         )
                         return (
                             True,
@@ -286,7 +288,7 @@ class PushExecutionService:
                     except Exception as fallback_error:
                         fallback_error_name = type(fallback_error).__name__
                         logger.error(
-                            f"[灾害预警] 会话 {session} 纯文本降级重发失败: {fallback_error}"
+                            f"[灾害预警] {session_log} 纯文本降级重发失败: {fallback_error}"
                         )
                         return (
                             False,
@@ -296,7 +298,7 @@ class PushExecutionService:
                         )
 
                 logger.warning(
-                    f"[灾害预警] 会话 {session} 富媒体发送失败，且消息中无可用纯文本可降级: {error_name}"
+                    f"[灾害预警] {session_log} 富媒体发送失败，且消息中无可用纯文本可降级: {error_name}"
                 )
                 return False, session, None, f"富媒体发送失败({error_name})"
 
@@ -377,7 +379,8 @@ class PushExecutionService:
                 if simulation_bypass:
                     runtime_config["push_enabled"] = True
                 else:
-                    logger.debug(f"[灾害预警] 会话 {session} 推送开关关闭，跳过")
+                    session_log = self.manager._get_session_log_str(session)
+                    logger.debug(f"[灾害预警] {session_log} 推送开关关闭，跳过")
                     continue
 
             # 过滤判定评估
@@ -396,13 +399,14 @@ class PushExecutionService:
                 filter_reason_detail_stats[detail_key] = (
                     filter_reason_detail_stats.get(detail_key, 0) + 1
                 )
+                session_log = self.manager._get_session_log_str(session)
                 if reason_detail:
                     logger.debug(
-                        f"[灾害预警] 事件 {event.id} 在会话 {session} 的预筛选阶段被拦截，原因：{reason}（{reason_detail}）"
+                        f"[灾害预警] 事件 {event.id} 在 {session_log} 的预筛选阶段被拦截，原因：{reason}（{reason_detail}）"
                     )
                 else:
                     logger.debug(
-                        f"[灾害预警] 事件 {event.id} 在会话 {session} 的预筛选阶段被拦截，原因：{reason}"
+                        f"[灾害预警] 事件 {event.id} 在 {session_log} 的预筛选阶段被拦截，原因：{reason}"
                     )
                 continue
 

--- a/core/message/system/system_notification_service.py
+++ b/core/message/system/system_notification_service.py
@@ -41,11 +41,12 @@ class MessageSystemNotificationService:
         success_count = 0
         # 遍历目标会话并同步下发纯文本提示
         for session in sessions:
+            session_log = self.manager._get_session_log_str(session)
             try:
                 await self.manager.session_sender.send(session, msg_chain)  # 发送消息
                 success_count += 1
             except Exception as e:
-                logger.error(f"[灾害预警] 系统提示消息发送到 {session} 失败: {e}")
+                logger.error(f"[灾害预警] 系统提示消息发送到 {session_log} 失败: {e}")
 
         if success_count > 0:
             logger.info(f"[灾害预警] 系统提示消息已发送到 {success_count} 个会话")

--- a/core/network/admin/api/runtime_routes.py
+++ b/core/network/admin/api/runtime_routes.py
@@ -78,7 +78,9 @@ def register_runtime_routes(app, disaster_service, config: dict[str, Any]):
     async def get_simulation_params_api():
         """获取模拟预警可用参数选项。"""
         try:
-            return ApiResponse.success(get_simulation_params(config))
+            # 传入会话配置管理器，使 target_sessions 携带备注名信息
+            mgr = getattr(disaster_service, "session_config_manager", None)
+            return ApiResponse.success(get_simulation_params(config, mgr))
         except Exception as e:
             logger.error(f"[灾害预警] 获取模拟参数失败: {e}")
             return ApiResponse.error(str(e), status_code=500)
@@ -151,11 +153,14 @@ def register_runtime_routes(app, disaster_service, config: dict[str, Any]):
                     bypass_fusion=True,
                 )
                 if push_success:
+                    target_log_str = session_config_manager.get_session_log_str(
+                        final_target_session
+                    )
                     logger.info(
-                        f"[灾害预警] ✅ 模拟事件已成功推送到 {final_target_session}"
+                        f"[灾害预警] ✅ 模拟事件已成功推送到 {target_log_str}"
                     )
                     simulation_result.report_lines.append(
-                        f"\n✅ 消息已发送到: {final_target_session}"
+                        f"\n✅ 消息已发送到: {target_log_str}"
                     )
                 else:
                     simulation_result.report_lines.append(

--- a/core/network/admin/api/runtime_routes.py
+++ b/core/network/admin/api/runtime_routes.py
@@ -156,9 +156,7 @@ def register_runtime_routes(app, disaster_service, config: dict[str, Any]):
                     target_log_str = session_config_manager.get_session_log_str(
                         final_target_session
                     )
-                    logger.info(
-                        f"[灾害预警] ✅ 模拟事件已成功推送到 {target_log_str}"
-                    )
+                    logger.info(f"[灾害预警] ✅ 模拟事件已成功推送到 {target_log_str}")
                     simulation_result.report_lines.append(
                         f"\n✅ 消息已发送到: {target_log_str}"
                     )

--- a/core/network/admin/api/session_config_routes.py
+++ b/core/network/admin/api/session_config_routes.py
@@ -38,6 +38,8 @@ def register_session_config_routes(app, *, disaster_service):
                 data.append(
                     {
                         "session": session,
+                        "session_name": mgr.get_session_name(session),
+                        "session_display_name": mgr.get_session_display_name(session),
                         "has_override": bool(override),
                         "override_keys": list(override.keys()),
                         "push_enabled": effective.get("push_enabled", True),

--- a/core/services/simulation/simulation_service.py
+++ b/core/services/simulation/simulation_service.py
@@ -64,13 +64,30 @@ def _next_sim_event_sequence() -> int:
         return _sim_event_sequence
 
 
-def get_simulation_params(config: dict[str, Any]) -> dict[str, Any]:
+def get_simulation_params(
+    config: dict[str, Any],
+    session_config_manager=None,
+) -> dict[str, Any]:
     """获取模拟预警可用参数。
 
     由服务层集中维护，供管理端接口直接读取，避免前端硬编码可选来源列表。
+    当传入 session_config_manager 时，target_sessions 将返回带备注名的对象列表。
     """
     raw_target_sessions = config.get("target_sessions", [])
-    target_sessions = [str(item) for item in raw_target_sessions]
+    if session_config_manager is not None:
+        # 返回带备注名的对象列表，前端可优先展示备注名
+        target_sessions = [
+            {
+                "session": str(item),
+                "session_name": session_config_manager.get_session_name(str(item)),
+                "session_display_name": session_config_manager.get_session_display_name(
+                    str(item)
+                ),
+            }
+            for item in raw_target_sessions
+        ]
+    else:
+        target_sessions = [str(item) for item in raw_target_sessions]
 
     defaults = SimulationParamsDefaults()
 

--- a/core/services/simulation/simulation_service.py
+++ b/core/services/simulation/simulation_service.py
@@ -73,7 +73,7 @@ def get_simulation_params(
     由服务层集中维护，供管理端接口直接读取，避免前端硬编码可选来源列表。
     当传入 session_config_manager 时，target_sessions 将返回带备注名的对象列表。
     """
-    raw_target_sessions = config.get("target_sessions", [])
+    raw_target_sessions = config.get("target_sessions") or []
     if session_config_manager is not None:
         # 返回带备注名的对象列表，前端可优先展示备注名
         target_sessions = [

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -44,6 +44,8 @@ class SessionConfigManager:
         "debug_config",
         # 会话级额外控制字段（插件自定义）
         "push_enabled",
+        # 会话备注名（仅用于日志与前端展示，不参与业务逻辑）
+        "session_name",
     }
 
     def __init__(self, default_config_ref: dict[str, Any]):
@@ -269,6 +271,102 @@ class SessionConfigManager:
         sessions = set(self.list_target_sessions())
         sessions.update(self._overrides.keys())
         return sorted(sessions)
+
+    @staticmethod
+    def _parse_session_id(session_id: str) -> tuple[str, str, str] | None:
+        """解析会话 UMO，返回 (platform, message_type, target_id)。
+
+        仅用于日志展示与备注名格式化，不对 UMO 做任何修正或重写。
+        """
+        if not isinstance(session_id, str):
+            return None
+
+        known_types = [
+            "FriendMessage",
+            "GroupMessage",
+            "PrivateMessage",
+            "GuildMessage",
+        ]
+
+        for msg_type in known_types:
+            search_pattern = f":{msg_type}:"
+            idx = session_id.find(search_pattern)
+            if idx != -1:
+                platform = session_id[:idx]
+                after_type = session_id[idx + len(search_pattern) :]
+                return platform, msg_type, after_type
+
+        parts = session_id.split(":")
+        if len(parts) == 3:
+            return parts[0], parts[1], parts[2]
+
+        if len(parts) > 3:
+            return ":".join(parts[:-2]), parts[-2], parts[-1]
+
+        return None
+
+    def get_session_name(self, umo: str) -> str:
+        """获取会话备注名（用于日志与前端展示）。
+
+        解析优先级：
+        1. 会话覆写记录中的 session_name 字段
+        2. 生效配置中的 session_name 字段
+        若均不存在则返回空字符串。
+        """
+        if not isinstance(umo, str) or not umo:
+            return ""
+
+        # 1. 优先从 override 中读取
+        override = self._overrides.get(umo, {})
+        if isinstance(override, dict):
+            raw = override.get("session_name")
+            if raw is not None:
+                text = str(raw).strip()
+                if text:
+                    return text
+
+        # 2. 再尝试从生效配置中读取
+        try:
+            effective = self.get_effective_config(umo)
+            if isinstance(effective, dict):
+                raw = effective.get("session_name")
+                if raw is not None:
+                    text = str(raw).strip()
+                    if text:
+                        return text
+        except Exception:
+            pass
+
+        return ""
+
+    def get_session_display_name(self, umo: str) -> str:
+        """获取会话展示名：备注名优先，缺失时回退原始 UMO。"""
+        name = self.get_session_name(umo)
+        return name if name else umo
+
+    def get_session_log_str(self, umo: str) -> str:
+        """获取统一格式的会话日志字符串。
+
+        格式：私聊/群聊 ID (备注名)
+        若无备注名则仅显示 类型 ID。
+        """
+        parsed = self._parse_session_id(umo)
+        session_name = self.get_session_name(umo)
+
+        if not parsed:
+            return f"{umo} ({session_name})" if session_name else umo
+
+        _, msg_type, target_id = parsed
+        type_str = "未知类型"
+        if "Friend" in msg_type or "Private" in msg_type:
+            type_str = "私聊"
+        elif "Group" in msg_type or "Guild" in msg_type:
+            type_str = "群聊"
+
+        log_str = f"{type_str} {target_id}"
+        if session_name:
+            log_str += f" ({session_name})"
+        return log_str
 
     def get_override(self, umo: str) -> dict[str, Any]:
         """获取指定会话的差异补丁副本。"""

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -334,8 +334,8 @@ class SessionConfigManager:
                     text = str(raw).strip()
                     if text:
                         return text
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"[灾害预警] 读取会话 {umo} 的生效配置失败: {e}")
 
         return ""
 

--- a/plugin/commands/plugin_admin_command_service.py
+++ b/plugin/commands/plugin_admin_command_service.py
@@ -23,6 +23,23 @@ class PluginAdminCommandService(CommandTelemetryMixin):
     def __init__(self, plugin):
         self.plugin = plugin
 
+    def _get_session_config_manager(self):
+        """安全获取会话配置管理器实例，不可用时返回 None。"""
+        service = getattr(self.plugin, "disaster_service", None)
+        if service and hasattr(service, "session_config_manager"):
+            return service.session_config_manager
+        return None
+
+    def _get_session_log_str(self, session_umo: str) -> str:
+        """获取统一格式的会话日志字符串（私聊/群聊 ID (备注名)）。
+
+        当会话配置管理器不可用时回退到原始 UMO。
+        """
+        mgr = self._get_session_config_manager()
+        if mgr:
+            return mgr.get_session_log_str(session_umo)
+        return session_umo
+
     async def handle_disaster_reconnect(self, event):
         """处理强制重连命令，尝试对所有离线或异常的数据源触发重连尝试。"""
         # 管理类命令统一在入口先做管理员校验，避免内部逻辑重复散落权限判断。
@@ -460,6 +477,9 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 yield event.plain_result("❌ 无法获取当前会话的 UMO")
                 return
 
+            # 统一使用 私聊/群聊 ID (备注名) 格式展示
+            session_log_str = self._get_session_log_str(session_umo)
+
             target_sessions = self.plugin.config.get("target_sessions", [])
             if target_sessions is None:
                 target_sessions = []
@@ -473,9 +493,9 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                     {"enabled": False, "target_session_count": len(target_sessions)},
                 )
                 yield event.plain_result(
-                    f"✅ 推送已关闭\n\n会话 ({session_umo}) 已从推送列表中移除。"
+                    f"✅ 推送已关闭\n\n{session_log_str} 已从推送列表中移除。"
                 )
-                logger.info(f"[灾害预警] 会话 {session_umo} 已关闭推送")
+                logger.info(f"[灾害预警] {session_log_str} 已关闭推送")
             else:
                 target_sessions.append(session_umo)
                 self.plugin.config["target_sessions"] = target_sessions
@@ -485,9 +505,9 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                     {"enabled": True, "target_session_count": len(target_sessions)},
                 )
                 yield event.plain_result(
-                    f"✅ 推送已开启\n\n会话 ({session_umo}) 已添加到推送列表。"
+                    f"✅ 推送已开启\n\n{session_log_str} 已添加到推送列表。"
                 )
-                logger.info(f"[灾害预警] 会话 {session_umo} 已开启推送")
+                logger.info(f"[灾害预警] {session_log_str} 已开启推送")
         except Exception as e:
             logger.error(f"[灾害预警] 切换推送状态失败: {e}")
             yield event.plain_result(f"❌ 切换推送状态失败: {str(e)}")
@@ -545,6 +565,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
             mgr = self.plugin.disaster_service.session_config_manager
             override = mgr.get_override(session_umo)
             effective = mgr.get_effective_config(session_umo)
+            session_log_str = mgr.get_session_log_str(session_umo)
             translated_override = (
                 self.plugin._command_support_service.translate_config_recursive(
                     override, schema
@@ -561,7 +582,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 translated_effective, indent=2, ensure_ascii=False
             )
             yield event.plain_result(
-                f"🔧 会话配置详情 ({session_umo})\n"
+                f"🔧 会话配置详情 ({session_log_str})\n"
                 f"\n📌 差异覆写 (override)：\n{override_str}"
                 f"\n\n📘 合并后配置 (effective)：\n{effective_str}"
             )


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

引入会话备注名称，并将其在后端服务和管理后台 UI 中进行传播，以便对目标会话进行一致的展示和日志记录。

New Features:
- 添加对每个会话备注名称字段的支持，用于日志和管理前端展示，不影响业务逻辑。
- 在仿真和 session-config API 中暴露会话备注元数据，使管理工具能够显示更易理解的会话标签。
- 在会话配置编辑器中提供可配置的会话备注输入，以管理每个会话的展示名称。

Enhancements:
- 使用共享辅助函数，在推送、系统通知、管理命令和仿真流程中统一会话日志字符串格式。
- 更新管理配置和仿真 UI，在可用的情况下将会话显示为 UMO 加备注名称，以便更清晰地进行目标定位。
- 扩展消息管理器以持有一个会话配置管理器引用，使下游服务能够访问备注和展示名称。
- 优化模式工具，将 `session_name` 与 `push_enabled` 一样视为仅针对会话的覆盖键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce session remark names and propagate them through backend services and admin UI for consistent display and logging of target sessions.

New Features:
- Add support for a per-session remark name field used for logs and admin frontend display without affecting business logic.
- Expose session remark metadata in simulation and session-config APIs so admin tools can show human-friendly session labels.
- Provide configurable session remark input in the session config editor to manage per-session display names.

Enhancements:
- Standardize session log string formatting across push, system notification, admin commands, and simulation flows using a shared helper.
- Update admin configuration and simulation UIs to show sessions as UMO plus remark name when available for clearer targeting.
- Extend message manager to hold a session config manager reference so downstream services can access remark and display names.
- Refine schema utilities to treat session_name as a session-only override key alongside push_enabled.

</details>