### PR TITLE
feat: 新增 JMA 区域震度的”町丁目→地域“映射功能

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -574,6 +574,12 @@
         "hint": "开启后，日本气象厅地震情报将显示所有观测到震度1及以上的区域，而不仅是最大震度区域",
         "default": false
       },
+      "jma_region_intensity": {
+        "description": "JMA震度按地域汇总",
+        "type": "bool",
+        "hint": "开启后，日本气象厅地震情报的各地震度详情将按「地域/地方」的级别汇总展示，而非逐个町丁目列出。",
+        "default": true
+      },
       "use_global_quake_card": {
         "description": "启用 Global Quake 卡片消息",
         "type": "bool",

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -37,6 +37,7 @@ from ..parsers.parser_registry import (
 )
 from ..services.config.config_service import ConfigAccessor
 from ..services.config.connection_plan_builder import ConnectionPlanBuilder
+from ..services.geo.jma_seis_int_loc_loader import get_sect_map
 from ..services.geo.region_service import region_service
 from ..services.notification import NotificationCenter
 from ..services.query.earthquake_list_service import EarthquakeListService
@@ -260,6 +261,8 @@ class DisasterWarningService:
             validate_catalog_parser_names()
             self._check_registry_integrity()
             await region_service.load_data_async()  # 加载地理省份数据文件
+            # 预加载 JMA 町丁目->地域映射表，避免首条地震情报时延迟加载
+            get_sect_map()
             self.http_fetcher = HTTPDataFetcher(self.config)  # 初始化 HTTP 轮询拉取组件
             self._register_handlers()
             self._configure_connections()

--- a/core/message/builders/text_message_builder.py
+++ b/core/message/builders/text_message_builder.py
@@ -35,10 +35,13 @@ class TextMessageBuilder:
         display_timezone = active_config.get("display_timezone", "UTC+8")
         # 日本震度详情是否展开由消息格式配置单独控制。
         detailed_jma = config.get("detailed_jma_intensity", False)
+        # 日本震度是否按地域汇总展示，默认开启。
+        jma_region = config.get("jma_region_intensity", True)
 
         options = {
             "timezone": display_timezone,
             "detailed_jma_intensity": detailed_jma,
+            "jma_region_intensity": jma_region,
             "local_monitoring": active_config.get("local_monitoring", {}),
         }
 

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -753,15 +753,18 @@ class JmaEarthquakeInfoPresenter(BasePresenter):
                     sect_map = get_sect_map()
                     if sect_map:
                         # 每个 sect 的最大震度
+                        # scale_key 来自 jma_points 原始数据，可能是 int（P2P）
+                        # 或 str（Wolfx），避免异质类型比较使用 in 检查
                         sect_max_scale: dict[str, object] = {}
                         for scale_key, addrs in scale_groups.items():
                             for addr in addrs:
                                 sect = sect_map.get(addr)
                                 if not sect:
                                     continue
-                                prev = sect_max_scale.get(sect, 0)
-                                # 震度值可能是 int 或其他可比较类型
-                                if scale_key > prev:
+                                if (
+                                    sect not in sect_max_scale
+                                    or scale_key > sect_max_scale[sect]
+                                ):
                                     sect_max_scale[sect] = scale_key
 
                         if sect_max_scale:

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -14,6 +14,7 @@ from ....utils.converters import ScaleConverter
 from ....utils.time_converter import TimeConverter
 from ...domain.event_context import EarthquakeDisplayContext
 from ...services.geo.intensity_service import IntensityCalculator
+from ...services.geo.jma_seis_int_loc_loader import get_sect_map
 from .base_presenter import BasePresenter
 
 
@@ -745,37 +746,59 @@ class JmaEarthquakeInfoPresenter(BasePresenter):
                 scale_groups.setdefault(scale, []).append(addr)
 
             if scale_groups:
-                if merged_options.get("detailed_jma_intensity", False):
-                    # 详细模式下按震度从高到低逐级展开展示。
-                    sorted_scales = sorted(scale_groups.keys(), reverse=True)
-                    lines.append("📡各地震度详情：")
-                    for scale_key in sorted_scales:
-                        scale_disp = ScaleConverter.format_jma_cwa_scale_display(
-                            scale_key
+                if merged_options.get("jma_region_intensity", True):
+                    # 地域汇总模式：将町丁目按 sect 聚合，
+                    # 每个 sect 的震度取其内所有町丁目的最大震度，
+                    # 然后按震度从高到低分组展示地域列表，不做截断。
+                    sect_map = get_sect_map()
+                    if sect_map:
+                        # 每个 sect 的最大震度
+                        sect_max_scale: dict[str, object] = {}
+                        for scale_key, addrs in scale_groups.items():
+                            for addr in addrs:
+                                sect = sect_map.get(addr)
+                                if not sect:
+                                    continue
+                                prev = sect_max_scale.get(sect, 0)
+                                # 震度值可能是 int 或其他可比较类型
+                                if scale_key > prev:
+                                    sect_max_scale[sect] = scale_key
+
+                        if sect_max_scale:
+                            # 按震度从高到低分组展示地域
+                            region_scale_groups: dict[object, list[str]] = {}
+                            for sect, s_scale in sect_max_scale.items():
+                                region_scale_groups.setdefault(s_scale, []).append(sect)
+
+                            sorted_scales = sorted(
+                                region_scale_groups.keys(), reverse=True
+                            )
+                            lines.append("📡各地震度详情：")
+                            for scale_key in sorted_scales:
+                                scale_disp = (
+                                    ScaleConverter.format_jma_cwa_scale_display(
+                                        scale_key
+                                    )
+                                )
+                                emoji = _get_intensity_emoji(
+                                    scale_key, is_eew=False, is_shindo=True
+                                )
+                                # 地域级不做截断，完整展示所有地域
+                                locs = sorted(region_scale_groups[scale_key])
+                                loc_str = "、".join(locs)
+                                lines.append(f"  {emoji}[震度{scale_disp}] {loc_str}")
+                        else:
+                            # sect 映射全部未命中时回退到町丁目模式
+                            cls._render_town_scale_groups(
+                                merged_options, scale_groups, lines
+                            )
+                    else:
+                        # 映射表加载失败时回退到町丁目模式
+                        cls._render_town_scale_groups(
+                            merged_options, scale_groups, lines
                         )
-                        emoji = _get_intensity_emoji(
-                            scale_key, is_eew=False, is_shindo=True
-                        )
-                        locs = scale_groups[scale_key]
-                        max_show = 20
-                        loc_str = "、".join(locs[:max_show])
-                        if len(locs) > max_show:
-                            loc_str += f" 等{len(locs)}处"
-                        lines.append(f"  {emoji}[震度{scale_disp}] {loc_str}")
                 else:
-                    # 简略模式仅展示最大震度对应的代表观测点，控制文本长度。
-                    max_scale_key = max(scale_groups.keys())
-                    scale_disp = ScaleConverter.format_jma_cwa_scale_display(
-                        max_scale_key
-                    )
-                    emoji = _get_intensity_emoji(
-                        max_scale_key, is_eew=False, is_shindo=True
-                    )
-                    locs = scale_groups[max_scale_key][:5]
-                    suffix = "等" if len(scale_groups[max_scale_key]) > 5 else ""
-                    lines.append(
-                        f"📡震度 {scale_disp} {emoji} 观测点：{'、'.join(locs)}{suffix}"
-                    )
+                    cls._render_town_scale_groups(merged_options, scale_groups, lines)
 
         jma_comment = display_context.jma_comment
         if (
@@ -786,6 +809,41 @@ class JmaEarthquakeInfoPresenter(BasePresenter):
             lines.append(f"📝备注：{jma_comment.strip()}")
 
         return "\n".join(lines)
+
+    @staticmethod
+    def _render_town_scale_groups(
+        merged_options: dict,
+        scale_groups: dict[object, list[str]],
+        lines: list[str],
+    ) -> None:
+        """按町丁目级震度分组渲染（原始模式，带截断）。
+
+        当 detailed_jma_intensity 开启时逐级展示所有震度的町丁目，
+        否则仅展示最大震度的代表观测点。町丁目列表会做截断处理以控制文本长度。
+        """
+        if merged_options.get("detailed_jma_intensity", False):
+            # 详细模式下按震度从高到低逐级展开展示。
+            sorted_scales = sorted(scale_groups.keys(), reverse=True)
+            lines.append("📡各地震度详情：")
+            for scale_key in sorted_scales:
+                scale_disp = ScaleConverter.format_jma_cwa_scale_display(scale_key)
+                emoji = _get_intensity_emoji(scale_key, is_eew=False, is_shindo=True)
+                locs = scale_groups[scale_key]
+                max_show = 20
+                loc_str = "、".join(locs[:max_show])
+                if len(locs) > max_show:
+                    loc_str += f" 等{len(locs)}处"
+                lines.append(f"  {emoji}[震度{scale_disp}] {loc_str}")
+        else:
+            # 简略模式仅展示最大震度对应的代表观测点，控制文本长度。
+            max_scale_key = max(scale_groups.keys())
+            scale_disp = ScaleConverter.format_jma_cwa_scale_display(max_scale_key)
+            emoji = _get_intensity_emoji(max_scale_key, is_eew=False, is_shindo=True)
+            locs = scale_groups[max_scale_key][:5]
+            suffix = "等" if len(scale_groups[max_scale_key]) > 5 else ""
+            lines.append(
+                f"📡震度 {scale_disp} {emoji} 观测点：{'、'.join(locs)}{suffix}"
+            )
 
 
 class GlobalQuakeTextPresenter(BasePresenter):

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -168,6 +168,9 @@ class PushExecutionService:
                         "detailed_jma_intensity": message_format_config.get(
                             "detailed_jma_intensity", False
                         ),
+                        "jma_region_intensity": message_format_config.get(
+                            "jma_region_intensity", True
+                        ),
                     },
                     "weather": {
                         "enable_weather_icon": weather_config.get(

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -127,7 +127,7 @@ class WebSocketManager:
                 )
                 self.connection_info[name].pop("offline_since", None)
                 self.connection_info[name].pop("short_retry_notified", None)
-                logger.info(f"[灾害预警] WebSocket连接成功: {name}")
+                logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
 
                 # 重置重连相关的状态变量
                 self.connection_retry_counts[name] = 0
@@ -154,7 +154,7 @@ class WebSocketManager:
 
         except asyncio.CancelledError:
             # 主动关闭或插件卸载引发的任务取消，不做额外处理，正常退出
-            logger.info(f"[灾害预警] WebSocket连接任务被取消: {name}")
+            logger.info(f"[灾害预警] WebSocket 连接任务被取消: {name}")
             self.connections.pop(name, None)
             self.connection_info.pop(name, None)
             raise
@@ -374,8 +374,8 @@ class HTTPDataFetcher:
                 if response.status == 200:
                     return await response.json()
                 else:
-                    logger.warning(f"[灾害预警] HTTP请求失败 {url}: {response.status}")
+                    logger.warning(f"[灾害预警] HTTP 请求失败 {url}: {response.status}")
         except Exception as e:
-            logger.error(f"[灾害预警] HTTP请求异常 {url}: {e}")
+            logger.error(f"[灾害预警] HTTP 请求异常 {url}: {e}")
 
         return None

--- a/core/network/websocket/websocket_runtime_service.py
+++ b/core/network/websocket/websocket_runtime_service.py
@@ -92,7 +92,7 @@ class WebSocketRuntimeService:
                 total=self.manager.config.get("http_timeout", 30)
             )
             self.manager.session = aiohttp.ClientSession(timeout=timeout)
-            logger.info("[灾害预警] WebSocket管理器已启动")
+            logger.info("[灾害预警] WebSocket 管理器已启动")
 
         if not self.manager.message_handlers:
             logger.warning("[灾害预警] 没有注册任何消息处理器")
@@ -102,11 +102,11 @@ class WebSocketRuntimeService:
         async with self.manager._stop_lock:
             # 引入防止重复停止的并发锁保护
             if self.manager._stopping:
-                logger.debug("[灾害预警] WebSocket管理器已在停止流程中，跳过重复调用")
+                logger.debug("[灾害预警] WebSocket 管理器已在停止流程中，跳过重复调用")
                 return
             self.manager._stopping = True
             try:
-                logger.info("[灾害预警] WebSocket管理器正在停止...")
+                logger.info("[灾害预警] WebSocket 管理器正在停止...")
                 self.manager.running = False
 
                 # 1. 优先关闭所有重连等待任务，防止在停止期间因为连接关闭而触发重连，陷入恶性循环
@@ -139,6 +139,6 @@ class WebSocketRuntimeService:
                 self.manager.fallback_retry_counts.clear()
                 self.manager.last_heartbeat_time.clear()
 
-                logger.info("[灾害预警] WebSocket管理器已停止")
+                logger.info("[灾害预警] WebSocket 管理器已停止")
             finally:
                 self.manager._stopping = False

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -319,6 +319,13 @@ class ConfigValidator:
             )
             cfg["host"] = "0.0.0.0"
 
+        # 密码校验：确保为字符串类型
+        if "password" in cfg and not isinstance(cfg["password"], str):
+            logger.warning(
+                "[灾害预警] 配置警告: Web 管理端密码类型错误，已重置为空字符串。"
+            )
+            cfg["password"] = ""
+
         # 布尔值校验
         ConfigValidator._ensure_bool(cfg, "enabled", False)
 
@@ -487,7 +494,7 @@ class ConfigValidator:
             if min_level and min_level not in valid_levels:
                 # 仅警告，不强制重置
                 logger.warning(
-                    f"[灾害预警] 配置警告: 气象预警级别 '{min_level}' 不在标准列表中。"
+                    f"[灾害预警] 配置警告: 气象预警级别 {min_level} 不在标准列表中。"
                 )
 
             ConfigValidator._ensure_bool(weather_filter, "enabled", False)
@@ -515,12 +522,12 @@ class ConfigValidator:
         if isinstance(max_size, (int, float)):
             if max_size < 1:
                 logger.warning(
-                    f"[灾害预警] 配置警告: 日志最大大小 {max_size}MB 过小，已修正为 1MB。"
+                    f"[灾害预警] 配置警告: 日志最大大小 {max_size} MB 过小，已修正为 1 MB。"
                 )
                 cfg["log_max_size_mb"] = 1
             elif max_size > 1024:
                 logger.warning(
-                    f"[灾害预警] 配置警告: 日志最大大小 {max_size}MB 过大，已修正为 1024MB。"
+                    f"[灾害预警] 配置警告: 日志最大大小 {max_size} MB 过大，已修正为 1024 MB。"
                 )
                 cfg["log_max_size_mb"] = 1024
 
@@ -572,6 +579,33 @@ class ConfigValidator:
                 cfg["filtered_message_types"] = [
                     str(x) for x in cfg["filtered_message_types"] if x
                 ]
+
+        # 日志模式校验
+        log_mode = cfg.get("log_mode")
+        valid_log_modes = ["全量", "简洁"]
+        if log_mode and log_mode not in valid_log_modes:
+            logger.warning(
+                f"[灾害预警] 配置警告: 日志模式 {log_mode} 不在标准列表中，已重置为 全量。"
+            )
+            cfg["log_mode"] = "全量"
+
+        # 简洁模式日志处理行为校验
+        downgrade_behavior = cfg.get("log_downgrade_behavior")
+        valid_behaviors = ["降级为DEBUG", "完全屏蔽"]
+        if downgrade_behavior and downgrade_behavior not in valid_behaviors:
+            logger.warning(
+                f"[灾害预警] 配置警告: 简洁模式日志处理行为 {downgrade_behavior} 不在标准列表中，已重置为 降级为DEBUG。"
+            )
+            cfg["log_downgrade_behavior"] = "降级为DEBUG"
+
+        # 原始消息日志路径校验
+        if "raw_message_log_path" in cfg and not isinstance(
+            cfg["raw_message_log_path"], str
+        ):
+            logger.warning(
+                "[灾害预警] 配置警告: 原始消息日志路径类型错误，已重置为 raw_messages.log。"
+            )
+            cfg["raw_message_log_path"] = "raw_messages.log"
 
         # 布尔值校验
         ConfigValidator._ensure_bool(cfg, "enable_raw_message_logging", False)
@@ -666,7 +700,7 @@ class ConfigValidator:
                 ):
                     # 仅警告，不强制重置，以支持未来扩展或自定义源
                     logger.warning(
-                        f"[灾害预警] 配置警告: 地图源 '{map_source}' 不在标准列表中，请确认是否为自定义源。"
+                        f"[灾害预警] 配置警告: 地图源 {map_source} 不在标准列表中，请确认是否为自定义源。"
                     )
 
         # Global Quake 模板校验
@@ -675,7 +709,7 @@ class ConfigValidator:
         if gq_template and gq_template not in valid_templates:
             # 仅警告，不强制重置
             logger.warning(
-                f"[灾害预警] 配置警告: GQ模板 '{gq_template}' 不在标准列表中，请确认是否为自定义模板。"
+                f"[灾害预警] 配置警告: GQ模板 {gq_template} 不在标准列表中，请确认是否为自定义模板。"
             )
 
         # Playwright 模式校验
@@ -683,7 +717,7 @@ class ConfigValidator:
         valid_modes = ["local", "remote"]
         if pw_mode and pw_mode not in valid_modes:
             logger.warning(
-                f"[灾害预警] 配置警告: Playwright 模式 '{pw_mode}' 无效，已重置为 local。"
+                f"[灾害预警] 配置警告: Playwright 模式 {pw_mode} 无效，已重置为 local。"
             )
             cfg["playwright_mode"] = "local"
 
@@ -715,6 +749,7 @@ class ConfigValidator:
         # 布尔值校验
         ConfigValidator._ensure_bool(cfg, "include_map", False)
         ConfigValidator._ensure_bool(cfg, "detailed_jma_intensity", False)
+        ConfigValidator._ensure_bool(cfg, "jma_region_intensity", True)
         ConfigValidator._ensure_bool(cfg, "use_global_quake_card", False)
 
         return cfg

--- a/core/services/geo/jma_seis_int_loc_loader.py
+++ b/core/services/geo/jma_seis_int_loc_loader.py
@@ -1,0 +1,131 @@
+"""
+JmaSeisIntLoc.js 加载器。
+
+负责解析 resources/JmaSeisIntLoc.js 文件，提取「町丁目 -> 地域(sect)」
+映射表，供地震展示器将町丁目级震度聚合为地域级震度使用。
+
+该模块采用惰性加载 + 模块级缓存策略，仅在首次调用时解析文件，
+后续直接返回缓存结果，避免重复 I/O 与正则开销。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from astrbot.api import logger
+
+# ---------------------------------------------------------------------------
+# 模块级缓存
+# ---------------------------------------------------------------------------
+
+_cached_sect_map: dict[str, str] | None = None
+_cache_lock = False  # 简单标志位，避免在加载过程中重复进入
+
+
+def _get_js_file_path() -> Path:
+    """获取 JmaSeisIntLoc.js 文件的绝对路径。"""
+    # 本文件位于 core/services/geo/，资源文件位于 resources/
+    # 向上回溯：geo -> services -> core -> 插件根目录
+    return Path(__file__).resolve().parents[3] / "resources" / "JmaSeisIntLoc.js"
+
+
+def _parse_js_sect_map(js_path: Path) -> dict[str, str]:
+    """从 JmaSeisIntLoc.js 提取 {町丁目名: sect} 映射。
+
+    JS 文件格式示例::
+
+        export const jmaSeisIntLoc = {
+          石狩市花川: {
+            location: [43.17, 141.32],
+            sect: "石狩地方北部",
+            arv: 1.44,
+          },
+          ...
+        };
+
+    由于 key 没有引号，无法直接 json.loads，因此使用正则逐条提取。
+    """
+    text = js_path.read_text(encoding="utf-8")
+
+    # 匹配模式：
+    #   町丁目名: {
+    #       location: [lat, lon],
+    #       sect: "地域名",
+    pattern = re.compile(
+        r"  (.+?):\s*\{\s*\n"
+        r"    location:\s*\[[\d.\-]+,\s*[\d.\-]+\],\s*\n"
+        r'    sect:\s*"(.+?)",',
+        re.MULTILINE,
+    )
+
+    sect_map: dict[str, str] = {}
+    for match in pattern.finditer(text):
+        addr = match.group(1).strip()
+        sect = match.group(2).strip()
+        sect_map[addr] = sect
+
+    return sect_map
+
+
+def get_sect_map() -> dict[str, str]:
+    """获取「町丁目 -> 地域」映射表（惰性加载 + 模块级缓存）。
+
+    Returns:
+        ``dict[str, str]``: key 为町丁目名（如 ``"御坊市薗"``），
+        value 为地域名（如 ``"和歌山県北部"``）。
+
+    若文件解析失败则返回空字典并记录错误日志，不影响主流程。
+    """
+    global _cached_sect_map, _cache_lock
+
+    if _cached_sect_map is not None:
+        return _cached_sect_map
+
+    if _cache_lock:
+        # 在加载过程中被再次调用时返回空字典兜底
+        return {}
+
+    _cache_lock = True
+    try:
+        js_path = _get_js_file_path()
+        if not js_path.exists():
+            logger.error(f"[灾害预警] JmaSeisIntLoc.js 文件不存在: {js_path}")
+            _cached_sect_map = {}
+            return _cached_sect_map
+
+        sect_map = _parse_js_sect_map(js_path)
+        _cached_sect_map = sect_map
+        logger.info(
+            f"[灾害预警] JmaSeisIntLoc.js 已加载，共 {len(sect_map)} 条町丁目->地域映射"
+        )
+        return _cached_sect_map
+    except Exception as exc:
+        logger.error(f"[灾害预警] 加载 JmaSeisIntLoc.js 失败: {exc}")
+        _cached_sect_map = {}
+        return _cached_sect_map
+    finally:
+        _cache_lock = False
+
+
+def lookup_sect(addr: str) -> str | None:
+    """查询单个町丁目对应的地域名。
+
+    Args:
+        addr: 町丁目名（如 ``"御坊市薗"``）。
+
+    Returns:
+        地域名字符串，未找到时返回 ``None``。
+    """
+    if not addr:
+        return None
+    return get_sect_map().get(addr)
+
+
+def clear_cache() -> None:
+    """清除模块级缓存，强制下次调用时重新加载文件。
+
+    主要用于测试场景或热更新资源文件后手动刷新。
+    """
+    global _cached_sect_map
+    _cached_sect_map = None

--- a/core/services/geo/jma_seis_int_loc_loader.py
+++ b/core/services/geo/jma_seis_int_loc_loader.py
@@ -20,7 +20,7 @@ from astrbot.api import logger
 # ---------------------------------------------------------------------------
 
 _cached_sect_map: dict[str, str] | None = None
-_cache_lock = False  # 简单标志位，避免在加载过程中重复进入
+_cache_loading = False  # 标志位，标记加载是否正在进行
 
 
 def _get_js_file_path() -> Path:
@@ -77,16 +77,17 @@ def get_sect_map() -> dict[str, str]:
 
     若文件解析失败则返回空字典并记录错误日志，不影响主流程。
     """
-    global _cached_sect_map, _cache_lock
+    global _cached_sect_map, _cache_loading
 
     if _cached_sect_map is not None:
         return _cached_sect_map
 
-    if _cache_lock:
-        # 在加载过程中被再次调用时返回空字典兜底
+    if _cache_loading:
+        # 加载过程中被再次调用时返回空字典兜底，
+        # 加载完成后后续调用会命中缓存
         return {}
 
-    _cache_lock = True
+    _cache_loading = True
     try:
         js_path = _get_js_file_path()
         if not js_path.exists():
@@ -105,7 +106,7 @@ def get_sect_map() -> dict[str, str]:
         _cached_sect_map = {}
         return _cached_sect_map
     finally:
-        _cache_lock = False
+        _cache_loading = False
 
 
 def lookup_sect(addr: str) -> str | None:

--- a/core/services/notification/notification_center.py
+++ b/core/services/notification/notification_center.py
@@ -208,7 +208,7 @@ class NotificationCenter:
 
         # 挂载后台长轮询定时协程任务
         self._poll_task = asyncio.create_task(_poll_loop())
-        logger.info("[灾害预警] 通知系统已启动。")
+        logger.info("[灾害预警] 通知系统已启动")
 
     async def stop(self) -> None:
         """停止通知中心。"""
@@ -223,4 +223,4 @@ class NotificationCenter:
             self._poll_task = None
         # 停止前将当前缓存内容原子落盘保存
         await self.save_cache()
-        logger.info("[灾害预警] 通知系统已停止。")
+        logger.info("[灾害预警] 通知系统已停止")


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

引入用于町级震感数据的 JMA 区域震度聚合，并加强若干配置与日志相关的校验。

New Features:
- 将 JMA 町级震度观测值聚合为区域（sect）震度用于消息渲染，并支持通过配置启用/禁用。
- 新增一个延迟加载的加载器，用于从 `JmaSeisIntLoc.js` 资源中加载 JMA 町到区域的映射，并在灾害服务初始化时预加载。

Bug Fixes:
- 确保非字符串的 Web 管理密码和原始消息日志路径被强制转换为安全的默认值，以避免类型问题。
- 校验并规范超出范围的日志大小值，以及无效的日志模式或降级行为，将其回退到安全的默认值。

Enhancements:
- 重构町级 JMA 震度渲染逻辑为可复用的辅助函数，并在缺少区域映射时提供回退行为。
- 扩展对 Web 管理、日志、天气、地图和模板配置的校验，包括对 JMA 区域震度和日志模式的新选项。
- 统一多处日志消息（包括 WebSocket 和通知系统日志），以提供更清晰的输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce JMA regional intensity aggregation for town-level shaking data and tighten several configuration and logging validations.

New Features:
- Aggregate JMA town-level intensity observations into regional (sect) intensities for message rendering, with configurable enablement.
- Add a lazy-loaded loader for JMA town-to-region mappings from the JmaSeisIntLoc.js resource and preload it during disaster service initialization.

Bug Fixes:
- Ensure non-string web admin passwords and raw message log paths are coerced to safe defaults to avoid type issues.
- Validate and normalize out-of-range log size values and invalid log modes or downgrade behaviors to safe defaults.

Enhancements:
- Refactor town-level JMA intensity rendering into a reusable helper with fallback behavior when regional mapping is unavailable.
- Extend configuration validation for web admin, logging, weather, map, and template settings, including new options for JMA regional intensity and log modes.
- Standardize multiple log messages, including WebSocket and notification system logs, for clearer output.

</details>