### PR TITLE
feat: 补齐 S-Net 入库与统计链路，修复会话差异配置不生效的问题，拆分EQSC开关与统计卡片布局样式增强

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -197,10 +197,16 @@
         "hint": "通过 EQSC API 获取灾害预警信息",
         "items": {
           "enabled": {
-            "description": "启用EQSC台风富化",
+            "description": "启用 EQSC 数据源",
             "type": "bool",
             "default": true,
-            "hint": "启用后，收到FAN Studio台风推送时将自动向EQSC拉取详细数据。未启用时台风仅使用FAN Studio基础数据展示。"
+            "hint": "控制 EQSC 通道是否启用（鉴权、连通性、后续子能力入口）。关闭后所有 EQSC 子能力均不可用。"
+          },
+          "typhoon_enrichment": {
+            "description": "启用台风富化",
+            "type": "bool",
+            "default": true,
+            "hint": "启用后，收到 FAN Studio 台风推送时将自动向 EQSC 拉取详细轨迹与风圈。未启用时台风仅使用 FAN Studio 基础数据展示。"
           },
           "base_url": {
             "description": "EQSC API 基础地址",

--- a/admin/css/base.css
+++ b/admin/css/base.css
@@ -24,6 +24,12 @@
     --md-sys-color-on-surface-variant: #49454F;
     --md-sys-color-surface-variant: #E7E0EC;
 
+    /* 错误色 (Error)：危险态、最大震级等暖色强调 */
+    --md-sys-color-error: #B3261E;
+    --md-sys-color-on-error: #FFFFFF;
+    --md-sys-color-error-container: #F9DEDC;
+    --md-sys-color-on-error-container: #410E0B;
+
     /* 背景色 (Background)：应用的主背景色 */
     --md-sys-color-background: #FEF7FF;
     --md-sys-color-outline-variant: rgba(103, 80, 164, 0.1);
@@ -97,6 +103,12 @@ body.dark-theme {
     --md-sys-color-on-surface-variant: #CAC4D0;
     --md-sys-color-surface-variant: #49454F;
 
+    /* 错误色 (Error) 深色变体 */
+    --md-sys-color-error: #F2B8B5;
+    --md-sys-color-on-error: #601410;
+    --md-sys-color-error-container: #8C1D18;
+    --md-sys-color-on-error-container: #F9DEDC;
+
     --md-sys-color-background: #141218;
     --md-sys-color-outline-variant: rgba(208, 188, 255, 0.1);
 
@@ -119,6 +131,11 @@ html.theme-dark body {
     --md-sys-color-on-surface: #E6E1E5;
     --md-sys-color-on-surface-variant: #CAC4D0;
     --md-sys-color-surface-variant: #49454F;
+
+    --md-sys-color-error: #F2B8B5;
+    --md-sys-color-on-error: #601410;
+    --md-sys-color-error-container: #8C1D18;
+    --md-sys-color-on-error-container: #F9DEDC;
 
     --md-sys-color-background: #141218;
     --md-sys-color-outline-variant: rgba(208, 188, 255, 0.1);
@@ -738,7 +755,6 @@ body.dark-theme .card {
  */
 .card.notification-feed-card,
 .card.notifications-hero-card,
-.card.max-mag-card,
 .card.trend-chart-card,
 .card.config-card,
 .card.markdown-docs-sidebar-card,

--- a/admin/css/views/stats.css
+++ b/admin/css/views/stats.css
@@ -656,6 +656,7 @@
     --card-shadow: 0 4px 20px 0 color-mix(in srgb, var(--md-sys-color-error) 10%, transparent);
     --card-hover-shadow: 0 12px 30px 0 color-mix(in srgb, var(--md-sys-color-error) 16%, transparent);
     --hover-lift: 4px;
+
     position: relative;
     overflow: visible;
     display: flex;
@@ -678,6 +679,7 @@
     --card-shadow: 0 4px 20px 0 color-mix(in srgb, var(--md-sys-color-primary) 10%, transparent);
     --card-hover-shadow: 0 12px 30px 0 color-mix(in srgb, var(--md-sys-color-primary) 16%, transparent);
     --hover-lift: 4px;
+
     position: relative;
     overflow: visible;
     display: flex;
@@ -827,7 +829,7 @@
     color: var(--md-sys-color-on-primary-container) !important;
 }
 
-/* Top3 单行列表*/
+/* Top3 单行列表 */
 .snet-max-card-list {
     display: flex;
     flex-direction: column;
@@ -928,6 +930,7 @@
     --card-shadow: var(--glass-shadow);
     --card-hover-shadow: 0 12px 30px 0 rgba(103, 80, 164, 0.12);
     --hover-lift: 4px;
+
     height: var(--stats-bottom-card-height, 200px);
     min-height: var(--stats-bottom-card-height, 200px);
     max-height: var(--stats-bottom-card-height, 200px);
@@ -1293,15 +1296,16 @@ html.theme-dark .snet-max-card {
         grid-template-columns: 1fr;
     }
 
+    /* 单列后允许高度随内容展开，避免第二张卡被固定 180px 裁切/覆盖 */
     .stats-peak-pair,
     .stats-note-slot,
     .max-mag-card,
     .snet-max-card,
     .stats-note-card {
         --stats-bottom-card-height: 180px;
-        height: var(--stats-bottom-card-height);
+        height: auto;
         min-height: var(--stats-bottom-card-height);
-        max-height: var(--stats-bottom-card-height);
+        max-height: none;
     }
 
     .max-mag-card-mag-value {

--- a/admin/css/views/stats.css
+++ b/admin/css/views/stats.css
@@ -18,6 +18,41 @@
     display: flex;
 }
 
+.stats-overview-main-stack {
+    width: 100%;
+    gap: 16px;
+    display: flex;
+    flex-direction: column;
+}
+
+/* 震级分布下方：历史最大地震 + S-Net 峰值并排 */
+.stats-peak-pair {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    width: 100%;
+    /* 与右侧说明卡片同高，避免说明卡被内容撑高 */
+    flex: 0 0 auto;
+    height: var(--stats-bottom-card-height, 200px);
+    min-height: var(--stats-bottom-card-height, 200px);
+}
+
+.stats-peak-pair-item {
+    min-width: 0;
+    display: flex;
+    height: 100%;
+    min-height: 0;
+}
+
+.stats-peak-pair-item > .card {
+    width: 100%;
+    height: 100%;
+}
+
+.stats-overview-note-wrap {
+    margin-top: 0;
+}
+
 /* 侧边机构、区域排行面板（居右） */
 .stats-overview-side {
     grid-column: span 4;
@@ -570,19 +605,83 @@
    6. 最大地震发生及频发天气预警级别展示区 (Max Earthquake & Weather Levels)
    ========================================================================== */
 
-.max-mag-card,
 .weather-level-card,
 .log-stats-card {
     height: 100%;
     min-height: 200px;
 }
 
-/* 本期最大地震卡片：采用特殊渐变警告红/橙色强调灾害烈度 */
+/* 底部三卡统一高度基准（最大地震 / S-Net / 说明） */
+:root {
+    --stats-bottom-card-height: 200px;
+}
+
+.max-mag-card,
+.snet-max-card,
+.stats-note-card {
+    height: var(--stats-bottom-card-height);
+    min-height: var(--stats-bottom-card-height);
+    max-height: var(--stats-bottom-card-height);
+    box-sizing: border-box;
+}
+
+/* 右侧说明槽：与左侧 peak-pair 同高 */
+.stats-note-slot {
+    flex: 0 0 auto;
+    height: var(--stats-bottom-card-height);
+    min-height: var(--stats-bottom-card-height);
+    display: flex;
+}
+
+.stats-note-slot > .card {
+    width: 100%;
+    height: 100%;
+}
+
+/* 最大地震卡片：暖色双层渐变（上层着色 + 底层 surface） */
 .max-mag-card {
-    --card-bg: linear-gradient(135deg, var(--md-sys-color-error-container) 0%, var(--md-sys-color-surface) 100%);
-    --hover-lift: 0px;
+    --card-bg:
+        linear-gradient(
+            145deg,
+            color-mix(in srgb, var(--md-sys-color-error) 18%, transparent) 0%,
+            color-mix(in srgb, #ff8a65 26%, transparent) 18%,
+            color-mix(in srgb, var(--md-sys-color-error-container) 92%, transparent) 46%,
+            color-mix(in srgb, #ffe0b2 42%, transparent) 74%,
+            transparent 100%
+        ),
+        var(--md-sys-color-surface);
+    /* 描边权重对齐通用 .card（1px glass 级），色相跟随暖色 */
+    --card-border-color: color-mix(in srgb, var(--md-sys-color-error) 18%, transparent);
+    --card-hover-border-color: color-mix(in srgb, var(--md-sys-color-error) 32%, transparent);
+    --card-shadow: 0 4px 20px 0 color-mix(in srgb, var(--md-sys-color-error) 10%, transparent);
+    --card-hover-shadow: 0 12px 30px 0 color-mix(in srgb, var(--md-sys-color-error) 16%, transparent);
+    --hover-lift: 4px;
     position: relative;
-    overflow: hidden; /* 裁剪水印装饰，避免溢出圆角 */
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
+}
+
+/* S-Net 历史最大震度：主色双层渐变 + 与通用卡片一致的描边权重 */
+.snet-max-card {
+    --card-bg:
+        linear-gradient(
+            145deg,
+            color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent) 0%,
+            color-mix(in srgb, var(--md-sys-color-primary-container) 86%, transparent) 44%,
+            transparent 100%
+        ),
+        var(--md-sys-color-surface);
+    /* 描边权重对齐通用 .card，色相跟随主色（避免“假紫边/过重”） */
+    --card-border-color: color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent);
+    --card-hover-border-color: color-mix(in srgb, var(--md-sys-color-primary) 32%, transparent);
+    --card-shadow: 0 4px 20px 0 color-mix(in srgb, var(--md-sys-color-primary) 10%, transparent);
+    --card-hover-shadow: 0 12px 30px 0 color-mix(in srgb, var(--md-sys-color-primary) 16%, transparent);
+    --hover-lift: 4px;
+    position: relative;
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
 }
 
 .max-mag-card--empty {
@@ -614,21 +713,27 @@
 }
 
 .max-mag-card-header {
-    margin-bottom: 16px;
+    margin-bottom: 12px;
 }
 
-.max-mag-card-title,
-.max-mag-card-place,
-.max-mag-card-time,
-.max-mag-card-source-chip {
+.max-mag-card-title {
     color: var(--md-sys-color-on-error-container) !important;
+}
+
+.max-mag-card-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 8px;
 }
 
 .max-mag-card-mag-row {
     display: flex;
-    align-items: baseline;
-    gap: 8px;
-    margin-bottom: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
 }
 
 /* 最大震级超级数字展示 */
@@ -636,25 +741,292 @@
     font-weight: 800 !important;
     color: var(--md-sys-color-error) !important;
     line-height: 1 !important;
+    font-size: clamp(2rem, 2.6vw, 2.75rem) !important;
+    letter-spacing: -0.02em;
 }
 
 .max-mag-card-mag-prefix {
-    margin-right: 8px;
-}
-
-.max-mag-card-source-chip {
-    height: 24px !important;
-    font-size: 12px !important;
-    background: rgba(255, 255, 255, 0.3) !important;
+    margin-right: 4px;
+    opacity: 0.92;
 }
 
 .max-mag-card-place {
     font-weight: 800 !important;
-    margin-bottom: 8px !important;
+    color: var(--md-sys-color-on-error-container) !important;
+    line-height: 1.35 !important;
+    margin: 0 !important;
+}
+
+.max-mag-card-footer {
+    margin-top: auto;
+    padding-top: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.max-mag-card-time,
+.snet-max-card-time {
+    font-size: 1rem !important;
+    font-weight: 700 !important;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+    line-height: 1.3 !important;
+    opacity: 0.88 !important;
 }
 
 .max-mag-card-time {
-    opacity: 0.7;
+    color: var(--md-sys-color-on-error-container) !important;
+}
+
+.max-mag-card-source {
+    color: var(--md-sys-color-on-error-container) !important;
+    font-weight: 700 !important;
+    opacity: 0.85;
+    white-space: nowrap;
+    max-width: 52%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.8rem !important;
+    line-height: 1.25 !important;
+}
+
+.snet-max-card--empty {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.snet-max-card-empty-icon {
+    font-size: 48px;
+    opacity: 0.2;
+}
+
+.snet-max-card-empty-text {
+    opacity: 0.5;
+    margin-top: 8px !important;
+}
+
+.snet-max-card-watermark {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    font-size: 100px;
+    opacity: 0.05;
+    pointer-events: none;
+    user-select: none;
+}
+
+.snet-max-card-header {
+    margin-bottom: 12px;
+}
+
+.snet-max-card-title {
+    color: var(--md-sys-color-on-primary-container) !important;
+}
+
+/* Top3 单行列表*/
+.snet-max-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+    min-height: 0;
+}
+
+.snet-max-card-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.snet-max-card-rank {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    opacity: 0.9;
+}
+
+.snet-max-card-line {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 6px;
+    color: var(--md-sys-color-on-primary-container) !important;
+    font-weight: 600 !important;
+    line-height: 1.35 !important;
+}
+
+.snet-max-card-station {
+    font-weight: 800;
+    letter-spacing: 0.01em;
+}
+
+.snet-max-card-label {
+    font-weight: 700;
+    color: var(--md-sys-color-primary);
+}
+
+.snet-max-card-value {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.78;
+    font-weight: 600;
+}
+
+.snet-max-card-sep {
+    display: none;
+}
+
+.snet-max-card-footer {
+    margin-top: auto;
+    padding-top: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.snet-max-card-time,
+.snet-max-card-source {
+    color: var(--md-sys-color-on-primary-container) !important;
+    line-height: 1.25 !important;
+}
+
+.snet-max-card-source {
+    font-weight: 700 !important;
+    opacity: 0.85;
+    white-space: nowrap;
+    font-size: 0.8rem !important;
+}
+
+/* 统计口径说明小卡片：与最大震级 / S-Net 同高，描边完全对齐通用 .card */
+.stats-note-card {
+    --card-bg:
+        linear-gradient(
+            145deg,
+            color-mix(in srgb, var(--md-sys-color-surface-variant) 55%, transparent) 0%,
+            color-mix(in srgb, var(--md-sys-color-primary-container) 14%, transparent) 42%,
+            transparent 100%
+        ),
+        var(--md-sys-color-surface);
+    /* 与通用 .card 完全一致的描边/阴影 token，避免“另起一套边框” */
+    --card-border-color: var(--glass-border);
+    --card-hover-border-color: rgba(103, 80, 164, 0.26);
+    --card-shadow: var(--glass-shadow);
+    --card-hover-shadow: 0 12px 30px 0 rgba(103, 80, 164, 0.12);
+    --hover-lift: 4px;
+    height: var(--stats-bottom-card-height, 200px);
+    min-height: var(--stats-bottom-card-height, 200px);
+    max-height: var(--stats-bottom-card-height, 200px);
+    position: relative;
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
+}
+
+/* 深色主题：说明卡 hover 描边跟随全局 dark card */
+body.dark-theme .stats-note-card,
+html.theme-dark .stats-note-card {
+    --card-hover-border-color: rgba(208, 188, 255, 0.24);
+    --card-hover-shadow: 0 14px 34px rgba(0, 0, 0, 0.38), 0 0 0 1px rgba(208, 188, 255, 0.08);
+}
+
+/* 深色主题：最大地震 / S-Net 描边与阴影略提亮，避免边框发灰 */
+body.dark-theme .max-mag-card,
+html.theme-dark .max-mag-card {
+    --card-border-color: color-mix(in srgb, var(--md-sys-color-error) 28%, transparent);
+    --card-hover-border-color: color-mix(in srgb, var(--md-sys-color-error) 42%, transparent);
+    --card-shadow: 0 8px 24px 0 rgba(0, 0, 0, 0.28);
+    --card-hover-shadow: 0 14px 34px rgba(0, 0, 0, 0.38), 0 0 0 1px color-mix(in srgb, var(--md-sys-color-error) 22%, transparent);
+}
+
+body.dark-theme .snet-max-card,
+html.theme-dark .snet-max-card {
+    --card-border-color: color-mix(in srgb, var(--md-sys-color-primary) 28%, transparent);
+    --card-hover-border-color: color-mix(in srgb, var(--md-sys-color-primary) 42%, transparent);
+    --card-shadow: 0 8px 24px 0 rgba(0, 0, 0, 0.28);
+    --card-hover-shadow: 0 14px 34px rgba(0, 0, 0, 0.38), 0 0 0 1px color-mix(in srgb, var(--md-sys-color-primary) 22%, transparent);
+}
+
+.stats-note-card-watermark {
+    position: absolute;
+    top: -8px;
+    right: -6px;
+    font-size: 84px;
+    opacity: 0.05;
+    pointer-events: none;
+    user-select: none;
+}
+
+.stats-note-card-header {
+    margin-bottom: 8px;
+    flex-shrink: 0;
+}
+
+.stats-note-card-title {
+    color: var(--md-sys-color-on-surface) !important;
+    font-weight: 800 !important;
+}
+
+.stats-note-card-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+}
+
+.stats-note-card-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+.stats-note-card-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.stats-note-card-bullet {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 800;
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    opacity: 0.9;
+    margin-top: 1px;
+}
+
+.stats-note-card-text {
+    opacity: 0.9;
+    line-height: 1.4 !important;
+    font-size: 12.5px !important;
+    color: var(--md-sys-color-on-surface-variant);
+    font-weight: 600 !important;
 }
 
 /* 天气警报级别卡片 */
@@ -905,6 +1277,40 @@
     .stats-overview-main,
     .stats-overview-side {
         grid-column: span 12;
+    }
+
+    .stats-peak-pair {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .stats-note-slot {
+        min-height: 180px;
+    }
+}
+
+@media (max-width: 720px) {
+    .stats-peak-pair {
+        grid-template-columns: 1fr;
+    }
+
+    .stats-peak-pair,
+    .stats-note-slot,
+    .max-mag-card,
+    .snet-max-card,
+    .stats-note-card {
+        --stats-bottom-card-height: 180px;
+        height: var(--stats-bottom-card-height);
+        min-height: var(--stats-bottom-card-height);
+        max-height: var(--stats-bottom-card-height);
+    }
+
+    .max-mag-card-mag-value {
+        font-size: 2rem !important;
+    }
+
+    .max-mag-card-source,
+    .snet-max-card-source {
+        max-width: 46%;
     }
 }
 
@@ -1262,5 +1668,16 @@
     .stats-overview-main,
     .stats-overview-side {
         grid-column: span 12;
+    }
+
+    /* 中屏保留双列极值卡片，窄屏再单列 */
+    .stats-peak-pair {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .stats-peak-pair {
+        grid-template-columns: 1fr;
     }
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -196,6 +196,8 @@
     <script type="text/babel" src="js/components/stats/TrendChart.jsx" defer></script>
     <script type="text/babel" src="js/components/stats/CalendarHeatmap.jsx" defer></script>
     <script type="text/babel" src="js/components/stats/MaxMagCard.jsx" defer></script>
+    <script type="text/babel" src="js/components/stats/SnetMaxCard.jsx" defer></script>
+    <script type="text/babel" src="js/components/stats/StatsNoteCard.jsx" defer></script>
     <script type="text/babel" src="js/components/stats/TopListCard.jsx" defer></script>
     <script type="text/babel" src="js/components/stats/WeatherLevelCard.jsx" defer></script>
     <script type="text/babel" src="js/components/stats/LogStatsCard.jsx" defer></script>

--- a/admin/js/components/config/ConfigModeToolbar.jsx
+++ b/admin/js/components/config/ConfigModeToolbar.jsx
@@ -81,6 +81,8 @@ function ConfigModeToolbar({
             {mode === 'session' && selectedSessionMeta && (
                 <Typography variant="caption" color="text.secondary" className="config-mode-toolbar__meta">
                     当前会话：{selectedSessionMeta.session_name ? `${selectedSessionMeta.session} (${selectedSessionMeta.session_name})` : selectedSessionMeta.session} ｜ push_enabled：{selectedSessionMeta.push_enabled ? '开启' : '关闭'} ｜ override字段：{(selectedSessionMeta.override_keys || []).join(', ') || '无'}
+                    <br />
+                    提示：此处编辑的是“生效配置”（全局 + 会话差异）。全局关闭时任何会话都不会推送。
                 </Typography>
             )}
         </Box>

--- a/admin/js/components/events/HorizontalTimeline.jsx
+++ b/admin/js/components/events/HorizontalTimeline.jsx
@@ -384,6 +384,21 @@ function HorizontalTimeline({ style }) {
      * 核心预警等级着色评级：根据地震震级、海啸警报级别或气象级别生成危险配色样式类
      */
     const getEventToneClass = (event) => {
+        // S-Net 测站峰值：按震度阶级着色（>=5弱 才进入重大事件）
+        if (event.type === 'snet_peak') {
+            const shindo = Number(event.shindo);
+            if (Number.isFinite(shindo)) {
+                if (shindo >= 6.5) return 'is-purple';
+                if (shindo >= 6.0) return 'is-red';
+                if (shindo >= 5.5) return 'is-orange';
+                if (shindo >= 4.5) return 'is-yellow';
+            }
+            const level = String(event.level || '');
+            if (level.includes('7') || level.includes('6強') || level.includes('6+')) return 'is-red';
+            if (level.includes('6弱') || level.includes('6-') || level.includes('5強') || level.includes('5+')) return 'is-orange';
+            return 'is-yellow';
+        }
+
         // A. 地震：根据震级进行判色
         if (event.type === 'earthquake' || event.type === 'earthquake_warning') {
             const sourceText = String(event?.source_id || event?.source || '').toLowerCase();
@@ -561,6 +576,15 @@ function HorizontalTimeline({ style }) {
                                             {/* A. 结构化大标题 */}
                                             <Typography variant="body2" className={`horizontal-timeline-node-title ${toneClass}`}>
                                                 {(() => {
+                                                    if (item.type === 'snet_peak') {
+                                                        const level = String(item.level || '').trim();
+                                                        if (level) return `震度${level}`;
+                                                        const shindo = Number(item.shindo);
+                                                        if (Number.isFinite(shindo)) {
+                                                            return `震度${shindo.toFixed(1)}`;
+                                                        }
+                                                        return 'S-Net';
+                                                    }
                                                     if (item.type === 'earthquake') {
                                                         const mag = Number(item.magnitude);
                                                         if (Number.isFinite(mag)) {
@@ -589,6 +613,10 @@ function HorizontalTimeline({ style }) {
                                             <Typography variant="caption" className="horizontal-timeline-node-subtitle">
                                                 {(() => {
                                                     const desc = String(item.description || '').trim();
+                                                    if (item.type === 'snet_peak') {
+                                                        const station = String(item.place_name || item.place || '').trim();
+                                                        return station || 'S-Net 测站';
+                                                    }
                                                     if (item.type === 'earthquake') {
                                                         const structuredPlace = String(item.place_name || item.place || '').trim();
                                                         if (structuredPlace) {

--- a/admin/js/components/stats/MagnitudeChart.jsx
+++ b/admin/js/components/stats/MagnitudeChart.jsx
@@ -11,7 +11,7 @@ const { useMemo } = React;
  * @param {Object} [props.style] 外部样式
  * @param {string} [props.className=''] 额外类名
  */
-function MagnitudeChart({ style, className = '' }) {
+function MagnitudeChart({ style, className = '', showNote = true }) {
     const { state } = useAppContext();
     
     // 获取后台统计并推送到 state 中的震级分布指标 map
@@ -97,15 +97,17 @@ function MagnitudeChart({ style, className = '' }) {
                 ))}
             </div>
             
-            {/* 底部备注提示区域 */}
-            <div className="magnitude-chart-note-wrap">
-                <div className="magnitude-chart-note">
-                    <span className="magnitude-chart-note-icon">ℹ️</span>
-                    <Typography variant="body2" className="magnitude-chart-note-text">
-                        地震震级分布与最大地震的统计可能会不一致，这是由于对数据源的筛选逻辑不一样导致的，前者比较宽松，后者比较严格。
-                    </Typography>
+            {/* 底部备注提示区域（可外置到布局层） */}
+            {showNote && (
+                <div className="magnitude-chart-note-wrap">
+                    <div className="magnitude-chart-note">
+                        <span className="magnitude-chart-note-icon">ℹ️</span>
+                        <Typography variant="body2" className="magnitude-chart-note-text">
+                            地震震级分布与最大地震的统计可能会不一致，这是由于对数据源的筛选逻辑不一样导致的，前者比较宽松，后者比较严格。
+                        </Typography>
+                    </div>
                 </div>
-            </div>
+            )}
         </div>
     );
 }

--- a/admin/js/components/stats/MaxMagCard.jsx
+++ b/admin/js/components/stats/MaxMagCard.jsx
@@ -1,9 +1,8 @@
-const { Box, Typography, Chip } = MaterialUI;
+const { Typography } = MaterialUI;
 
 /**
  * 历史最大地震信息卡片组件 (MaxMagCard)
- * 用于在统计仪表盘显眼位置陈列系统捕获并持久化记录的历史上震级最大的地震事件。
- * 包含特效浮水印、震级大数字渲染、发布源高亮标签、震中地名及发生时间。
+ * 与 S-Net 卡片并排：标题 + 震级大数 + 地点 + 底部左时间/右来源。
  *
  * @param {Object} props
  * @param {Object} [props.style] 外部自定义样式
@@ -13,13 +12,13 @@ function MaxMagCard({ style, className = '' }) {
     const { state } = useAppContext();
     const { stats, config } = state;
     const displayTimezone = config.displayTimezone || 'UTC+8';
-    
-    // 获取历史最大震级地震负载
+
     const maxMag = stats && stats.maxMagnitude ? stats.maxMagnitude : null;
     const magValue = Number(maxMag?.value);
-    
+
     const displayMag = Number.isFinite(magValue) ? magValue.toFixed(1) : '--';
     const displayPlace = maxMag?.place_name || '暂无震中信息';
+    const sourceLabel = maxMag?.source ? formatSourceName(maxMag.source) : '';
 
     /**
      * 格式化震中发震时间
@@ -49,30 +48,29 @@ function MaxMagCard({ style, className = '' }) {
                 <span className="stats-card-header-icon">🔥</span>
                 <Typography variant="h6" className="max-mag-card-title">历史最大地震</Typography>
             </div>
-            
-            {/* 震级高亮大数行与数据源来源标签 */}
-            <div className="max-mag-card-mag-row">
-                <Typography variant="h3" className="max-mag-card-mag-value">
-                    <span className="max-mag-card-mag-prefix">M</span>{displayMag}
+
+            <div className="max-mag-card-body">
+                <div className="max-mag-card-mag-row">
+                    <Typography variant="h3" className="max-mag-card-mag-value">
+                        <span className="max-mag-card-mag-prefix">M</span>{displayMag}
+                    </Typography>
+                </div>
+
+                <Typography variant="body1" className="max-mag-card-place">
+                    {displayPlace}
                 </Typography>
-                {maxMag?.source && (
-                    <Chip
-                        label={formatSourceName(maxMag.source)}
-                        size="small"
-                        className="max-mag-card-source-chip"
-                    />
-                )}
             </div>
 
-            {/* 震中地点名称 */}
-            <Typography variant="body1" className="max-mag-card-place">
-                {displayPlace}
-            </Typography>
-            
-            {/* 发震时间详情 */}
-            <Typography variant="body2" className="max-mag-card-time">
-                {formatTime(maxMag?.time)}
-            </Typography>
+            <div className="max-mag-card-footer">
+                <Typography variant="body2" className="max-mag-card-time">
+                    {formatTime(maxMag?.time)}
+                </Typography>
+                {sourceLabel && (
+                    <Typography variant="caption" className="max-mag-card-source">
+                        {sourceLabel}
+                    </Typography>
+                )}
+            </div>
         </div>
     );
 }

--- a/admin/js/components/stats/SnetMaxCard.jsx
+++ b/admin/js/components/stats/SnetMaxCard.jsx
@@ -1,0 +1,102 @@
+const { Typography } = MaterialUI;
+const { useMemo } = React;
+
+/**
+ * S-Net 历史最大震度卡片 (SnetMaxCard)
+ * 展示历史最大震度 Top3 测站（单行：站名 + 震度标签 + 数值），
+ * 底部左时间、右数据源。
+ *
+ * @param {Object} props
+ * @param {Object} [props.style]
+ * @param {string} [props.className='']
+ */
+function SnetMaxCard({ style, className = '' }) {
+    const { state } = useAppContext();
+    const { stats, config } = state;
+    const displayTimezone = config.displayTimezone || 'UTC+8';
+
+    const topPeaks = useMemo(() => {
+        const raw = Array.isArray(stats?.snetTopPeaks) ? stats.snetTopPeaks : [];
+        if (raw.length > 0) {
+            return raw.slice(0, 3).map((item) => ({
+                stationName: String(item.station_name || item.stationName || item.station_id || item.stationId || '').trim(),
+                shindo: Number(item.shindo),
+                shindoLabel: String(item.shindo_label || item.shindoLabel || '').trim(),
+                at: item.at || '',
+            })).filter((item) => item.stationName && Number.isFinite(item.shindo));
+        }
+
+        // 兼容仅有 global_max 的旧载荷
+        const globalMax = stats?.snetGlobalMax;
+        if (!globalMax) return [];
+        const shindo = Number(globalMax.shindo);
+        if (!Number.isFinite(shindo)) return [];
+        return [{
+            stationName: String(globalMax.station_name || globalMax.stationName || globalMax.station_id || '').trim() || '未知测站',
+            shindo,
+            shindoLabel: String(globalMax.shindo_label || globalMax.shindoLabel || '').trim(),
+            at: globalMax.at || '',
+        }];
+    }, [stats]);
+
+    const footerTime = useMemo(() => {
+        // 优先用 Top1 峰值时间；否则回退 last_observation / global_max
+        const fromTop = topPeaks[0]?.at;
+        const fallback = stats?.snetGlobalMax?.at || stats?.snetLastObservationAt || '';
+        const raw = fromTop || fallback;
+        if (!raw) return '未知时间';
+        return formatTimeWithZone(raw, displayTimezone, true);
+    }, [topPeaks, stats, displayTimezone]);
+
+    if (!topPeaks.length) {
+        return (
+            <div className={`card snet-max-card snet-max-card--empty ${className}`} style={style}>
+                <span className="snet-max-card-empty-icon">🌊</span>
+                <Typography variant="body2" className="snet-max-card-empty-text">
+                    暂无 S-Net 峰值记录
+                </Typography>
+            </div>
+        );
+    }
+
+    return (
+        <div className={`card snet-max-card ${className}`} style={style}>
+            <div className="snet-max-card-watermark">🌊</div>
+
+            <div className="chart-card-header snet-max-card-header">
+                <span className="stats-card-header-icon">🌊</span>
+                <Typography variant="h6" className="snet-max-card-title">S-Net 历史最大震度</Typography>
+            </div>
+
+            <div className="snet-max-card-list">
+                {topPeaks.map((item, index) => {
+                    // 后端 label 通常是「0以下 / 5強 / 1」等，不含「震度」前缀
+                    const rawLabel = item.shindoLabel || '';
+                    const label = rawLabel
+                        ? (rawLabel.startsWith('震度') ? rawLabel : `震度${rawLabel}`)
+                        : `震度${item.shindo.toFixed(3)}`;
+                    const valueText = Number.isFinite(item.shindo) ? item.shindo.toFixed(3) : '--';
+                    return (
+                        <div key={`${item.stationName}-${index}`} className="snet-max-card-row">
+                            <span className="snet-max-card-rank" aria-hidden="true">{index + 1}</span>
+                            <Typography variant="body2" className="snet-max-card-line" component="div">
+                                <span className="snet-max-card-station">{item.stationName}</span>
+                                <span className="snet-max-card-label">{label}</span>
+                                <span className="snet-max-card-value">({valueText})</span>
+                            </Typography>
+                        </div>
+                    );
+                })}
+            </div>
+
+            <div className="snet-max-card-footer">
+                <Typography variant="caption" className="snet-max-card-time">
+                    {footerTime}
+                </Typography>
+                <Typography variant="caption" className="snet-max-card-source">
+                    NIED S-Net
+                </Typography>
+            </div>
+        </div>
+    );
+}

--- a/admin/js/components/stats/SnetMaxCard.jsx
+++ b/admin/js/components/stats/SnetMaxCard.jsx
@@ -17,13 +17,15 @@ function SnetMaxCard({ style, className = '' }) {
 
     const topPeaks = useMemo(() => {
         const raw = Array.isArray(stats?.snetTopPeaks) ? stats.snetTopPeaks : [];
-        if (raw.length > 0) {
-            return raw.slice(0, 3).map((item) => ({
-                stationName: String(item.station_name || item.stationName || item.station_id || item.stationId || '').trim(),
-                shindo: Number(item.shindo),
-                shindoLabel: String(item.shindo_label || item.shindoLabel || '').trim(),
-                at: item.at || '',
-            })).filter((item) => item.stationName && Number.isFinite(item.shindo));
+        // 先过滤再取 Top3；过滤后为空才降级到 snetGlobalMax，避免脏数据导致空态。
+        const filtered = raw.map((item) => ({
+            stationName: String(item.station_name || item.stationName || item.station_id || item.stationId || '').trim(),
+            shindo: Number(item.shindo),
+            shindoLabel: String(item.shindo_label || item.shindoLabel || '').trim(),
+            at: item.at || '',
+        })).filter((item) => item.stationName && Number.isFinite(item.shindo));
+        if (filtered.length > 0) {
+            return filtered.slice(0, 3);
         }
 
         // 兼容仅有 global_max 的旧载荷

--- a/admin/js/components/stats/StatsNoteCard.jsx
+++ b/admin/js/components/stats/StatsNoteCard.jsx
@@ -1,0 +1,39 @@
+const { Typography } = MaterialUI;
+
+/**
+ * 统计口径说明小卡片 (StatsNoteCard)
+ * 放在总览右侧、事件总数卡片下方，与最大震级 / S-Net 同高。
+ *
+ * @param {Object} props
+ * @param {Object} [props.style]
+ * @param {string} [props.className='']
+ */
+function StatsNoteCard({ style, className = '' }) {
+    return (
+        <div className={`card stats-note-card ${className}`} style={style}>
+            <div className="stats-note-card-watermark" aria-hidden="true">ℹ️</div>
+
+            <div className="chart-card-header stats-note-card-header">
+                <span className="stats-card-header-icon">ℹ️</span>
+                <Typography variant="h6" className="stats-note-card-title">统计口径说明</Typography>
+            </div>
+
+            <div className="stats-note-card-body">
+                <ul className="stats-note-card-list">
+                    <li className="stats-note-card-item">
+                        <span className="stats-note-card-bullet" aria-hidden="true">1</span>
+                        <Typography variant="body2" className="stats-note-card-text">
+                            震级分布统计口径较宽松，最大地震统计口径更严格。两者可能不一致，这是由于对数据源的筛选逻辑不一样导致的。
+                        </Typography>
+                    </li>
+                    <li className="stats-note-card-item">
+                        <span className="stats-note-card-bullet" aria-hidden="true">2</span>
+                        <Typography variant="body2" className="stats-note-card-text">
+                            S-Net 仅归档测站历史最大震度，不计入事件总数与热力图。
+                        </Typography>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/admin/js/hooks/config/useConfigLoader.js
+++ b/admin/js/hooks/config/useConfigLoader.js
@@ -106,6 +106,12 @@ function useConfigLoader({
             }
             setSessionLoading(true);
             const sessionData = await api.getSessionConfig(currentSession);
+            // 会话模式必须编辑“生效配置”(global + override)，
+            // 否则未写入 override 的字段会显示成 schema 默认关，
+            // 但运行时仍继承全局开启，导致“界面关了却仍推送”。
+            if (sessionData?.effective && typeof sessionData.effective === 'object') {
+                return sessionData.effective;
+            }
             return sessionData?.override || {};
         }
         return await api.getFullConfig();

--- a/admin/js/hooks/config/useConfigPersistence.js
+++ b/admin/js/hooks/config/useConfigPersistence.js
@@ -34,9 +34,14 @@ function useConfigPersistence({
     const buildSavePayload = React.useCallback(() => {
         const visibleSchema = getVisibleSchema(mode);
         // 会话模式下仅截取并过滤出差异覆写表单子元素，全局模式透传所有
-        const configToSave = mode === 'session'
+        let configToSave = mode === 'session'
             ? pickConfigBySchema(config, visibleSchema)
             : config;
+
+        // 会话保存时强制剥离仅全局可改字段（如 S-Net 轮询间隔）
+        if (mode === 'session' && window.ConfigSchemaUtils && window.ConfigSchemaUtils.stripGlobalOnlyFields) {
+            configToSave = window.ConfigSchemaUtils.stripGlobalOnlyFields(configToSave);
+        }
 
         return {
             visibleSchema,
@@ -92,10 +97,11 @@ function useConfigPersistence({
                     return;
                 }
 
-                // 提交会话级 override 覆写结构
+                // 会话表单展示的是生效配置；以 effective 模式提交，
+                // 由后端 compute_diff 生成最小 override（可显式写入 false）。
                 await api.updateSessionConfig(selectedSession, {
-                    mode: 'override',
-                    override: cleanedConfig,
+                    mode: 'effective',
+                    effective: cleanedConfig,
                 });
                 showToast('会话差异配置已保存', 'success');
                 setDirty(false);

--- a/admin/js/services/statsNormalizer.js
+++ b/admin/js/services/statsNormalizer.js
@@ -28,6 +28,7 @@
         const earthquakeStats = stats.earthquake_stats || {};
         const weatherStats = stats.weather_stats || {};
         const typhoonStats = stats.typhoon_stats || {};
+        const snetStats = stats.snet_stats || {};
         const byType = stats.by_type || {};
 
         // 会话推送统计：从 session_stats.top_sessions 提取并排序
@@ -111,6 +112,12 @@
                 weatherCount: byType.weather_alarm || 0,                     // 气象灾害总数
                 typhoonCount: byType.typhoon || 0,                           // 台风事件总数
                 maxMagnitude: earthquakeStats.max_magnitude || null,         // 周期内全球最大震级极值
+                snetGlobalMax: snetStats.global_max || null,                 // S-Net 全网历史最大震度
+                snetTopPeaks: Array.isArray(snetStats.top_peaks)
+                    ? snetStats.top_peaks.slice(0, 3)
+                    : [],                                                    // S-Net 历史最大震度 Top3
+                snetStationCount: Number(snetStats.station_count) || 0,      // S-Net 已归档测站数
+                snetLastObservationAt: snetStats.last_observation_at || null,
                 earthquakeRegions: entriesToSortedList(earthquakeStats.by_region, 'region'), // 地震多发地 Top10 排行数据
                 weatherRegions: entriesToSortedList(weatherStats.by_region, 'region'),       // 气象多发地 Top10 排行数据
                 weatherTypes: entriesToSortedList(weatherStats.by_type, 'type'),             // 气象细分类别分布

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -9,9 +9,14 @@
     const CONFIG_SESSION_ONLY_KEYS = new Set(['push_enabled', 'session_name']);
 
     // 仅允许全局配置修改的嵌套路径（会话模式隐藏且保存时剥离）
-    // 例如 S-Net 轮询间隔影响全局采集节奏，不允许按会话分叉。
+    // S-Net 轮询间隔、EQSC 通道鉴权参数影响全局运行态；
+    // typhoon_enrichment 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
     const CONFIG_SESSION_GLOBAL_ONLY_PATHS = [
         ['data_sources', 'snet', 'poll_interval_seconds'],
+        ['data_sources', 'eqsc', 'enabled'],
+        ['data_sources', 'eqsc', 'base_url'],
+        ['data_sources', 'eqsc', 'refresh_token'],
+        ['data_sources', 'eqsc', 'cache_ttl'],
     ];
 
     /**

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -8,6 +8,12 @@
     // 定义会话覆写专属的局部参数 Key（如单群推送开关、会话备注名）
     const CONFIG_SESSION_ONLY_KEYS = new Set(['push_enabled', 'session_name']);
 
+    // 仅允许全局配置修改的嵌套路径（会话模式隐藏且保存时剥离）
+    // 例如 S-Net 轮询间隔影响全局采集节奏，不允许按会话分叉。
+    const CONFIG_SESSION_GLOBAL_ONLY_PATHS = [
+        ['data_sources', 'snet', 'poll_interval_seconds'],
+    ];
+
     /**
      * 递归获取 Schema 下所有可折叠对象节点的分支路径列表
      */
@@ -84,11 +90,76 @@
     }
 
     /**
+     * 从对象中剥离仅全局可改的嵌套字段。
+     */
+    function stripGlobalOnlyFields(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+        const next = JSON.parse(JSON.stringify(value));
+        CONFIG_SESSION_GLOBAL_ONLY_PATHS.forEach((path) => {
+            let cursor = next;
+            const stack = [];
+            for (let i = 0; i < path.length; i += 1) {
+                const key = path[i];
+                if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor) || !(key in cursor)) {
+                    return;
+                }
+                stack.push([cursor, key]);
+                cursor = cursor[key];
+            }
+            if (!stack.length) return;
+            const [leafParent, leafKey] = stack[stack.length - 1];
+            delete leafParent[leafKey];
+            for (let i = stack.length - 2; i >= 0; i -= 1) {
+                const [parent, key] = stack[i];
+                const child = parent[key];
+                if (child && typeof child === 'object' && !Array.isArray(child) && Object.keys(child).length === 0) {
+                    delete parent[key];
+                } else {
+                    break;
+                }
+            }
+        });
+        return next;
+    }
+
+    /**
+     * 从 Schema 中移除仅全局可改的嵌套字段定义。
+     */
+    function stripGlobalOnlyFromSchema(schemaObject) {
+        if (!schemaObject || typeof schemaObject !== 'object' || Array.isArray(schemaObject)) {
+            return schemaObject;
+        }
+        const next = JSON.parse(JSON.stringify(schemaObject));
+        CONFIG_SESSION_GLOBAL_ONLY_PATHS.forEach((path) => {
+            let cursor = next;
+            for (let i = 0; i < path.length; i += 1) {
+                const key = path[i];
+                if (!cursor || typeof cursor !== 'object') return;
+                // schema 对象节点的子项在 items 下
+                if (cursor.type === 'object' && cursor.items && typeof cursor.items === 'object') {
+                    cursor = cursor.items;
+                }
+                if (i === path.length - 1) {
+                    if (cursor && typeof cursor === 'object') {
+                        delete cursor[key];
+                    }
+                    return;
+                }
+                const child = cursor[key];
+                if (!child || typeof child !== 'object') return;
+                cursor = child;
+            }
+        });
+        return next;
+    }
+
+    /**
      * 根据当前的配置编辑模式获取过滤后的可见 Schema
      * 
      * 过滤策略：
      * - 全局模式下直接返回完整 Schema。
      * - 会话差异覆写模式下，剔除敏感及不适用于单群的字段，并动态塞入局部单会话推送开关的表单描述定义。
+     * - 同时剥离仅全局可改的嵌套字段（如 S-Net 轮询间隔）。
      */
     function getVisibleSchema(schemaArg, currentMode = 'global') {
         if (!schemaArg || currentMode !== 'session') return schemaArg;
@@ -105,18 +176,22 @@
                 default: true,
             };
         }
-        return visible;
+        // 会话模式隐藏全局-only 嵌套字段
+        return stripGlobalOnlyFromSchema(visible);
     }
 
     // 绑定至全局
     window.ConfigSchemaUtils = {
         CONFIG_SESSION_DIFF_HIDDEN_KEYS,
         CONFIG_SESSION_ONLY_KEYS,
+        CONFIG_SESSION_GLOBAL_ONLY_PATHS,
         getAllExpandablePaths,
         isValidSchemaObject,
         cleanConfig,
         generateDefaults,
         pickConfigBySchema,
+        stripGlobalOnlyFields,
+        stripGlobalOnlyFromSchema,
         getVisibleSchema,
     };
 })();

--- a/admin/js/views/StatsView.jsx
+++ b/admin/js/views/StatsView.jsx
@@ -30,19 +30,27 @@ function StatsView() {
             <div className="dashboard-grid">
                 {/* 第一栏大板块：地震震级历史占比与近期核心指标 */}
                 <div className="stats-overview-grid">
-                    {/* 左侧：占比分布曲线/圆饼图（主卡片） */}
+                    {/* 左侧：震级分布主图 + 下方并排极值卡片 */}
                     <div className="stats-overview-main">
-                        <div className="stats-fill-column">
-                            <MagnitudeChart className="stats-flex-fill" />
+                        <div className="stats-fill-column stats-overview-main-stack">
+                            <MagnitudeChart className="stats-flex-fill" showNote={false} />
+                            <div className="stats-peak-pair">
+                                <div className="stats-peak-pair-item">
+                                    <MaxMagCard />
+                                </div>
+                                <div className="stats-peak-pair-item">
+                                    <SnetMaxCard />
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    {/* 右侧：纵向堆叠的指标小卡片和历史极值归档 */}
+                    {/* 右侧：总览指标 + 统计口径说明（与下方极值卡片等高） */}
                     <div className="stats-overview-side">
                         <div className="stats-fill-column stats-flex-fill">
                             <StatsCard className="stats-flex-fill" />
                         </div>
-                        <div className="stats-fill-column stats-flex-fill">
-                             <MaxMagCard />
+                        <div className="stats-fill-column stats-note-slot">
+                            <StatsNoteCard className="stats-flex-fill" />
                         </div>
                     </div>
                 </div>

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -289,12 +289,18 @@ class DisasterWarningService:
             self.http_fetcher = HTTPDataFetcher(self.config)  # 初始化 HTTP 轮询拉取组件
             self._register_handlers()
             self._configure_connections()
-            # 台风富化服务在 EQSC 启用时输出就绪日志
-            if self.typhoon_enrichment_service.is_enabled:
+            # EQSC 通道 / 台风富化就绪日志（组总闸与子开关已解耦）
+            enrichment = self.typhoon_enrichment_service
+            if enrichment.is_enabled:
                 logger.info("[灾害预警] EQSC 台风富化服务已就绪")
+            elif getattr(enrichment, "is_channel_enabled", False):
+                logger.info(
+                    "[灾害预警] EQSC 通道已启用，但台风富化子开关关闭；"
+                    "台风将使用 FAN Studio 基础数据"
+                )
             else:
                 logger.info(
-                    "[灾害预警] EQSC 台风富化服务未启用，台风将使用 FAN Studio 基础数据"
+                    "[灾害预警] EQSC 数据源未启用，台风将使用 FAN Studio 基础数据"
                 )
             logger.info("[灾害预警] 灾害预警服务初始化完成")
 
@@ -312,10 +318,12 @@ class DisasterWarningService:
 
     def schedule_eqsc_token_warmup(self) -> None:
         """启动后第一时间后台预热 EQSC AccessToken，避免状态长期显示鉴权失效。"""
-        if not self.typhoon_enrichment_service.is_enabled:
+        # 通道级预热：只要组总闸开启且 token 已配置即可，不依赖台风富化子开关
+        enrichment = self.typhoon_enrichment_service
+        if not getattr(enrichment, "is_channel_enabled", enrichment.is_enabled):
             return
         warmup_task = asyncio.create_task(
-            self.typhoon_enrichment_service.warm_up_access_token(),
+            enrichment.warm_up_access_token(),
             name="dw_eqsc_token_warmup",
         )
         self.register_background_task(warmup_task)

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -317,13 +317,25 @@ class DisasterWarningService:
             raise
 
     def schedule_eqsc_token_warmup(self) -> None:
-        """启动后第一时间后台预热 EQSC AccessToken，避免状态长期显示鉴权失效。"""
+        """启动后第一时间后台预热 EQSC AccessToken，并开启保活续期。
+
+        状态面板只读内存 token 有效性；若仅启动预热、无业务请求触发续期，
+        AccessToken（约 1 小时）过期后会长期显示“鉴权失效”。
+        """
         # 通道级预热：只要组总闸开启且 token 已配置即可，不依赖台风富化子开关
         enrichment = self.typhoon_enrichment_service
         if not getattr(enrichment, "is_channel_enabled", enrichment.is_enabled):
             return
+
+        async def _warmup_and_keepalive() -> None:
+            await enrichment.warm_up_access_token()
+            # 预热成功与否都启动保活：失败时循环会按重试间隔继续尝试
+            start_keepalive = getattr(enrichment, "start_token_keepalive", None)
+            if callable(start_keepalive):
+                start_keepalive()
+
         warmup_task = asyncio.create_task(
-            enrichment.warm_up_access_token(),
+            _warmup_and_keepalive(),
             name="dw_eqsc_token_warmup",
         )
         self.register_background_task(warmup_task)

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -73,6 +73,15 @@ class TyphoonEnrichmentService:
         self._circuit_failures = 0
         self._circuit_open_until: float = 0.0
 
+        # AccessToken 后台保活：状态面板只读 has_valid_access_token，
+        # 若仅启动预热、无业务请求触发 get_access_token，约 1 小时后会误显示“鉴权失效”。
+        self._token_keepalive_task: asyncio.Task | None = None
+        self._token_keepalive_stop = asyncio.Event()
+        # 最短检查间隔，避免异常情况下 tight loop
+        self._token_keepalive_min_interval = 30.0
+        # 无有效 token 时的重试间隔
+        self._token_keepalive_retry_interval = 120.0
+
     @staticmethod
     def resolve_eqsc_flags(eqsc_config: dict[str, Any] | None) -> tuple[bool, bool]:
         """解析 EQSC 组总闸与台风富化子开关。
@@ -164,6 +173,88 @@ class TyphoonEnrichmentService:
                 f"[灾害预警] EQSC AccessToken 预热异常: {type(exc).__name__}: {exc}"
             )
             return False
+
+    def start_token_keepalive(self) -> None:
+        """启动 AccessToken 后台保活循环（幂等）。
+
+        在过期前提前调用 get_access_token 续期，保证状态面板在无台风业务时
+        也不会因内存 token 过期而长期显示“鉴权失效”。
+        """
+        if not self.is_channel_enabled:
+            return
+        if (
+            self._token_keepalive_task is not None
+            and not self._token_keepalive_task.done()
+        ):
+            return
+        self._token_keepalive_stop.clear()
+        self._token_keepalive_task = asyncio.create_task(
+            self._token_keepalive_loop(),
+            name="dw_eqsc_token_keepalive",
+        )
+
+    async def stop_token_keepalive(self) -> None:
+        """停止 AccessToken 后台保活循环。"""
+        self._token_keepalive_stop.set()
+        task = self._token_keepalive_task
+        self._token_keepalive_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
+    async def _token_keepalive_loop(self) -> None:
+        """周期性确保内存 AccessToken 未过期。"""
+        logger.debug("[灾害预警] EQSC AccessToken 保活循环已启动")
+        try:
+            while not self._token_keepalive_stop.is_set():
+                if not self.is_channel_enabled:
+                    break
+
+                # 先尝试获取/续期（内部会在提前刷新窗口内真正打网络）
+                try:
+                    token = await self._token_manager.get_access_token()
+                except Exception as exc:
+                    logger.debug(
+                        f"[灾害预警] EQSC AccessToken 保活刷新异常: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                    token = None
+
+                if not token:
+                    sleep_seconds = self._token_keepalive_retry_interval
+                else:
+                    # 在真正过期前 access_advance_seconds 触发续期；
+                    # 再留一点缓冲，避免刚好踩在边界。
+                    remaining = self._token_manager.seconds_until_expiry()
+                    advance = float(
+                        getattr(self._token_manager, "_access_advance_seconds", 60)
+                        or 60
+                    )
+                    sleep_seconds = max(
+                        self._token_keepalive_min_interval,
+                        remaining - advance,
+                    )
+                    # 上限避免极端有效期导致长时间不检查配置变更
+                    sleep_seconds = min(sleep_seconds, 1800.0)
+
+                try:
+                    await asyncio.wait_for(
+                        self._token_keepalive_stop.wait(),
+                        timeout=sleep_seconds,
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            raise
+        finally:
+            logger.debug("[灾害预警] EQSC AccessToken 保活循环已停止")
 
     @staticmethod
     def resolve_connection_counts(service: Any) -> tuple[int, int]:
@@ -569,6 +660,7 @@ class TyphoonEnrichmentService:
 
     async def close(self) -> None:
         """关闭富化服务，释放资源。"""
+        await self.stop_token_keepalive()
         await self._typhoon_client.close()
 
 

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -44,7 +44,15 @@ class TyphoonEnrichmentService:
             message_logger: 可选原始消息记录器，用于落盘 EQSC HTTP 响应。
         """
         eqsc_config = config.get("data_sources", {}).get("eqsc", {})
-        self._enabled = bool(eqsc_config.get("enabled", False))
+        if not isinstance(eqsc_config, dict):
+            eqsc_config = {}
+        channel_enabled, typhoon_enrichment = self.resolve_eqsc_flags(eqsc_config)
+        # 组总闸：控制 EQSC 通道（鉴权/连通/后续子能力入口）
+        self._channel_enabled = channel_enabled
+        # 子能力：台风富化（可独立关闭）
+        self._typhoon_enrichment_enabled = typhoon_enrichment
+        # 兼容旧属性名：历史代码可能读取 _enabled 表示“服务是否工作”
+        self._enabled = self._channel_enabled
         self._token_manager = EqscTokenManager(eqsc_config)
         self._typhoon_client = EqscTyphoonClient(
             self._token_manager,
@@ -65,21 +73,54 @@ class TyphoonEnrichmentService:
         self._circuit_failures = 0
         self._circuit_open_until: float = 0.0
 
+    @staticmethod
+    def resolve_eqsc_flags(eqsc_config: dict[str, Any] | None) -> tuple[bool, bool]:
+        """解析 EQSC 组总闸与台风富化子开关。
+
+        Returns:
+            (channel_enabled, typhoon_enrichment_enabled)
+
+        兼容旧配置：若缺少 typhoon_enrichment 字段，则回退使用 enabled 的值
+        （旧语义下 enabled 同时表示通道与台风富化）。
+        """
+        if not isinstance(eqsc_config, dict):
+            return False, False
+        channel_enabled = bool(eqsc_config.get("enabled", False))
+        if "typhoon_enrichment" in eqsc_config:
+            typhoon_enrichment = bool(eqsc_config.get("typhoon_enrichment"))
+        else:
+            typhoon_enrichment = channel_enabled
+        return channel_enabled, typhoon_enrichment
+
+    @property
+    def is_channel_enabled(self) -> bool:
+        """EQSC 通道是否可用：组总闸开启且 refresh_token 已配置。"""
+        return self._channel_enabled and self._token_manager.is_configured
+
+    @property
+    def is_typhoon_enrichment_enabled(self) -> bool:
+        """台风富化子能力是否开启（不含 token 判定）。"""
+        return bool(self._typhoon_enrichment_enabled)
+
     @property
     def is_enabled(self) -> bool:
-        """检查 EQSC 富化是否启用。"""
-        return self._enabled and self._token_manager.is_configured
+        """台风富化是否可实际工作：通道可用 + 子开关开启。"""
+        return self.is_channel_enabled and self._typhoon_enrichment_enabled
 
     def get_health_status(self) -> dict[str, Any]:
         """返回 EQSC 通道健康快照，供管理端连接状态面板使用。"""
         circuit_open = self._is_circuit_open()
-        # 子数据源启用态只跟随「启用EQSC台风富化」配置开关，
-        # 不把 refresh_token/AccessToken 是否就绪混入“是否启用”。
-        config_enabled = bool(self._enabled)
+        # config_enabled：组总闸（不混入 token）
+        config_enabled = bool(self._channel_enabled)
+        typhoon_enrichment = bool(self._typhoon_enrichment_enabled)
         access_token_valid = bool(self._token_manager.has_valid_access_token)
         return {
-            "enabled": self.is_enabled,
+            # enabled：通道可工作（组总闸 + token 已配置）
+            "enabled": self.is_channel_enabled,
             "config_enabled": config_enabled,
+            "typhoon_enrichment": typhoon_enrichment,
+            # 台风富化实际可工作
+            "typhoon_enrichment_active": self.is_enabled,
             "token_configured": bool(self._token_manager.is_configured),
             "access_token_valid": access_token_valid,
             "circuit_open": circuit_open,
@@ -88,14 +129,14 @@ class TyphoonEnrichmentService:
             "provider": "eqsc",
             # 当前 EQSC 仅展示一个子数据源：中国气象局实时活跃台风
             "sub_sources": {
-                "china_typhoon": config_enabled,
+                "china_typhoon": typhoon_enrichment,
             },
         }
 
     def get_connection_counts(self) -> tuple[int, int]:
         """返回 EQSC 对活跃/总连接数的贡献 (active, total)。
 
-        - total：配置启用且 refresh_token 已配置（is_enabled）时计 1
+        - total：组总闸开启且 refresh_token 已配置时计 1
         - active：当前内存 AccessToken 仍有效时计 1
         """
         health = self.get_health_status()
@@ -106,10 +147,10 @@ class TyphoonEnrichmentService:
     async def warm_up_access_token(self) -> bool:
         """启动后主动预热 AccessToken，避免状态面板长期显示鉴权失效。
 
-        仅在 EQSC 已启用且 token 已配置时请求；不触发业务查询。
+        仅在 EQSC 通道已启用且 token 已配置时请求；不触发业务查询。
         成功返回 True，未启用/失败返回 False。
         """
-        if not self.is_enabled:
+        if not self.is_channel_enabled:
             return False
         try:
             access_token = await self._token_manager.get_access_token()

--- a/core/message/builders/text_message_builder.py
+++ b/core/message/builders/text_message_builder.py
@@ -45,6 +45,8 @@ class TextMessageBuilder:
             "local_monitoring": active_config.get("local_monitoring", {}),
             # 台风展示是否暴露本地距离/逼近信息，对齐地震 local_monitoring.enabled。
             "typhoon_config": active_config.get("typhoon_config", {}),
+            # 会话级 data_sources（如 eqsc.typhoon_enrichment）影响台风展示是否使用 EQSC 富化字段。
+            "data_sources": active_config.get("data_sources", {}),
         }
 
         data = event.event

--- a/core/message/message_manager.py
+++ b/core/message/message_manager.py
@@ -217,10 +217,17 @@ class MessagePushManager:
         """基于运行时配置构建推送规则决策所需状态上下文。"""
         # 规则状态对象按会话维度按需构建，
         # 这样既能复用公共规则组件，又能保留会话级差异化配置。
-        return self._runtime_component_factory.build(
+        policy_state = self._runtime_component_factory.build(
             runtime_config,
             session_id=session_id,
         )
+        # 注入全局 data_sources，供 SourceEnabledRule 做“全局总闸 AND 会话开关”
+        global_config = self.config if isinstance(self.config, dict) else {}
+        global_data_sources = global_config.get("data_sources", {})
+        policy_state["global_data_sources"] = (
+            global_data_sources if isinstance(global_data_sources, dict) else {}
+        )
+        return policy_state
 
     async def _render_with_cache(
         self,

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -145,6 +145,17 @@ class PushExecutionService:
             typhoon_config = runtime_config.get("typhoon_config", {})
             if not isinstance(typhoon_config, dict):
                 typhoon_config = {}
+            data_sources = runtime_config.get("data_sources", {})
+            if not isinstance(data_sources, dict):
+                data_sources = {}
+            eqsc_cfg = data_sources.get("eqsc", {})
+            if not isinstance(eqsc_cfg, dict):
+                eqsc_cfg = {}
+            # 会话级 typhoon_enrichment 影响台风正文是否展示 EQSC 富化字段。
+            if "typhoon_enrichment" in eqsc_cfg:
+                typhoon_enrichment = bool(eqsc_cfg.get("typhoon_enrichment"))
+            else:
+                typhoon_enrichment = bool(eqsc_cfg.get("enabled", True))
             cache_key = json.dumps(
                 {
                     "event_id": event.id,
@@ -187,6 +198,7 @@ class PushExecutionService:
                         "show_local_estimation": typhoon_config.get(
                             "show_local_estimation", False
                         ),
+                        "typhoon_enrichment": typhoon_enrichment,
                     },
                 },
                 sort_keys=True,

--- a/core/network/admin/api/events_routes.py
+++ b/core/network/admin/api/events_routes.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import Any
 
 from astrbot.api import logger
 
+from .....utils.time_converter import TimeConverter
 from ....domain.typhoon import resolve_data_mode
 from ....storage.source_compat import format_event_source_name
 from ..payloads.api_response import ApiResponse
@@ -242,7 +244,8 @@ def register_events_routes(app, *, disaster_service):
             if guard_result is not None:
                 return ApiResponse.success({"events": []})
 
-            db = disaster_service.statistics_manager.db
+            stats_manager = disaster_service.statistics_manager
+            db = stats_manager.db
             # 负数或零表示“不限制”，但这里仍显式映射为数据库可接受的大整数上限。
             if limit <= 0:
                 safe_limit = 9223372036854775807
@@ -250,6 +253,37 @@ def register_events_routes(app, *, disaster_service):
                 safe_limit = min(max(1, limit), 500)
 
             events = await db.get_major_events(safe_limit)
+
+            # S-Net 峰值重大条目（震度 >= 5弱）由峰值服务单独注入，不进通用 events 表。
+            peak_service = getattr(stats_manager, "snet_peak_service", None)
+            if peak_service is not None:
+                try:
+                    snet_events = await peak_service.list_major_peak_events(
+                        limit=safe_limit
+                    )
+                    if snet_events:
+                        events.extend(snet_events)
+
+                        def _major_event_sort_key(item: dict[str, Any]):
+                            parsed = TimeConverter.parse_datetime(item.get("time"))
+                            if parsed is None:
+                                parsed = TimeConverter.parse_datetime(
+                                    item.get("updated_at")
+                                )
+                            ts = parsed.timestamp() if parsed is not None else 0.0
+                            raw_id = item.get("id") or 0
+                            try:
+                                id_part = int(raw_id)
+                            except (TypeError, ValueError):
+                                id_part = 0
+                            return (ts, id_part)
+
+                        events.sort(key=_major_event_sort_key, reverse=True)
+                        if limit > 0:
+                            events = events[:safe_limit]
+                except Exception as snet_exc:
+                    logger.debug(f"[灾害预警] 注入 S-Net 重大峰值失败: {snet_exc}")
+
             # 重大事件列表同样需要台风后处理（图标、来源标签、当前观测等级）
             _enrich_event_list(events)
             return ApiResponse.success({"events": events})

--- a/core/network/admin/api/events_routes.py
+++ b/core/network/admin/api/events_routes.py
@@ -246,11 +246,11 @@ def register_events_routes(app, *, disaster_service):
 
             stats_manager = disaster_service.statistics_manager
             db = stats_manager.db
-            # 负数或零表示“不限制”，但这里仍显式映射为数据库可接受的大整数上限。
+            # 统一钳制查询上限，避免 limit<=0 绕过 500 条保护导致全表扫描。
             if limit <= 0:
-                safe_limit = 9223372036854775807
+                safe_limit = 50
             else:
-                safe_limit = min(max(1, limit), 500)
+                safe_limit = min(max(1, int(limit)), 500)
 
             events = await db.get_major_events(safe_limit)
 

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
+from ....app.services.typhoon_enrichment_service import TyphoonEnrichmentService
 from ....services.query.source_runtime_query_service import SourceRuntimeQueryService
 
 
@@ -69,7 +70,10 @@ class ConnectionsPayloadBuilder:
             if isinstance(raw, dict):
                 eqsc_cfg = raw
 
-        config_enabled = bool(eqsc_cfg.get("enabled", False))
+        channel_enabled, typhoon_enrichment = (
+            TyphoonEnrichmentService.resolve_eqsc_flags(eqsc_cfg)
+        )
+        config_enabled = channel_enabled
         token_configured = bool(str(eqsc_cfg.get("refresh_token", "") or "").strip())
         latency = self.latency_cache.get("eqsc")
 
@@ -89,23 +93,27 @@ class ConnectionsPayloadBuilder:
                 except Exception:
                     health = {}
 
-        # enabled：配置启用且 refresh_token 已配置（服务可工作）
+        # enabled：组总闸开启且 refresh_token 已配置（通道可工作）
         enabled = (
             bool(health.get("enabled"))
             if health
             else (config_enabled and token_configured)
         )
-        # 子数据源启用仅跟随「启用EQSC台风富化」配置开关
         effective_config_enabled = bool(
             health.get("config_enabled", config_enabled) if health else config_enabled
+        )
+        # 子数据源展示只看子开关本身，不与总闸/服务状态做 AND
+        effective_typhoon_enrichment = bool(
+            health.get("typhoon_enrichment", typhoon_enrichment)
+            if health
+            else typhoon_enrichment
         )
         circuit_open = bool(health.get("circuit_open", False))
         access_token_valid = bool(health.get("access_token_valid", False))
         sub_sources = health.get("sub_sources")
         if not isinstance(sub_sources, dict):
-            # 与 FAN 台风开关对齐的展示键；仅一个子数据源
             sub_sources = {
-                "china_typhoon": effective_config_enabled,
+                "china_typhoon": effective_typhoon_enrichment,
             }
 
         # HTTP 通道无 WS 重试语义。
@@ -149,6 +157,7 @@ class ConnectionsPayloadBuilder:
             "circuit_open": circuit_open,
             "token_configured": bool(health.get("token_configured", token_configured)),
             "config_enabled": effective_config_enabled,
+            "typhoon_enrichment": effective_typhoon_enrichment,
             "access_token_valid": access_token_valid,
         }
 

--- a/core/network/http/eqsc_token_manager.py
+++ b/core/network/http/eqsc_token_manager.py
@@ -51,6 +51,18 @@ class EqscTokenManager:
         """
         return bool(self._access_token and time.time() < self._access_token_expires_at)
 
+    @property
+    def access_token_expires_at(self) -> float:
+        """当前缓存 AccessToken 的过期时间戳（epoch 秒）；无缓存时为 0。"""
+        return float(self._access_token_expires_at or 0.0)
+
+    def seconds_until_expiry(self) -> float:
+        """距离 AccessToken 真正过期的剩余秒数；无缓存或已过期时返回 0。"""
+        if not self._access_token:
+            return 0.0
+        remaining = float(self._access_token_expires_at) - time.time()
+        return remaining if remaining > 0.0 else 0.0
+
     def _cached_token_if_usable(
         self, *, current_time: float | None = None, require_advance_margin: bool = True
     ) -> str | None:

--- a/core/parsers/snet_parser.py
+++ b/core/parsers/snet_parser.py
@@ -556,6 +556,7 @@ class SnetParser(BaseParser):
         }
 
         scale_label = ScaleConverter.format_measured_intensity_display(max_shindo)
+        top_station_name = str(top.get("name") or "未知测站")
         domain_event = EarthquakeEvent(
             occurred_at=occurred_at,
             latitude=float(top.get("lat") or 0.0),
@@ -582,7 +583,7 @@ class SnetParser(BaseParser):
             attributes={"timestamp": timestamp, "max_shindo": max_shindo},
         )
 
-        return EventEnvelope(
+        envelope = EventEnvelope(
             identity=identity,
             event=domain_event,
             payload=SourcePayload(
@@ -600,6 +601,18 @@ class SnetParser(BaseParser):
             ),
             metadata=metadata,
         )
+
+        # 默认 DEBUG；达到震度 1（計測震度 >= 0.5）或本轮推送阈值时升为 INFO
+        log_message = (
+            f"[灾害预警] NIED S-Net 海底震度解析成功: {top_station_name}, "
+            f"震度: {scale_label or max_shindo}, 时间: {occurred_at}"
+        )
+        if max_shindo >= 0.5 or max_shindo >= min_shindo:
+            plugin_logger.info(log_message, is_event_linked=True)
+        else:
+            plugin_logger.debug(log_message)
+
+        return envelope
 
 
 # 便于服务层复用

--- a/core/parsers/snet_parser.py
+++ b/core/parsers/snet_parser.py
@@ -602,12 +602,13 @@ class SnetParser(BaseParser):
             metadata=metadata,
         )
 
-        # 默认 DEBUG；达到震度 1（計測震度 >= 0.5）或本轮推送阈值时升为 INFO
+        # 默认 DEBUG；达到震度 1（計測震度 >= 0.5）时升为 INFO。
+        # 推送路径仅在有 triggered 时进入，不再用 min_shindo 判定（否则几乎恒为 INFO）。
         log_message = (
             f"[灾害预警] NIED S-Net 海底震度解析成功: {top_station_name}, "
             f"震度: {scale_label or max_shindo}, 时间: {occurred_at}"
         )
-        if max_shindo >= 0.5 or max_shindo >= min_shindo:
+        if max_shindo >= 0.5:
             plugin_logger.info(log_message, is_event_linked=True)
         else:
             plugin_logger.debug(log_message)

--- a/core/rules/source_rule.py
+++ b/core/rules/source_rule.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ..sources.source_catalog import get_source_entry
 from .base_rule import BaseRule, RuleContext
 from .rule_result import RuleDecision
@@ -15,21 +17,56 @@ class SourceEnabledRule(BaseRule):
 
     rule_name = "source_rule"
 
-    def evaluate(self, context: RuleContext) -> RuleDecision:
-        """检查当前事件对应的数据源是否在会话中开启。
+    @staticmethod
+    def _is_enabled_in_data_sources(
+        source_id: str,
+        data_sources_cfg: Any,
+        *,
+        source_entry,
+    ) -> tuple[bool, str]:
+        """在给定 data_sources 配置中判断是否启用（opt-in）。
 
-        判定口径必须与 SourceRuntimeQueryService.is_source_enabled 对齐：
-        - 分组/子源缺省均为 False（opt-in）
-        - 未注册 source_id / 配置缺失 → 不推送
-        避免数据源在会话差异配置中“未显式开启却被默认放行”。
+        Returns:
+            (enabled, reject_detail)
+        """
+        if not isinstance(data_sources_cfg, dict):
+            return False, "数据源配置无效"
+
+        group_cfg = data_sources_cfg.get(source_entry.config_group, {})
+        if not isinstance(group_cfg, dict):
+            group_cfg = {}
+
+        # 分组总开关：缺省 False
+        if not bool(group_cfg.get("enabled", False)):
+            return False, f"已禁用数据源分组 {source_entry.config_group}"
+
+        # 组内子源开关：缺省 False。
+        # 单源组（S-Net / Global Quake）的 config_key 就是 "enabled"，
+        # 与分组开关同一字段；多源组（Fan/Wolfx/P2P）则检查独立子键。
+        if not bool(group_cfg.get(source_entry.config_key, False)):
+            return False, f"已禁用数据源 {source_id}"
+
+        return True, ""
+
+    def evaluate(self, context: RuleContext) -> RuleDecision:
+        """检查当前事件对应的数据源是否允许推送到该会话。
+
+        推送判定 = 全局总闸 AND 会话生效配置：
+        1. 全局 data_sources 必须开启（采集/轮询总闸；全局关则任何会话都不推）
+        2. 会话生效配置（全局默认 + 会话 override）也必须开启
+
+        因此：
+        - 全局开 + 会话未覆写 → 继承全局，可推送
+        - 全局开 + 会话显式 false → 不推送
+        - 全局关 + 会话显式 true → 仍不推送（会话不能突破全局总闸）
+
+        采集/轮询只看全局；本规则只决定“该会话是否推送”。
         """
         # 单元测试模拟发震，直接通过，绕开全局数据源开关限制
         if context.runtime_config.get("__simulation_bypass_regular_filters", False):
             return RuleDecision.accept(reason="模拟模式跳过数据源开关过滤")
 
         source_id = context.source_id
-        # 读取会话生效配置中的 data_sources（已含全局默认 + 会话 override）
-        data_sources_cfg = context.runtime_config.get("data_sources", {})
         source_entry = get_source_entry(source_id)
 
         # 未注册数据源：不推送，与运行时查询服务一致
@@ -40,38 +77,38 @@ class SourceEnabledRule(BaseRule):
                 context={"source_id": source_id},
             )
 
-        # 配置结构异常时不放行 opt-in 源
-        if not isinstance(data_sources_cfg, dict):
-            return RuleDecision.reject(
-                reason="会话数据源开关关闭",
-                detail=f"会话 {context.session_id or 'global'} 数据源配置无效",
-                context={"source_id": source_id},
-            )
+        session_label = context.session_id or "global"
 
-        group_cfg = data_sources_cfg.get(source_entry.config_group, {})
-        if not isinstance(group_cfg, dict):
-            group_cfg = {}
-
-        # 分组总开关：缺省 False（与 SourceRuntimeQueryService 一致）
-        if not bool(group_cfg.get("enabled", False)):
-            return RuleDecision.reject(
-                reason="会话数据源开关关闭",
-                detail=(
-                    f"会话 {context.session_id or 'global'} 已禁用数据源分组 "
-                    f"{source_entry.config_group}"
-                ),
-                context={"source_id": source_id},
-            )
-
-        # 组内子源开关：缺省 False。
-        # 注意 S-Net 的 config_key 本身就是 "enabled"，与分组开关同一字段，
-        # 此时 group 已通过则子源也通过；其他源（如 wolfx.*）仍检查独立子键。
-        source_enabled = bool(group_cfg.get(source_entry.config_key, False))
-        if source_enabled:
-            return RuleDecision.accept(reason="数据源已启用")
-
-        return RuleDecision.reject(
-            reason="会话数据源开关关闭",
-            detail=f"会话 {context.session_id or 'global'} 已禁用数据源 {source_id}",
-            context={"source_id": source_id},
+        # 1) 全局总闸：policy_state.global_data_sources 由推送侧注入
+        policy_state = (
+            context.policy_state if isinstance(context.policy_state, dict) else {}
         )
+        global_data_sources = policy_state.get("global_data_sources")
+        if global_data_sources is not None:
+            global_enabled, global_detail = self._is_enabled_in_data_sources(
+                source_id,
+                global_data_sources,
+                source_entry=source_entry,
+            )
+            if not global_enabled:
+                return RuleDecision.reject(
+                    reason="会话数据源开关关闭",
+                    detail=f"全局配置{global_detail}",
+                    context={"source_id": source_id},
+                )
+
+        # 2) 会话生效配置（已含全局默认 + 会话 override）
+        data_sources_cfg = context.runtime_config.get("data_sources", {})
+        session_enabled, session_detail = self._is_enabled_in_data_sources(
+            source_id,
+            data_sources_cfg,
+            source_entry=source_entry,
+        )
+        if not session_enabled:
+            return RuleDecision.reject(
+                reason="会话数据源开关关闭",
+                detail=f"会话 {session_label} {session_detail}",
+                context={"source_id": source_id},
+            )
+
+        return RuleDecision.accept(reason="数据源已启用")

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -1050,10 +1050,14 @@ class ConfigValidator:
         if isinstance(fan_studio_cfg, dict):
             ConfigValidator._ensure_bool(fan_studio_cfg, "china_typhoon", True)
 
-        # 校验 EQSC 台风富化数据源配置
+        # 校验 EQSC 数据源配置（组总闸 + 台风富化子开关）
         eqsc_cfg = cfg.get("eqsc")
         if isinstance(eqsc_cfg, dict):
             ConfigValidator._ensure_bool(eqsc_cfg, "enabled", False)
+            # 兼容旧配置：缺少 typhoon_enrichment 时，回退为 enabled 的值
+            if "typhoon_enrichment" not in eqsc_cfg:
+                eqsc_cfg["typhoon_enrichment"] = bool(eqsc_cfg.get("enabled", False))
+            ConfigValidator._ensure_bool(eqsc_cfg, "typhoon_enrichment", False)
 
             # Base URL 校验：确保为非空字符串且去除尾部斜杠
             base_url = eqsc_cfg.get("base_url")
@@ -1105,8 +1109,8 @@ class ConfigValidator:
                 and not str(eqsc_cfg.get("refresh_token", "")).strip()
             ):
                 logger.warning(
-                    "[灾害预警] 配置警告: EQSC 台风富化已启用但未配置 refresh_token，"
-                    "富化服务将无法正常工作，台风将回退到 FAN Studio 基础数据。"
+                    "[灾害预警] 配置警告: EQSC 数据源已启用但未配置 refresh_token，"
+                    "鉴权与台风富化将无法正常工作，台风将回退到 FAN Studio 基础数据。"
                 )
 
         return cfg

--- a/core/services/display/builders/typhoon_context_builder.py
+++ b/core/services/display/builders/typhoon_context_builder.py
@@ -159,6 +159,19 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
         typhoon_config = {}
     show_local_estimation = bool(typhoon_config.get("show_local_estimation", False))
 
+    # 会话级 typhoon_enrichment：关闭时展示层回退 Fan 字段，不暴露 EQSC 轨迹/四象限风圈。
+    data_sources = display_options.get("data_sources", {})
+    if not isinstance(data_sources, dict):
+        data_sources = {}
+    eqsc_cfg = data_sources.get("eqsc", {})
+    if not isinstance(eqsc_cfg, dict):
+        eqsc_cfg = {}
+    if "typhoon_enrichment" in eqsc_cfg:
+        allow_eqsc_enrichment = bool(eqsc_cfg.get("typhoon_enrichment"))
+    else:
+        # 兼容旧配置：缺省时跟随通道 enabled
+        allow_eqsc_enrichment = bool(eqsc_cfg.get("enabled", True))
+
     # 领域事件优先提供规范化台风状态，投影视图只承担旧数据回退。
     payload_details = _extract_typhoon_projection_details(
         metadata,
@@ -183,6 +196,20 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
             display_metadata.pop("typhoon_local_estimation", None)
     else:
         display_metadata.pop("typhoon_local_estimation", None)
+
+    wind_circle = dict(payload_details["wind_circle"] or {})
+    history_track = list(payload_details["history_track"] or [])
+    future_track = list(payload_details["future_track"] or [])
+    data_source = str(payload_details["data_source"] or "fan_studio").strip()
+    if not allow_eqsc_enrichment:
+        # 会话关闭台风富化：仅保留 Fan 单值风圈语义，去掉 EQSC 富化痕迹。
+        wind_circle = {}
+        history_track = []
+        future_track = []
+        data_source = "fan_studio"
+        display_metadata["data_source"] = "fan_studio"
+        display_metadata["info_type"] = "fan"
+        display_metadata["typhoon_data_mode"] = "fan"
 
     return TyphoonDisplayContext(
         event_id=envelope.id,
@@ -252,10 +279,10 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
             if hasattr(domain_event, "radius10")
             else payload_details["radius10"]
         ),
-        wind_circle=dict(payload_details["wind_circle"]),
-        history_track=list(payload_details["history_track"]),
-        future_track=list(payload_details["future_track"]),
-        data_source=str(payload_details["data_source"] or "fan_studio").strip(),
+        wind_circle=wind_circle,
+        history_track=history_track,
+        future_track=future_track,
+        data_source=data_source,
         updated_at=(
             getattr(domain_event, "updated_at", None) or payload_details["updated_at"]
         ),

--- a/core/services/display/service.py
+++ b/core/services/display/service.py
@@ -168,10 +168,11 @@ def build_admin_statistics_projection(
     if not isinstance(stats, dict):
         stats = {}
 
-    # 从原始统计中分离出地震、气象、台风专项统计子节点
+    # 从原始统计中分离出地震、气象、台风、S-Net 专项统计子节点
     earthquake_stats = dict(stats.get("earthquake_stats", {}))
     weather_stats = dict(stats.get("weather_stats", {}))
     typhoon_stats = dict(stats.get("typhoon_stats", {}))
+    snet_stats = dict(stats.get("snet_stats", {}))
     # 取最近250条推送记录用于管理端面板渲染，多余的予以截断以减轻前台压力
     recent_push_records = list(stats.get("recent_pushes", [])[:250])
     # 解析用于地图渲染的地震位置标记列表
@@ -213,6 +214,20 @@ def build_admin_statistics_projection(
             "min_pressure_typhoons": dict(
                 typhoon_stats.get("min_pressure_typhoons", {})
             ),
+        },
+        "snet_stats": {
+            # 已记录峰值的测站数量
+            "station_count": int(snet_stats.get("station_count") or 0),
+            "stations_with_peak": int(snet_stats.get("stations_with_peak") or 0),
+            # 全网历史最大震度测站摘要
+            "global_max": snet_stats.get("global_max"),
+            # 历史最大震度 Top3（按 max_shindo 降序）
+            "top_peaks": list(snet_stats.get("top_peaks") or [])[:3],
+            # 最近峰值刷新列表（截断）
+            "recent_peak_updates": list(snet_stats.get("recent_peak_updates") or [])[
+                :20
+            ],
+            "last_observation_at": snet_stats.get("last_observation_at"),
         },
         # 原始推送历史缓存
         "recent_pushes": recent_push_records,

--- a/core/services/notification/notification_center.py
+++ b/core/services/notification/notification_center.py
@@ -170,7 +170,7 @@ class NotificationCenter:
                 self._cache = next_cache
                 return changed
         except Exception as e:
-            logger.warning(f"[灾害预警] 同步远端通知失败: {e} (可忽略)")
+            logger.debug(f"[灾害预警] 同步远端通知失败: {e} (可忽略)")
             return False
         finally:
             async with self._sync_state_lock:

--- a/core/services/snet/__init__.py
+++ b/core/services/snet/__init__.py
@@ -2,4 +2,13 @@
 
 from .snet_poll_service import SnetPollService
 
-__all__ = ["SnetPollService"]
+__all__ = ["SnetPeakService", "SnetPollService"]
+
+
+def __getattr__(name: str):
+    """延迟导出 SnetPeakService，避免与 storage 形成包级循环导入。"""
+    if name == "SnetPeakService":
+        from .snet_peak_service import SnetPeakService
+
+        return SnetPeakService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/services/snet/snet_peak_service.py
+++ b/core/services/snet/snet_peak_service.py
@@ -1,0 +1,209 @@
+"""
+S-Net 测站峰值观测服务。
+
+将连续观测网数据写入峰值仓储，并维护内存 snet_stats。
+不进入通用 events / total_events 统计链路。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from astrbot.api import logger
+
+from ....utils.converters import ScaleConverter
+from ...domain.event_models import EarthquakeEvent, EventEnvelope
+from ...storage.snet_peak_repository import SnetPeakRepository
+
+
+class SnetPeakService:
+    """S-Net 峰值观测与统计服务。"""
+
+    SOURCE_ID = "snet_msil"
+    # 重大事件回溯阈值：日本震度 5弱（計測震度 >= 4.5）
+    MAJOR_SHINDO_THRESHOLD = SnetPeakRepository.MAJOR_SHINDO_THRESHOLD
+
+    def __init__(self, statistics_manager):
+        self.manager = statistics_manager
+        self.repository = SnetPeakRepository(statistics_manager.db)
+
+    @staticmethod
+    def is_snet_event(event: EventEnvelope) -> bool:
+        """判断是否为 S-Net 观测事件。"""
+        source_id = str(getattr(event, "source_id", "") or "").strip().lower()
+        if source_id == SnetPeakService.SOURCE_ID:
+            return True
+        identity = getattr(event, "identity", None)
+        identity_source = str(getattr(identity, "source_id", "") or "").strip().lower()
+        return identity_source == SnetPeakService.SOURCE_ID
+
+    async def refresh_stats_from_database(self) -> None:
+        """从峰值表重建内存 snet_stats。"""
+        summary = await self.repository.build_stats_summary()
+        snet_stats = self.manager.stats.setdefault("snet_stats", {})
+        snet_stats["station_count"] = int(summary.get("station_count") or 0)
+        snet_stats["stations_with_peak"] = int(summary.get("stations_with_peak") or 0)
+        snet_stats["global_max"] = summary.get("global_max")
+        snet_stats["top_peaks"] = list(summary.get("top_peaks") or [])[:3]
+        snet_stats["recent_peak_updates"] = list(
+            summary.get("recent_peak_updates") or []
+        )
+        snet_stats["last_observation_at"] = summary.get("last_observation_at")
+
+    async def observe_stations(
+        self,
+        stations: list[dict[str, Any]],
+        *,
+        observed_at: str | datetime | None = None,
+        hit_threshold: float | None = None,
+    ) -> dict[str, Any]:
+        """观测一批测站并更新峰值表与内存统计。"""
+        observed_at_text = self._normalize_observed_at(observed_at)
+        results = await self.repository.upsert_station_peaks_batch(
+            stations,
+            observed_at=observed_at_text,
+            hit_threshold=hit_threshold,
+        )
+        peak_updates = [row for row in results if row.get("peak_updated")]
+        await self.refresh_stats_from_database()
+
+        # 用本轮刷新的峰值补 recent 列表头部（保持“刚刷新”语义）
+        if peak_updates:
+            recent = self.manager.stats.setdefault("snet_stats", {}).setdefault(
+                "recent_peak_updates", []
+            )
+            for row in sorted(
+                peak_updates,
+                key=lambda item: float(item.get("max_shindo") or -999.0),
+                reverse=True,
+            ):
+                view = {
+                    "station_id": str(row.get("station_id") or ""),
+                    "station_name": str(
+                        row.get("station_name") or row.get("station_id") or ""
+                    ),
+                    "shindo": float(row.get("max_shindo") or 0.0),
+                    "shindo_label": ScaleConverter.format_measured_intensity_display(
+                        row.get("max_shindo")
+                    ),
+                    "at": str(row.get("max_shindo_at") or observed_at_text),
+                }
+                recent = [
+                    item
+                    for item in recent
+                    if str(item.get("station_id") or "") != view["station_id"]
+                ]
+                recent.insert(0, view)
+            self.manager.stats["snet_stats"]["recent_peak_updates"] = recent[:20]
+            self.manager.stats["snet_stats"]["last_observation_at"] = observed_at_text
+
+        return {
+            "observed_at": observed_at_text,
+            "processed": len(results),
+            "peak_updates": len(peak_updates),
+            "results": results,
+        }
+
+    async def observe_event(self, event: EventEnvelope) -> dict[str, Any]:
+        """从 EventEnvelope 提取测站并写入峰值。"""
+        stations = self._extract_stations(event)
+        observed_at = self._extract_observed_at(event)
+        # hit_count 使用推送过滤阈值（若有），否则不累计
+        hit_threshold = None
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        raw_min = metadata.get("min_shindo")
+        if raw_min is not None:
+            try:
+                hit_threshold = float(raw_min)
+            except (TypeError, ValueError):
+                hit_threshold = None
+
+        result = await self.observe_stations(
+            stations,
+            observed_at=observed_at,
+            hit_threshold=hit_threshold,
+        )
+        logger.debug(
+            "[灾害预警] S-Net 峰值观测完成 processed=%s peak_updates=%s",
+            result.get("processed"),
+            result.get("peak_updates"),
+        )
+        return result
+
+    async def clear_peaks(self) -> bool:
+        """清空峰值表并重置内存统计。"""
+        ok = await self.repository.clear_all()
+        snet_stats = self.manager.stats.setdefault("snet_stats", {})
+        snet_stats["station_count"] = 0
+        snet_stats["stations_with_peak"] = 0
+        snet_stats["global_max"] = None
+        snet_stats["top_peaks"] = []
+        snet_stats["recent_peak_updates"] = []
+        snet_stats["last_observation_at"] = None
+        return ok
+
+    async def list_major_peak_events(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """重大事件回溯用：震度 >= 5弱 的测站峰值投影。"""
+        return await self.repository.list_major_peak_events(
+            min_shindo=self.MAJOR_SHINDO_THRESHOLD,
+            limit=limit,
+        )
+
+    @staticmethod
+    def _extract_stations(event: EventEnvelope) -> list[dict[str, Any]]:
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        candidates = metadata.get("stations")
+        if not isinstance(candidates, list) or not candidates:
+            domain = event.event
+            domain_meta = getattr(domain, "metadata", None)
+            if isinstance(domain_meta, dict):
+                candidates = domain_meta.get("stations")
+        if not isinstance(candidates, list):
+            return []
+        return [item for item in candidates if isinstance(item, dict)]
+
+    @staticmethod
+    def _extract_observed_at(event: EventEnvelope) -> str:
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        timestamp = str(metadata.get("timestamp") or "").strip()
+        if timestamp:
+            # MSIL 瓦片时间戳：YYYYMMDDHHMM00（UTC）
+            try:
+                dt = datetime.strptime(timestamp, "%Y%m%d%H%M00").replace(
+                    tzinfo=timezone.utc
+                )
+                return dt.isoformat()
+            except (TypeError, ValueError):
+                pass
+
+        domain = event.event
+        if isinstance(domain, EarthquakeEvent) and domain.occurred_at is not None:
+            occurred = domain.occurred_at
+            if occurred.tzinfo is None:
+                occurred = occurred.replace(tzinfo=timezone.utc)
+            return occurred.isoformat()
+
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _normalize_observed_at(value: str | datetime | None) -> str:
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            return dt.isoformat()
+        text = str(value or "").strip()
+        if text:
+            # 兼容瓦片时间戳
+            if len(text) == 14 and text.isdigit():
+                try:
+                    dt = datetime.strptime(text, "%Y%m%d%H%M00").replace(
+                        tzinfo=timezone.utc
+                    )
+                    return dt.isoformat()
+                except ValueError:
+                    pass
+            return text
+        return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = ["SnetPeakService"]

--- a/core/services/snet/snet_peak_service.py
+++ b/core/services/snet/snet_peak_service.py
@@ -132,8 +132,13 @@ class SnetPeakService:
         return result
 
     async def clear_peaks(self) -> bool:
-        """清空峰值表并重置内存统计。"""
+        """清空峰值表并重置内存统计。
+
+        仅在数据库清空成功后才重置内存，避免前端显示已清空但旧峰值仍可恢复。
+        """
         ok = await self.repository.clear_all()
+        if not ok:
+            return False
         snet_stats = self.manager.stats.setdefault("snet_stats", {})
         snet_stats["station_count"] = 0
         snet_stats["stations_with_peak"] = 0
@@ -141,7 +146,7 @@ class SnetPeakService:
         snet_stats["top_peaks"] = []
         snet_stats["recent_peak_updates"] = []
         snet_stats["last_observation_at"] = None
-        return ok
+        return True
 
     async def list_major_peak_events(self, *, limit: int = 100) -> list[dict[str, Any]]:
         """重大事件回溯用：震度 >= 5弱 的测站峰值投影。"""

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -177,20 +177,19 @@ class SnetPollService:
             "min_shindo": threshold,
         }
 
-        stations: list[dict[str, Any]] | None = None
-        # 峰值归档与推送解耦：轮询时始终解码测站，保证历史最大震度可更新
-        if parse_stations or emit_event:
-            stations = self._get_or_decode_stations(tiles_payload)
-            if stations is not None:
-                raw_dict["stations"] = stations
-                raw_dict["triggered"] = [
-                    s for s in stations if float(s.get("shindo", -999.0)) >= threshold
-                ]
-                await self._observe_station_peaks(
-                    stations,
-                    timestamp=str(tiles_payload.get("timestamp") or ""),
-                    hit_threshold=threshold,
-                )
+        # 峰值归档与推送解耦：只要拿到瓦片就解码并写入峰值档案，
+        # 不依赖 emit_event / parse_stations，保证无推送时历史最大震度仍可更新。
+        stations = self._get_or_decode_stations(tiles_payload)
+        if stations is not None:
+            raw_dict["stations"] = stations
+            raw_dict["triggered"] = [
+                s for s in stations if float(s.get("shindo", -999.0)) >= threshold
+            ]
+            await self._observe_station_peaks(
+                stations,
+                timestamp=str(tiles_payload.get("timestamp") or ""),
+                hit_threshold=threshold,
+            )
 
         if emit_event:
             await self._emit_event(raw_dict)

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -35,6 +35,8 @@ class SnetPollService:
     SOURCE_ID = "snet_msil"
     DEFAULT_INTERVAL_SECONDS = 60
     TILE_NAMES = (("y11", "11"), ("y12", "12"))
+    # 推送去重：仅比较震度最高的前 N 个触发测站（名称 + 震度）
+    PUSH_DEDUP_TOP_N = 5
     # 瓦片快照最短/最长 TTL（秒）；实际 TTL 会结合 poll_interval 收敛
     MIN_TILE_CACHE_TTL = 30.0
     MAX_TILE_CACHE_TTL = 600.0
@@ -176,6 +178,7 @@ class SnetPollService:
         }
 
         stations: list[dict[str, Any]] | None = None
+        # 峰值归档与推送解耦：轮询时始终解码测站，保证历史最大震度可更新
         if parse_stations or emit_event:
             stations = self._get_or_decode_stations(tiles_payload)
             if stations is not None:
@@ -183,11 +186,45 @@ class SnetPollService:
                 raw_dict["triggered"] = [
                     s for s in stations if float(s.get("shindo", -999.0)) >= threshold
                 ]
+                await self._observe_station_peaks(
+                    stations,
+                    timestamp=str(tiles_payload.get("timestamp") or ""),
+                    hit_threshold=threshold,
+                )
 
         if emit_event:
             await self._emit_event(raw_dict)
 
         return raw_dict
+
+    async def _observe_station_peaks(
+        self,
+        stations: list[dict[str, Any]],
+        *,
+        timestamp: str,
+        hit_threshold: float | None = None,
+    ) -> None:
+        """将本轮测站观测写入峰值档案（不依赖是否触发推送）。"""
+        stats_manager = getattr(self.service, "statistics_manager", None)
+        peak_service = (
+            getattr(stats_manager, "snet_peak_service", None) if stats_manager else None
+        )
+        if peak_service is None:
+            return
+        try:
+            if stats_manager is not None and not getattr(
+                stats_manager, "_db_initialized", False
+            ):
+                await stats_manager.initialize()
+            await peak_service.observe_stations(
+                stations,
+                observed_at=timestamp,
+                hit_threshold=hit_threshold,
+            )
+            if stats_manager is not None and hasattr(stats_manager, "save_stats"):
+                stats_manager.save_stats()
+        except Exception as exc:
+            logger.debug(f"[灾害预警] S-Net 峰值观测旁路写入失败: {exc}")
 
     async def fetch_for_query(
         self,
@@ -378,9 +415,40 @@ class SnetPollService:
             )
         return normalized
 
+    @classmethod
+    def _build_push_fingerprint(cls, triggered: list[dict[str, Any]]) -> str:
+        """构建推送去重指纹：仅看震度最高的前 N 个测站（名称 + 震度）。
+
+        不含瓦片时间戳，避免“每分钟时间变了但 Top-N 未变”仍刷屏。
+        """
+        ranked: list[tuple[str, float]] = []
+        for item in triggered or []:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
+            try:
+                shindo = round(float(item.get("shindo", -999.0)), 3)
+            except (TypeError, ValueError):
+                continue
+            ranked.append((name, shindo))
+
+        # 先按震度降序，同震度按名称稳定排序，再截取 Top-N
+        ranked.sort(key=lambda row: (-row[1], row[0]))
+        top_n = ranked[: cls.PUSH_DEDUP_TOP_N]
+        return json.dumps(
+            {
+                "top": [{"name": name, "shindo": shindo} for name, shindo in top_n],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
     async def _emit_event(self, raw_dict: dict[str, Any]) -> None:
         """解析并送入统一事件流水线。"""
-        # 指纹：同一分钟 + 触发测站集合 + 最大震度，避免无变化重复推送
+        # 指纹：仅比较触发测站中震度最高的前 5 个（名称+震度），无变化则不推送
         triggered = (
             raw_dict.get("triggered")
             if isinstance(raw_dict.get("triggered"), list)
@@ -393,19 +461,9 @@ class SnetPollService:
             )
             return
 
-        top = max(triggered, key=lambda s: float(s.get("shindo", -999.0)))
-        fingerprint = json.dumps(
-            {
-                "ts": raw_dict.get("timestamp"),
-                "max": round(float(top.get("shindo", 0.0)), 3),
-                "count": len(triggered),
-                "names": sorted(str(s.get("name") or "") for s in triggered[:20]),
-            },
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        fingerprint = self._build_push_fingerprint(triggered)
         if fingerprint == self._last_payload_fingerprint:
-            logger.debug("[灾害预警] S-Net 载荷未变化，跳过推送")
+            logger.debug("[灾害预警] S-Net Top-5 测站未变化，跳过推送")
             return
 
         message = json.dumps(raw_dict, ensure_ascii=False)
@@ -414,12 +472,10 @@ class SnetPollService:
             return
 
         event_id = getattr(event, "id", None)
-        if (
-            event_id
-            and event_id == self._last_event_id
-            and fingerprint == self._last_payload_fingerprint
-        ):
-            return
+        if event_id and event_id == self._last_event_id:
+            # 同 event_id 且指纹已在上方判等；此处兜底防止重复投递
+            if fingerprint == self._last_payload_fingerprint:
+                return
 
         self._last_payload_fingerprint = fingerprint
         self._last_event_id = event_id

--- a/core/services/telemetry/telemetry_service.py
+++ b/core/services/telemetry/telemetry_service.py
@@ -272,7 +272,7 @@ class TelemetryManager:
                             self._last_429_time is None
                             or (now - self._last_429_time).total_seconds() > 600
                         ):
-                            logger.warning("[灾害预警] 遥测请求频率超限")
+                            logger.debug("[灾害预警] 遥测请求频率超限")
                             self._last_429_time = now
                     else:
                         logger.debug(

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -212,6 +212,25 @@ class DatabaseManager:
             )
             """
         )
+        # S-Net 测站峰值状态表：每个测站一行，持续 upsert，不进入通用 events 事件流
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS snet_station_peaks (
+                station_id      TEXT PRIMARY KEY,
+                station_name    TEXT NOT NULL,
+                lat             REAL,
+                lon             REAL,
+                max_shindo      REAL NOT NULL,
+                max_shindo_at   TEXT NOT NULL,
+                last_shindo     REAL,
+                last_seen_at    TEXT,
+                first_seen_at   TEXT,
+                hit_count       INTEGER DEFAULT 0,
+                updated_at      TEXT NOT NULL
+            )
+            """
+        )
+
         # 索引集中覆盖事件标识、来源、类型、时间等高频检索维度，加速分页与汇总查询
         for sql in (
             "CREATE INDEX IF NOT EXISTS idx_ev_real_id   ON events(real_event_id)",
@@ -223,6 +242,8 @@ class DatabaseManager:
             "CREATE INDEX IF NOT EXISTS idx_ev_wind_speed ON events(wind_speed)",
             "CREATE INDEX IF NOT EXISTS idx_ev_is_major  ON events(is_major)",
             "CREATE INDEX IF NOT EXISTS idx_upd_event_id ON event_updates(event_id)",
+            "CREATE INDEX IF NOT EXISTS idx_snet_peaks_shindo ON snet_station_peaks(max_shindo DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_snet_peaks_time ON snet_station_peaks(max_shindo_at DESC)",
         ):
             await cursor.execute(sql)
 
@@ -1005,7 +1026,11 @@ class DatabaseManager:
         return transitions
 
     async def get_major_events(self, limit: int = 100) -> list[dict[str, Any]]:
-        """获取重大事件，并将台风等级转折投影为独立时间轴点。"""
+        """获取重大事件，并将台风等级转折投影为独立时间轴点。
+
+        注意：S-Net 峰值重大条目不在本方法内拼接，由上层（events_routes /
+        StatisticsManager）通过 SnetPeakService 单独注入，避免仓储职责回膨胀。
+        """
         try:
             cursor = await self.connection.cursor()
             await cursor.execute(

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -48,6 +48,12 @@ class SessionConfigManager:
         "session_name",
     }
 
+    # 仅允许全局配置修改的嵌套路径（会话 override 写入时强制剥离）。
+    # 例如 S-Net 轮询间隔影响全局采集节奏，不允许按会话分叉。
+    GLOBAL_ONLY_NESTED_PATHS: tuple[tuple[str, ...], ...] = (
+        ("data_sources", "snet", "poll_interval_seconds"),
+    )
+
     def __init__(self, default_config_ref: dict[str, Any]):
         """初始化会话差异配置管理器并加载已保存的差异补丁。"""
         self.default_config_ref = default_config_ref
@@ -224,6 +230,40 @@ class SessionConfigManager:
         if key == "province" and isinstance(value, str):
             return True
         return False
+
+    @classmethod
+    def _strip_global_only_fields(cls, value: Any) -> Any:
+        """从会话 patch / effective 中剥离仅全局可改的嵌套字段。"""
+        if not isinstance(value, dict):
+            return value
+
+        result = copy.deepcopy(value)
+        for path in cls.GLOBAL_ONLY_NESTED_PATHS:
+            cursor: Any = result
+            parents: list[tuple[dict[str, Any], str]] = []
+            valid = True
+            for key in path:
+                if not isinstance(cursor, dict) or key not in cursor:
+                    valid = False
+                    break
+                parents.append((cursor, key))
+                cursor = cursor[key]
+            if not valid or not parents:
+                continue
+
+            # 删除叶子字段
+            leaf_parent, leaf_key = parents[-1]
+            leaf_parent.pop(leaf_key, None)
+
+            # 自底向上清理因剥离产生的空 dict
+            for parent, key in reversed(parents[:-1]):
+                child = parent.get(key)
+                if isinstance(child, dict) and not child:
+                    parent.pop(key, None)
+                else:
+                    break
+
+        return result
 
     def _prune_to_schema(self, value: Any, schema_node: dict[str, Any] | None) -> Any:
         """按 schema 递归裁剪新提交的配置，仅阻止未来污染，不清理已存旧字段。"""
@@ -472,6 +512,7 @@ class SessionConfigManager:
         - 顶层仅保留会话白名单键
         - 对 schema 内对象块递归裁剪新写入字段
         - 若旧 override 中已存在历史兼容字段，则原样保留，不做清空/重置
+        - 剥离仅全局可改字段（如 S-Net 轮询间隔）
         - 递归移除空 dict
         """
         if patch is None:
@@ -480,7 +521,17 @@ class SessionConfigManager:
         if not isinstance(patch, dict):
             return patch
 
+        if depth == 0:
+            patch = self._strip_global_only_fields(patch)
+            if not isinstance(patch, dict):
+                return patch
+
         legacy_patch = preserve_legacy if isinstance(preserve_legacy, dict) else {}
+        if depth == 0 and isinstance(legacy_patch, dict):
+            legacy_patch = self._strip_global_only_fields(legacy_patch)
+            if not isinstance(legacy_patch, dict):
+                legacy_patch = {}
+
         sanitized: dict[str, Any] = {}
         active_schema = self.schema if isinstance(self.schema, dict) else {}
 
@@ -501,23 +552,52 @@ class SessionConfigManager:
                     merged_child = copy.deepcopy(legacy_child)
                     merged_child.update(child)
                     child = merged_child
+                if isinstance(child, dict):
+                    stripped = self._strip_global_only_fields({key: child})
+                    if isinstance(stripped, dict):
+                        child = stripped.get(key, child)
             else:
                 child = self._sanitize_patch(val, depth + 1, legacy_child)
 
             if isinstance(child, dict) and not child:
                 if isinstance(legacy_child, dict) and legacy_child:
-                    sanitized[key] = copy.deepcopy(legacy_child)
+                    cleaned_legacy = self._strip_global_only_fields({key: legacy_child})
+                    legacy_value = (
+                        cleaned_legacy.get(key)
+                        if isinstance(cleaned_legacy, dict)
+                        else None
+                    )
+                    if isinstance(legacy_value, dict) and legacy_value:
+                        sanitized[key] = legacy_value
                 continue
             if child is not None:
                 sanitized[key] = child
             elif legacy_child is not None:
-                sanitized[key] = copy.deepcopy(legacy_child)
+                cleaned_legacy = self._strip_global_only_fields({key: legacy_child})
+                legacy_value = (
+                    cleaned_legacy.get(key)
+                    if isinstance(cleaned_legacy, dict)
+                    else None
+                )
+                if legacy_value is not None:
+                    sanitized[key] = legacy_value
 
         if depth == 0:
             for key, legacy_value in legacy_patch.items():
                 if key in sanitized:
                     continue
                 if key in self.ALLOWED_ROOT_KEYS:
-                    sanitized[key] = copy.deepcopy(legacy_value)
+                    cleaned_legacy = self._strip_global_only_fields({key: legacy_value})
+                    value = (
+                        cleaned_legacy.get(key)
+                        if isinstance(cleaned_legacy, dict)
+                        else None
+                    )
+                    if value is not None:
+                        sanitized[key] = value
+
+            sanitized = self._strip_global_only_fields(sanitized)
+            if not isinstance(sanitized, dict):
+                return {}
 
         return sanitized

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -49,9 +49,14 @@ class SessionConfigManager:
     }
 
     # 仅允许全局配置修改的嵌套路径（会话 override 写入时强制剥离）。
-    # 例如 S-Net 轮询间隔影响全局采集节奏，不允许按会话分叉。
+    # S-Net 轮询间隔、EQSC 通道鉴权参数影响全局运行态；
+    # typhoon_enrichment 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
     GLOBAL_ONLY_NESTED_PATHS: tuple[tuple[str, ...], ...] = (
         ("data_sources", "snet", "poll_interval_seconds"),
+        ("data_sources", "eqsc", "enabled"),
+        ("data_sources", "eqsc", "base_url"),
+        ("data_sources", "eqsc", "refresh_token"),
+        ("data_sources", "eqsc", "cache_ttl"),
     )
 
     def __init__(self, default_config_ref: dict[str, Any]):
@@ -449,7 +454,11 @@ class SessionConfigManager:
     def update_session_from_effective(
         self, umo: str, effective_config: dict[str, Any]
     ) -> None:
-        """根据提交的生效配置反推并保存差异补丁。"""
+        """根据提交的生效配置反推并保存差异补丁。
+
+        effective 全量回写以 compute_diff 结果为权威：与全局默认相同的字段
+        必须从 override 中消失，不能再通过 preserve_legacy 把旧差异补回。
+        """
         if not isinstance(effective_config, dict):
             raise ValueError("effective_config 必须是对象")
 
@@ -457,10 +466,15 @@ class SessionConfigManager:
         session_effective = self._sanitize_patch(copy.deepcopy(effective_config)) or {}
 
         patch = self.compute_diff(default_conf, session_effective)
-        patch = self._sanitize_patch(
-            patch, preserve_legacy=self._overrides.get(umo, {})
-        )
-        self.set_override(umo, patch)
+        if not isinstance(patch, dict):
+            patch = {}
+        # 不传 preserve_legacy：用户把某字段改回全局默认时，应真正清除该 override 键
+        patch = self._sanitize_patch(patch, preserve_legacy=None)
+        if patch:
+            self._overrides[umo] = patch
+        else:
+            self._overrides.pop(umo, None)
+        self._save()
 
     @classmethod
     def deep_merge(cls, base: Any, patch: Any) -> Any:

--- a/core/storage/snet_peak_repository.py
+++ b/core/storage/snet_peak_repository.py
@@ -30,6 +30,171 @@ class SnetPeakRepository:
     async def _connection(self):
         return await self.db._ensure_connection()
 
+    @staticmethod
+    def _normalize_station_observation(
+        station: dict[str, Any],
+        *,
+        observed_at: str,
+        hit_threshold: float | None = None,
+    ) -> dict[str, Any] | None:
+        """规范化单站观测字段；非法数据返回 None。"""
+        station_id = str(
+            station.get("station_id")
+            or station.get("name")
+            or station.get("station_name")
+            or ""
+        ).strip()
+        if not station_id:
+            return None
+
+        try:
+            shindo = float(station.get("shindo"))
+        except (TypeError, ValueError):
+            return None
+
+        observed_at_text = str(observed_at or "").strip()
+        if not observed_at_text:
+            return None
+
+        station_name = (
+            str(
+                station.get("station_name") or station.get("name") or station_id
+            ).strip()
+            or station_id
+        )
+        try:
+            lat = float(station.get("lat")) if station.get("lat") is not None else None
+        except (TypeError, ValueError):
+            lat = None
+        try:
+            lon = float(station.get("lon")) if station.get("lon") is not None else None
+        except (TypeError, ValueError):
+            lon = None
+
+        hit_increment = 0
+        if hit_threshold is not None:
+            try:
+                if shindo >= float(hit_threshold):
+                    hit_increment = 1
+            except (TypeError, ValueError):
+                hit_increment = 0
+
+        return {
+            "station_id": station_id,
+            "station_name": station_name,
+            "lat": lat,
+            "lon": lon,
+            "shindo": shindo,
+            "observed_at": observed_at_text,
+            "hit_increment": hit_increment,
+        }
+
+    async def _upsert_station_peak_on_cursor(
+        self,
+        cursor,
+        station: dict[str, Any],
+        *,
+        observed_at: str,
+        hit_threshold: float | None = None,
+    ) -> dict[str, Any] | None:
+        """在已有 cursor 上执行单站原子 upsert（不单独 commit）。"""
+        normalized = self._normalize_station_observation(
+            station,
+            observed_at=observed_at,
+            hit_threshold=hit_threshold,
+        )
+        if normalized is None:
+            return None
+
+        station_id = normalized["station_id"]
+        station_name = normalized["station_name"]
+        lat = normalized["lat"]
+        lon = normalized["lon"]
+        shindo = float(normalized["shindo"])
+        observed_at_text = str(normalized["observed_at"])
+        hit_increment = int(normalized["hit_increment"])
+
+        await cursor.execute(
+            """
+            SELECT station_id, max_shindo, max_shindo_at, hit_count
+            FROM snet_station_peaks
+            WHERE station_id = ?
+            LIMIT 1
+            """,
+            (station_id,),
+        )
+        existing = await cursor.fetchone()
+        created = existing is None
+        if existing is None:
+            old_max = None
+            old_max_at = observed_at_text
+            old_hit = 0
+        else:
+            old_max = float(existing["max_shindo"] or 0.0)
+            old_max_at = str(existing["max_shindo_at"] or observed_at_text)
+            old_hit = int(existing["hit_count"] or 0)
+
+        peak_updated = created or (old_max is None) or (shindo > float(old_max))
+        new_max = shindo if peak_updated else float(old_max or 0.0)
+        new_max_at = observed_at_text if peak_updated else old_max_at
+        new_hit = old_hit + hit_increment
+
+        # 单条原子 upsert：避免 SELECT 与 UPDATE 之间被并发写穿。
+        await cursor.execute(
+            """
+            INSERT INTO snet_station_peaks (
+                station_id, station_name, lat, lon,
+                max_shindo, max_shindo_at,
+                last_shindo, last_seen_at,
+                first_seen_at, hit_count, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(station_id) DO UPDATE SET
+                station_name = excluded.station_name,
+                lat = COALESCE(excluded.lat, snet_station_peaks.lat),
+                lon = COALESCE(excluded.lon, snet_station_peaks.lon),
+                max_shindo = CASE
+                    WHEN excluded.max_shindo > snet_station_peaks.max_shindo
+                    THEN excluded.max_shindo
+                    ELSE snet_station_peaks.max_shindo
+                END,
+                max_shindo_at = CASE
+                    WHEN excluded.max_shindo > snet_station_peaks.max_shindo
+                    THEN excluded.max_shindo_at
+                    ELSE snet_station_peaks.max_shindo_at
+                END,
+                last_shindo = excluded.last_shindo,
+                last_seen_at = excluded.last_seen_at,
+                hit_count = snet_station_peaks.hit_count + excluded.hit_count,
+                updated_at = excluded.updated_at
+            """,
+            (
+                station_id,
+                station_name,
+                lat,
+                lon,
+                shindo,
+                observed_at_text,
+                shindo,
+                observed_at_text,
+                observed_at_text,
+                hit_increment,
+                observed_at_text,
+            ),
+        )
+        return {
+            "station_id": station_id,
+            "station_name": station_name,
+            "lat": lat,
+            "lon": lon,
+            "created": created,
+            "peak_updated": peak_updated,
+            "max_shindo": new_max,
+            "max_shindo_at": new_max_at,
+            "last_shindo": shindo,
+            "last_seen_at": observed_at_text,
+            "hit_count": new_hit,
+        }
+
     async def upsert_station_peak(
         self,
         station: dict[str, Any],
@@ -45,156 +210,18 @@ class SnetPeakRepository:
         - hit_count：当 shindo >= hit_threshold 时累加（可选）
         """
         try:
-            station_id = str(
-                station.get("station_id")
-                or station.get("name")
-                or station.get("station_name")
-                or ""
-            ).strip()
-            if not station_id:
-                return None
-
-            try:
-                shindo = float(station.get("shindo"))
-            except (TypeError, ValueError):
-                return None
-
-            observed_at_text = str(observed_at or "").strip()
-            if not observed_at_text:
-                return None
-
-            station_name = (
-                str(
-                    station.get("station_name") or station.get("name") or station_id
-                ).strip()
-                or station_id
-            )
-            try:
-                lat = (
-                    float(station.get("lat"))
-                    if station.get("lat") is not None
-                    else None
-                )
-            except (TypeError, ValueError):
-                lat = None
-            try:
-                lon = (
-                    float(station.get("lon"))
-                    if station.get("lon") is not None
-                    else None
-                )
-            except (TypeError, ValueError):
-                lon = None
-
-            hit_increment = 0
-            if hit_threshold is not None:
-                try:
-                    if shindo >= float(hit_threshold):
-                        hit_increment = 1
-                except (TypeError, ValueError):
-                    hit_increment = 0
-
             connection = await self._connection()
             cursor = await connection.cursor()
-            await cursor.execute(
-                """
-                SELECT station_id, max_shindo, max_shindo_at, hit_count, first_seen_at
-                FROM snet_station_peaks
-                WHERE station_id = ?
-                LIMIT 1
-                """,
-                (station_id,),
+            row = await self._upsert_station_peak_on_cursor(
+                cursor,
+                station,
+                observed_at=observed_at,
+                hit_threshold=hit_threshold,
             )
-            existing = await cursor.fetchone()
-
-            if existing is None:
-                await cursor.execute(
-                    """
-                    INSERT INTO snet_station_peaks (
-                        station_id, station_name, lat, lon,
-                        max_shindo, max_shindo_at,
-                        last_shindo, last_seen_at,
-                        first_seen_at, hit_count, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        station_id,
-                        station_name,
-                        lat,
-                        lon,
-                        shindo,
-                        observed_at_text,
-                        shindo,
-                        observed_at_text,
-                        observed_at_text,
-                        hit_increment,
-                        observed_at_text,
-                    ),
-                )
-                await connection.commit()
-                return {
-                    "station_id": station_id,
-                    "station_name": station_name,
-                    "lat": lat,
-                    "lon": lon,
-                    "created": True,
-                    "peak_updated": True,
-                    "max_shindo": shindo,
-                    "max_shindo_at": observed_at_text,
-                    "last_shindo": shindo,
-                    "last_seen_at": observed_at_text,
-                    "hit_count": hit_increment,
-                }
-
-            old_max = float(existing["max_shindo"] or 0.0)
-            old_max_at = str(existing["max_shindo_at"] or observed_at_text)
-            old_hit = int(existing["hit_count"] or 0)
-            peak_updated = shindo > old_max
-            new_max = shindo if peak_updated else old_max
-            new_max_at = observed_at_text if peak_updated else old_max_at
-            new_hit = old_hit + hit_increment
-
-            await cursor.execute(
-                """
-                UPDATE snet_station_peaks
-                SET station_name = ?,
-                    lat = COALESCE(?, lat),
-                    lon = COALESCE(?, lon),
-                    max_shindo = ?,
-                    max_shindo_at = ?,
-                    last_shindo = ?,
-                    last_seen_at = ?,
-                    hit_count = ?,
-                    updated_at = ?
-                WHERE station_id = ?
-                """,
-                (
-                    station_name,
-                    lat,
-                    lon,
-                    new_max,
-                    new_max_at,
-                    shindo,
-                    observed_at_text,
-                    new_hit,
-                    observed_at_text,
-                    station_id,
-                ),
-            )
+            if row is None:
+                return None
             await connection.commit()
-            return {
-                "station_id": station_id,
-                "station_name": station_name,
-                "lat": lat,
-                "lon": lon,
-                "created": False,
-                "peak_updated": peak_updated,
-                "max_shindo": new_max,
-                "max_shindo_at": new_max_at,
-                "last_shindo": shindo,
-                "last_seen_at": observed_at_text,
-                "hit_count": new_hit,
-            }
+            return row
         except Exception as e:
             logger.error(f"[灾害预警] S-Net 测站峰值写入失败: {e}")
             try:
@@ -211,19 +238,36 @@ class SnetPeakRepository:
         observed_at: str,
         hit_threshold: float | None = None,
     ) -> list[dict[str, Any]]:
-        """批量 upsert 测站峰值。"""
+        """批量 upsert 测站峰值（单事务，减少往返与半批提交）。"""
         results: list[dict[str, Any]] = []
-        for station in stations or []:
-            if not isinstance(station, dict):
-                continue
-            row = await self.upsert_station_peak(
-                station,
-                observed_at=observed_at,
-                hit_threshold=hit_threshold,
-            )
-            if row is not None:
-                results.append(row)
-        return results
+        prepared = [
+            station for station in (stations or []) if isinstance(station, dict)
+        ]
+        if not prepared:
+            return results
+
+        try:
+            connection = await self._connection()
+            cursor = await connection.cursor()
+            for station in prepared:
+                row = await self._upsert_station_peak_on_cursor(
+                    cursor,
+                    station,
+                    observed_at=observed_at,
+                    hit_threshold=hit_threshold,
+                )
+                if row is not None:
+                    results.append(row)
+            await connection.commit()
+            return results
+        except Exception as e:
+            logger.error(f"[灾害预警] S-Net 测站峰值批量写入失败: {e}")
+            try:
+                if getattr(self.db, "connection", None) is not None:
+                    await self.db.connection.rollback()
+            except Exception:
+                pass
+            return []
 
     async def list_peaks(
         self,

--- a/core/storage/snet_peak_repository.py
+++ b/core/storage/snet_peak_repository.py
@@ -1,0 +1,451 @@
+"""
+S-Net 测站峰值仓储。
+
+负责 snet_station_peaks 表的读写，与通用 events 事件流解耦。
+DatabaseManager 仅保留建表职责；峰值 upsert/查询集中在本仓储。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from astrbot.api import logger
+
+from ...utils.converters import ScaleConverter
+
+
+class SnetPeakRepository:
+    """S-Net 测站峰值仓储。"""
+
+    # 日本震度 5弱 的計測震度起点
+    MAJOR_SHINDO_THRESHOLD = 4.5
+
+    def __init__(self, db):
+        """
+        Args:
+            db: DatabaseManager 实例（复用其连接与 initialize 生命周期）。
+        """
+        self.db = db
+
+    async def _connection(self):
+        return await self.db._ensure_connection()
+
+    async def upsert_station_peak(
+        self,
+        station: dict[str, Any],
+        *,
+        observed_at: str,
+        hit_threshold: float | None = None,
+    ) -> dict[str, Any] | None:
+        """写入/更新单个测站峰值。
+
+        规则：
+        - max_shindo / max_shindo_at：仅当新值严格更大时更新；同值保留更早时间
+        - last_shindo / last_seen_at：每次观测都更新
+        - hit_count：当 shindo >= hit_threshold 时累加（可选）
+        """
+        try:
+            station_id = str(
+                station.get("station_id")
+                or station.get("name")
+                or station.get("station_name")
+                or ""
+            ).strip()
+            if not station_id:
+                return None
+
+            try:
+                shindo = float(station.get("shindo"))
+            except (TypeError, ValueError):
+                return None
+
+            observed_at_text = str(observed_at or "").strip()
+            if not observed_at_text:
+                return None
+
+            station_name = (
+                str(
+                    station.get("station_name") or station.get("name") or station_id
+                ).strip()
+                or station_id
+            )
+            try:
+                lat = (
+                    float(station.get("lat"))
+                    if station.get("lat") is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                lat = None
+            try:
+                lon = (
+                    float(station.get("lon"))
+                    if station.get("lon") is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                lon = None
+
+            hit_increment = 0
+            if hit_threshold is not None:
+                try:
+                    if shindo >= float(hit_threshold):
+                        hit_increment = 1
+                except (TypeError, ValueError):
+                    hit_increment = 0
+
+            connection = await self._connection()
+            cursor = await connection.cursor()
+            await cursor.execute(
+                """
+                SELECT station_id, max_shindo, max_shindo_at, hit_count, first_seen_at
+                FROM snet_station_peaks
+                WHERE station_id = ?
+                LIMIT 1
+                """,
+                (station_id,),
+            )
+            existing = await cursor.fetchone()
+
+            if existing is None:
+                await cursor.execute(
+                    """
+                    INSERT INTO snet_station_peaks (
+                        station_id, station_name, lat, lon,
+                        max_shindo, max_shindo_at,
+                        last_shindo, last_seen_at,
+                        first_seen_at, hit_count, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        station_id,
+                        station_name,
+                        lat,
+                        lon,
+                        shindo,
+                        observed_at_text,
+                        shindo,
+                        observed_at_text,
+                        observed_at_text,
+                        hit_increment,
+                        observed_at_text,
+                    ),
+                )
+                await connection.commit()
+                return {
+                    "station_id": station_id,
+                    "station_name": station_name,
+                    "lat": lat,
+                    "lon": lon,
+                    "created": True,
+                    "peak_updated": True,
+                    "max_shindo": shindo,
+                    "max_shindo_at": observed_at_text,
+                    "last_shindo": shindo,
+                    "last_seen_at": observed_at_text,
+                    "hit_count": hit_increment,
+                }
+
+            old_max = float(existing["max_shindo"] or 0.0)
+            old_max_at = str(existing["max_shindo_at"] or observed_at_text)
+            old_hit = int(existing["hit_count"] or 0)
+            peak_updated = shindo > old_max
+            new_max = shindo if peak_updated else old_max
+            new_max_at = observed_at_text if peak_updated else old_max_at
+            new_hit = old_hit + hit_increment
+
+            await cursor.execute(
+                """
+                UPDATE snet_station_peaks
+                SET station_name = ?,
+                    lat = COALESCE(?, lat),
+                    lon = COALESCE(?, lon),
+                    max_shindo = ?,
+                    max_shindo_at = ?,
+                    last_shindo = ?,
+                    last_seen_at = ?,
+                    hit_count = ?,
+                    updated_at = ?
+                WHERE station_id = ?
+                """,
+                (
+                    station_name,
+                    lat,
+                    lon,
+                    new_max,
+                    new_max_at,
+                    shindo,
+                    observed_at_text,
+                    new_hit,
+                    observed_at_text,
+                    station_id,
+                ),
+            )
+            await connection.commit()
+            return {
+                "station_id": station_id,
+                "station_name": station_name,
+                "lat": lat,
+                "lon": lon,
+                "created": False,
+                "peak_updated": peak_updated,
+                "max_shindo": new_max,
+                "max_shindo_at": new_max_at,
+                "last_shindo": shindo,
+                "last_seen_at": observed_at_text,
+                "hit_count": new_hit,
+            }
+        except Exception as e:
+            logger.error(f"[灾害预警] S-Net 测站峰值写入失败: {e}")
+            try:
+                if getattr(self.db, "connection", None) is not None:
+                    await self.db.connection.rollback()
+            except Exception:
+                pass
+            return None
+
+    async def upsert_station_peaks_batch(
+        self,
+        stations: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        hit_threshold: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """批量 upsert 测站峰值。"""
+        results: list[dict[str, Any]] = []
+        for station in stations or []:
+            if not isinstance(station, dict):
+                continue
+            row = await self.upsert_station_peak(
+                station,
+                observed_at=observed_at,
+                hit_threshold=hit_threshold,
+            )
+            if row is not None:
+                results.append(row)
+        return results
+
+    async def list_peaks(
+        self,
+        *,
+        min_shindo: float | None = None,
+        limit: int | None = None,
+        order_by: str = "max_shindo",
+    ) -> list[dict[str, Any]]:
+        """查询测站峰值列表。"""
+        try:
+            connection = await self._connection()
+            cursor = await connection.cursor()
+            clauses: list[str] = []
+            params: list[Any] = []
+            if min_shindo is not None:
+                clauses.append("max_shindo >= ?")
+                params.append(float(min_shindo))
+            where_sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+
+            order_key = str(order_by or "max_shindo").strip().lower()
+            if order_key == "max_shindo_at":
+                order_sql = (
+                    " ORDER BY max_shindo_at DESC, max_shindo DESC, station_id ASC"
+                )
+            else:
+                order_sql = (
+                    " ORDER BY max_shindo DESC, max_shindo_at DESC, station_id ASC"
+                )
+
+            limit_sql = ""
+            if limit is not None:
+                try:
+                    safe_limit = max(1, int(limit))
+                    limit_sql = " LIMIT ?"
+                    params.append(safe_limit)
+                except (TypeError, ValueError):
+                    limit_sql = ""
+
+            await cursor.execute(
+                f"SELECT * FROM snet_station_peaks{where_sql}{order_sql}{limit_sql}",
+                tuple(params),
+            )
+            return [dict(row) for row in await cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"[灾害预警] 查询 S-Net 测站峰值失败: {e}")
+            return []
+
+    async def get_global_max_peak(self) -> dict[str, Any] | None:
+        """获取全网历史最大震度测站。"""
+        rows = await self.list_peaks(limit=1, order_by="max_shindo")
+        return rows[0] if rows else None
+
+    async def clear_all(self) -> bool:
+        """清空测站峰值表。"""
+        try:
+            connection = await self._connection()
+            cursor = await connection.cursor()
+            await cursor.execute("DELETE FROM snet_station_peaks")
+            await connection.commit()
+            return True
+        except Exception as e:
+            logger.error(f"[灾害预警] 清除 S-Net 测站峰值失败: {e}")
+            try:
+                if getattr(self.db, "connection", None) is not None:
+                    await self.db.connection.rollback()
+            except Exception:
+                pass
+            return False
+
+    async def build_stats_summary(self) -> dict[str, Any]:
+        """构建峰值统计摘要（供内存 snet_stats / 管理端卡片）。"""
+        empty = {
+            "station_count": 0,
+            "stations_with_peak": 0,
+            "global_max": None,
+            "top_peaks": [],
+            "recent_peak_updates": [],
+            "last_observation_at": None,
+        }
+        try:
+            connection = await self._connection()
+            cursor = await connection.cursor()
+            await cursor.execute("SELECT COUNT(*) AS cnt FROM snet_station_peaks")
+            row = await cursor.fetchone()
+            station_count = int(row["cnt"] if row else 0)
+
+            global_max_row = await self.get_global_max_peak()
+            global_max = self._to_global_max_view(global_max_row)
+
+            # Top-N 按历史最大震度降序，供管理端 S-Net 卡片展示
+            top_rows = await self.list_peaks(limit=3, order_by="max_shindo")
+            top_peaks = []
+            for item in top_rows:
+                view = self._to_peak_update_view(item)
+                if view is not None:
+                    top_peaks.append(view)
+
+            recent_rows = await self.list_peaks(limit=20, order_by="max_shindo_at")
+            recent_peak_updates = []
+            for item in recent_rows:
+                view = self._to_peak_update_view(item)
+                if view is not None:
+                    recent_peak_updates.append(view)
+
+            last_observation_at = None
+            await cursor.execute(
+                """
+                SELECT last_seen_at
+                FROM snet_station_peaks
+                WHERE last_seen_at IS NOT NULL AND TRIM(last_seen_at) != ''
+                ORDER BY last_seen_at DESC
+                LIMIT 1
+                """
+            )
+            last_row = await cursor.fetchone()
+            if last_row:
+                last_observation_at = str(last_row["last_seen_at"] or "") or None
+
+            return {
+                "station_count": station_count,
+                "stations_with_peak": station_count,
+                "global_max": global_max,
+                "top_peaks": top_peaks,
+                "recent_peak_updates": recent_peak_updates,
+                "last_observation_at": last_observation_at,
+            }
+        except Exception as e:
+            logger.error(f"[灾害预警] 构建 S-Net 峰值统计失败: {e}")
+            return empty
+
+    async def list_major_peak_events(
+        self,
+        *,
+        min_shindo: float = MAJOR_SHINDO_THRESHOLD,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """将达到阈值的测站峰值投影为重大事件时间轴条目。
+
+        阈值默认 4.5（日本震度 5弱）。仅展示时间、测站名与震度。
+        """
+        try:
+            threshold = float(min_shindo)
+        except (TypeError, ValueError):
+            threshold = self.MAJOR_SHINDO_THRESHOLD
+
+        rows = await self.list_peaks(
+            min_shindo=threshold,
+            limit=limit,
+            order_by="max_shindo_at",
+        )
+        events: list[dict[str, Any]] = []
+        for row in rows:
+            station_id = str(row.get("station_id") or "").strip()
+            station_name = str(row.get("station_name") or station_id).strip()
+            try:
+                shindo = float(row.get("max_shindo"))
+            except (TypeError, ValueError):
+                continue
+            peak_at = str(row.get("max_shindo_at") or "").strip()
+            label = (
+                ScaleConverter.format_measured_intensity_display(shindo)
+                or f"{shindo:.1f}"
+            )
+            description = f"S-Net {station_name} 震度{label} ({shindo:.2f})"
+            events.append(
+                {
+                    "id": f"snet-peak-{station_id}",
+                    "event_id": f"snet_peak_{station_id}",
+                    "real_event_id": station_id,
+                    "unique_id": f"snet_peak:{station_id}",
+                    "type": "snet_peak",
+                    "source": "snet_msil",
+                    "source_id": "snet_msil",
+                    "description": description,
+                    "place_name": station_name,
+                    "latitude": row.get("lat"),
+                    "longitude": row.get("lon"),
+                    "level": label,
+                    "shindo": shindo,
+                    "time": peak_at,
+                    "is_major": 1,
+                    "update_count": 1,
+                    "history": [],
+                }
+            )
+        return events
+
+    @staticmethod
+    def _to_global_max_view(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        try:
+            shindo_val = float(row.get("max_shindo"))
+        except (TypeError, ValueError):
+            return None
+        return {
+            "shindo": shindo_val,
+            "shindo_label": ScaleConverter.format_measured_intensity_display(
+                shindo_val
+            ),
+            "station_id": str(row.get("station_id") or ""),
+            "station_name": str(row.get("station_name") or row.get("station_id") or ""),
+            "at": str(row.get("max_shindo_at") or ""),
+            "lat": row.get("lat"),
+            "lon": row.get("lon"),
+        }
+
+    @staticmethod
+    def _to_peak_update_view(row: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            shindo_val = float(row.get("max_shindo"))
+        except (TypeError, ValueError):
+            return None
+        return {
+            "station_id": str(row.get("station_id") or ""),
+            "station_name": str(row.get("station_name") or row.get("station_id") or ""),
+            "shindo": shindo_val,
+            "shindo_label": ScaleConverter.format_measured_intensity_display(
+                shindo_val
+            ),
+            "at": str(row.get("max_shindo_at") or ""),
+        }
+
+
+__all__ = ["SnetPeakRepository"]

--- a/core/storage/statistics_manager.py
+++ b/core/storage/statistics_manager.py
@@ -4,6 +4,7 @@
 作为 storage 目录中统计子系统的统一协调层。
 """
 
+from datetime import datetime, timezone
 from typing import Any
 
 from astrbot.api import logger
@@ -71,6 +72,11 @@ class StatisticsManager:
         self.aggregator = EventStatsAggregator(self)
         self.record_service = StatsRecordService(self)
         self.load_service = StatsLoadService(self)
+        # S-Net 峰值观测：独立于通用事件流，维护测站历史最大震度档案。
+        # 延迟导入，避免 snet ↔ storage 包级循环依赖。
+        from ..services.snet.snet_peak_service import SnetPeakService
+
+        self.snet_peak_service = SnetPeakService(self)
 
     async def initialize(self):
         """异步初始化数据库并加载历史数据"""
@@ -90,6 +96,18 @@ class StatisticsManager:
             # 这里统一串联聚合、近期列表更新、会话统计与持久化流程。
             if not self._db_initialized:
                 await self.initialize()
+
+            # S-Net 是连续观测网：只更新测站峰值档案，不进入通用事件计数/列表/热力图。
+            if self.snet_peak_service.is_snet_event(event):
+                await self.snet_peak_service.observe_event(event)
+                pushed_sessions = pushed_sessions or []
+                current_time = datetime.now(timezone.utc).isoformat()
+                if pushed_sessions:
+                    self.session_service.record_session_stats(
+                        pushed_sessions, current_time
+                    )
+                self.save_stats()
+                return
 
             # 先完成聚合，统一拿到本次写入所需的时间、来源与唯一标识。
             aggregate_result = await self.aggregator.aggregate_event(event)
@@ -170,7 +188,10 @@ class StatisticsManager:
 
             if self._db_initialized:
                 await self.db.clear_all_events()
+                await self.snet_peak_service.clear_peaks()
 
+            # 重置后 query_service 仍引用旧 stats 字典，需要重新绑定。
+            self.query_service = StatsQueryService(self.stats, self.display_timezone)
             self.save_stats()
             logger.info("[灾害预警] 统计数据已重置")
 

--- a/core/storage/statistics_manager.py
+++ b/core/storage/statistics_manager.py
@@ -97,9 +97,9 @@ class StatisticsManager:
             if not self._db_initialized:
                 await self.initialize()
 
-            # S-Net 是连续观测网：只更新测站峰值档案，不进入通用事件计数/列表/热力图。
+            # S-Net 是连续观测网：峰值已在轮询侧归档，这里只记会话推送统计，
+            # 避免与 snet_poll_service._observe_station_peaks 双写 hit_count。
             if self.snet_peak_service.is_snet_event(event):
-                await self.snet_peak_service.observe_event(event)
                 pushed_sessions = pushed_sessions or []
                 current_time = datetime.now(timezone.utc).isoformat()
                 if pushed_sessions:

--- a/core/storage/stats/stats_load_service.py
+++ b/core/storage/stats/stats_load_service.py
@@ -91,11 +91,11 @@ class StatsLoadService:
             elif json_has_events:
                 logger.info("[灾害预警] 检测到 JSON 历史记录，开始迁移到数据库...")
                 await self.migrate_json_from_file()
-
-            # S-Net 峰值档案独立于 events 表，始终尝试从专用表恢复。
-            await self._restore_snet_stats()
         except Exception as e:
             logger.error(f"[灾害预警] 从数据库加载失败: {e}")
+
+        # S-Net 峰值档案独立于 events 表：即使通用事件恢复失败也要尝试恢复。
+        await self._restore_snet_stats()
 
     async def migrate_json_from_file(self) -> None:
         """将 JSON 文件中的历史记录一次性迁移到数据库。"""

--- a/core/storage/stats/stats_load_service.py
+++ b/core/storage/stats/stats_load_service.py
@@ -91,6 +91,9 @@ class StatsLoadService:
             elif json_has_events:
                 logger.info("[灾害预警] 检测到 JSON 历史记录，开始迁移到数据库...")
                 await self.migrate_json_from_file()
+
+            # S-Net 峰值档案独立于 events 表，始终尝试从专用表恢复。
+            await self._restore_snet_stats()
         except Exception as e:
             logger.error(f"[灾害预警] 从数据库加载失败: {e}")
 
@@ -179,6 +182,17 @@ class StatsLoadService:
             rebuild_events,
             allow_weather_fallback=False,
         )
+        await self._restore_snet_stats()
+
+    async def _restore_snet_stats(self) -> None:
+        """从 snet_station_peaks 恢复内存 snet_stats。"""
+        peak_service = getattr(self.manager, "snet_peak_service", None)
+        if peak_service is None:
+            return
+        try:
+            await peak_service.refresh_stats_from_database()
+        except Exception as e:
+            logger.warning(f"[灾害预警] 恢复 S-Net 峰值统计失败: {e}")
 
     def _restore_time_series_counts(self, counts: dict[str, Any] | None) -> None:
         """恢复数据库全量聚合得到的时间序列桶。"""

--- a/core/storage/stats/stats_query_service.py
+++ b/core/storage/stats/stats_query_service.py
@@ -91,12 +91,47 @@ class StatsQueryService:
                 [
                     "",
                     f"🔥 最大地震: M{max_mag['value']} {max_mag['place_name']}{source_info}",
-                    "",
                 ]
             )
 
-        text.append("☁️ 气象预警分布:")
-        text.append("")
+        # S-Net 观测峰值紧跟历史最大地震，阅读顺序与管理端卡片一致。
+        snet_stats = (
+            s.get("snet_stats", {}) if isinstance(s.get("snet_stats"), dict) else {}
+        )
+        global_max = (
+            snet_stats.get("global_max") if isinstance(snet_stats, dict) else None
+        )
+        if isinstance(global_max, dict) and global_max.get("shindo") is not None:
+            try:
+                shindo_val = float(global_max.get("shindo"))
+            except (TypeError, ValueError):
+                shindo_val = None
+            if shindo_val is not None:
+                station_name = str(
+                    global_max.get("station_name")
+                    or global_max.get("station_id")
+                    or "未知测站"
+                )
+                label = str(global_max.get("shindo_label") or "").strip()
+                if label:
+                    label_part = label if label.startswith("震度") else f"震度{label}"
+                else:
+                    label_part = f"{shindo_val:.3f}"
+                at_text = str(global_max.get("at") or "").strip()
+                time_part = at_text[:19].replace("T", " ") if at_text else "未知时间"
+                text.extend(
+                    [
+                        "",
+                        "🌊 S-Net 海底震度峰值:",
+                        f"最大震度: {station_name} {label_part} ({shindo_val:.3f})",
+                        f"⏰ 时间: {time_part}",
+                    ]
+                )
+                station_count = int(snet_stats.get("station_count") or 0)
+                if station_count > 0:
+                    text.append(f"已归档测站: {station_count}")
+
+        text.extend(["", "☁️ 气象预警分布:", ""])
         weather_level = s["weather_stats"]["by_level"]
         level_order = ["🔴红色", "🟠橙色", "🟡黄色", "🔵蓝色", "⚪白色", "未知"]
         has_weather = False

--- a/core/storage/stats/stats_query_service.py
+++ b/core/storage/stats/stats_query_service.py
@@ -127,7 +127,10 @@ class StatsQueryService:
                         f"⏰ 时间: {time_part}",
                     ]
                 )
-                station_count = int(snet_stats.get("station_count") or 0)
+                try:
+                    station_count = int(snet_stats.get("station_count") or 0)
+                except (TypeError, ValueError):
+                    station_count = 0
                 if station_count > 0:
                     text.append(f"已归档测站: {station_count}")
 

--- a/core/storage/stats/stats_state_factory.py
+++ b/core/storage/stats/stats_state_factory.py
@@ -58,6 +58,15 @@ class StatsStateFactory:
                 "max_wind_typhoons": {},
                 "min_pressure_typhoons": {},
             },
+            # S-Net 观测峰值统计：不计入 total_events / by_type 事件流。
+            "snet_stats": {
+                "station_count": 0,
+                "stations_with_peak": 0,
+                "global_max": None,
+                "top_peaks": [],
+                "recent_peak_updates": [],
+                "last_observation_at": None,
+            },
             # 近期事件摘要与去重辅助字段。
             "recent_pushes": [],
             "major_events": [],

--- a/plugin/commands/plugin_admin_command_service.py
+++ b/plugin/commands/plugin_admin_command_service.py
@@ -13,6 +13,7 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
 from ...core.app.services import quoted_plain_result
+from ...core.app.services.typhoon_enrichment_service import TyphoonEnrichmentService
 from ...utils.version import get_plugin_version
 from .telemetry_mixin import CommandTelemetryMixin
 
@@ -229,19 +230,22 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 )
                 if not isinstance(eqsc_cfg, dict):
                     eqsc_cfg = {}
-                config_enabled = bool(eqsc_cfg.get("enabled", False))
+                config_enabled, typhoon_enrichment = (
+                    TyphoonEnrichmentService.resolve_eqsc_flags(eqsc_cfg)
+                )
                 token_configured = bool(
                     str(eqsc_cfg.get("refresh_token", "") or "").strip()
                 )
                 eqsc_health = {
                     "enabled": config_enabled and token_configured,
                     "config_enabled": config_enabled,
+                    "typhoon_enrichment": typhoon_enrichment,
                     "token_configured": token_configured,
                     "access_token_valid": False,
                     "circuit_open": False,
-                    # 子数据源启用仅跟随台风富化开关
+                    # 子数据源展示只看子开关本身
                     "sub_sources": {
-                        "china_typhoon": config_enabled,
+                        "china_typhoon": typhoon_enrichment,
                     },
                 }
 
@@ -322,10 +326,13 @@ class PluginAdminCommandService(CommandTelemetryMixin):
 
             sub_source_status = dict(status.get("sub_source_status", {}) or {})
             # 注入 EQSC 子源（不在 SOURCE_CATALOG 的 WebSocket 分组内）
-            # 子数据源启用仅跟随「启用EQSC台风富化」配置开关
+            # 子数据源展示只看 typhoon_enrichment 子开关本身
             eqsc_sub_sources = eqsc_health.get("sub_sources")
+            eqsc_typhoon_enrichment = bool(
+                eqsc_health.get("typhoon_enrichment", eqsc_config_enabled)
+            )
             if not isinstance(eqsc_sub_sources, dict):
-                eqsc_sub_sources = {"china_typhoon": eqsc_config_enabled}
+                eqsc_sub_sources = {"china_typhoon": eqsc_typhoon_enrichment}
             sub_source_status["eqsc"] = dict(eqsc_sub_sources)
             if eqsc_config_enabled:
                 grouped_sources.setdefault("eqsc", ["china_typhoon"])

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -609,6 +609,16 @@ class PluginQueryCommandService(CommandTelemetryMixin):
             yield _quoted_plain_result("❌ S-Net 轮询服务未就绪")
             return
 
+        # 全局总闸：全局未启用时不允许 /snet（与轮询启动口径一致）
+        try:
+            if hasattr(snet_poll, "is_enabled") and not snet_poll.is_enabled():
+                yield _quoted_plain_result(
+                    "❌ S-Net 数据源未在全局配置中启用，无法查询"
+                )
+                return
+        except Exception:
+            pass
+
         raw_arg = (arg or "").strip()
         debug_mode = None
         if raw_arg:

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -610,14 +610,19 @@ class PluginQueryCommandService(CommandTelemetryMixin):
             return
 
         # 全局总闸：全局未启用时不允许 /snet（与轮询启动口径一致）
+        # 配置读取异常时 fail-closed，避免 opt-in 开关被静默绕过。
         try:
             if hasattr(snet_poll, "is_enabled") and not snet_poll.is_enabled():
                 yield _quoted_plain_result(
                     "❌ S-Net 数据源未在全局配置中启用，无法查询"
                 )
                 return
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(f"[灾害预警] 检查 S-Net 全局启用状态失败: {exc}")
+            yield _quoted_plain_result(
+                "❌ 无法确认 S-Net 启用状态，已拒绝查询（请检查全局配置）"
+            )
+            return
 
         raw_arg = (arg or "").strip()
         debug_mode = None

--- a/resources/snet_data/SREV/C0.svg
+++ b/resources/snet_data/SREV/C0.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#a0a0a0"/><circle cx="20" cy="20" r="18" stroke="#d0d0d0" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">0</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#9B9B9B"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+  >0</text>
+</svg>

--- a/resources/snet_data/SREV/C1.svg
+++ b/resources/snet_data/SREV/C1.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#d9e3f0"/><circle cx="20" cy="20" r="18" stroke="#eef4fa" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">1</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#666666"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+  >1</text>
+</svg>

--- a/resources/snet_data/SREV/C2.svg
+++ b/resources/snet_data/SREV/C2.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#adc8e0"/><circle cx="20" cy="20" r="18" stroke="#d6e4f2" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">2</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#4998C8"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+  >2</text>
+</svg>

--- a/resources/snet_data/SREV/C3.svg
+++ b/resources/snet_data/SREV/C3.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#7cc4b5"/><circle cx="20" cy="20" r="18" stroke="#b5e2da" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">3</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#32B464"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+  >3</text>
+</svg>

--- a/resources/snet_data/SREV/C4.svg
+++ b/resources/snet_data/SREV/C4.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#ffeb3b"/><circle cx="20" cy="20" r="18" stroke="#fff7a0" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">4</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#FFE762"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#000000"
+  >4</text>
+</svg>

--- a/resources/snet_data/SREV/C5+.svg
+++ b/resources/snet_data/SREV/C5+.svg
@@ -1,1 +1,16 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#ff7043"/><circle cx="20" cy="20" r="18" stroke="#ffaa8a" stroke-width="3" fill="none"/><text x="16" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#ffffff">5</text><text x="28" y="15" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="900" stroke="#ffffff" stroke-width="0.8" fill="#ffffff">+</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#F78201"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="16"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#000000"
+  >5</text>
+  <rect x="24.8" y="15.9" width="7.2" height="1.9" rx="0.2" fill="#000000"/>
+  <rect x="27.45" y="13.25" width="1.9" height="7.2" rx="0.2" fill="#000000"/>
+</svg>

--- a/resources/snet_data/SREV/C5-.svg
+++ b/resources/snet_data/SREV/C5-.svg
@@ -1,1 +1,15 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#ffb74d"/><circle cx="20" cy="20" r="18" stroke="#ffdb9a" stroke-width="3" fill="none"/><text x="16" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#000000">5</text><text x="28" y="15" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="900" stroke="#000000" stroke-width="0.8" fill="#000000">-</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#FFB600"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="16"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#000000"
+  >5</text>
+  <rect x="24.8" y="15.7" width="7.2" height="1.9" rx="0.2" fill="#000000"/>
+</svg>

--- a/resources/snet_data/SREV/C6+.svg
+++ b/resources/snet_data/SREV/C6+.svg
@@ -1,1 +1,16 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#b71c1c"/><circle cx="20" cy="20" r="18" stroke="#d85a5a" stroke-width="3" fill="none"/><text x="16" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#ffffff">6</text><text x="28" y="15" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="900" stroke="#ffffff" stroke-width="0.8" fill="#ffffff">+</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#850C33"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="16"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#ffffff"
+  >6</text>
+  <rect x="24.8" y="15.9" width="7.2" height="1.9" rx="0.2" fill="#ffffff"/>
+  <rect x="27.45" y="13.25" width="1.9" height="7.2" rx="0.2" fill="#ffffff"/>
+</svg>

--- a/resources/snet_data/SREV/C6-.svg
+++ b/resources/snet_data/SREV/C6-.svg
@@ -1,1 +1,15 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#e53935"/><circle cx="20" cy="20" r="18" stroke="#f28a82" stroke-width="3" fill="none"/><text x="16" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#ffffff">6</text><text x="28" y="15" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="900" stroke="#ffffff" stroke-width="0.8" fill="#ffffff">-</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#F52020"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="16"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#ffffff"
+  >6</text>
+  <rect x="24.8" y="16.2" width="7.2" height="1.9" rx="0.2" fill="#ffffff"/>
+</svg>

--- a/resources/snet_data/SREV/C7.svg
+++ b/resources/snet_data/SREV/C7.svg
@@ -1,1 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="18" fill="#4a0030"/><circle cx="20" cy="20" r="18" stroke="#8f4a78" stroke-width="3" fill="none"/><text x="20" y="20" text-anchor="middle" dominant-baseline="central" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#ffffff">7</text></svg>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#8500C3"/>
+  <circle cx="20" cy="20" r="18" stroke="#AEB8BD" stroke-width="3" fill="none"/>
+  <text
+    x="20"
+    y="20"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+  >7</text>
+</svg>


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

将 S-Net 台站峰值观测集成到统计与重大事件流程中，收紧全局与会话级数据源配置语义，并改进 EQSC 台风增强标志的处理及管理后台体验。

New Features:
- 在专用数据库表中持久化和聚合 S-Net 台站峰值烈度，并在管理后台统计及重大事件时间线中展示这些数据。
- 在管理后台仪表盘中新增 S-Net 历史最大烈度卡片，以及与现有最大震级视图并列的统计备注卡片。

Bug Fixes:
- 确保会话级数据源开关遵守全局数据源门控，使会话无法启用已在全局层面禁用的数据源。
- 修复会话配置编辑逻辑，使其基于有效配置（全局配置加覆盖项）进行操作，并计算最小化的覆盖差异，避免出现 UI 显示为禁用但仍发生推送的情况。

Enhancements:
- 优化 S-Net 推送去重机制，使用前 N 个被触发台站的指纹，并将峰值归档与推送发送解耦。
- 将 EQSC 通道启用与台风增强子能力分离，并在健康状态上报、连接负载和日志记录中传播这一拆分。
- 改进统计卡片的视觉布局和样式，包括统一卡片高度、更新最大震级与 S-Net 卡片设计，以及响应式调整。
- 通过将 S-Net 峰值信息插入概要文本并更新各类管理提示与通知，来澄清统计文案输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate S-Net station peak observations into the statistics and major-event flows, tighten global vs session data source configuration semantics, and enhance EQSC typhoon enrichment flag handling and admin UX.

New Features:
- Persist and aggregate S-Net station peak intensities in a dedicated database table and expose them in admin stats and major events timelines.
- Add admin dashboard cards for S-Net historical maximum intensity and a statistics notes card alongside the existing max-magnitude view.

Bug Fixes:
- Ensure session-level data source toggles respect a global data source gate so sessions cannot override disabled global sources.
- Fix session configuration editing to operate on the effective configuration (global plus overrides) and to compute minimal overrides, avoiding cases where UI appears disabled but pushes still occur.

Enhancements:
- Refine S-Net push de-duplication using a fingerprint over the top N triggered stations and decouple peak archiving from push emission.
- Separate EQSC channel enablement from the typhoon enrichment sub-capability and propagate the split through health reporting, connection payloads, and logging.
- Improve the visual layout and styling of statistics cards, including unified card heights and updated max-magnitude and S-Net card designs, with responsive tweaks.
- Clarify statistics text output by inserting S-Net peak information into summary text and updating various admin hints and notifications.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 S-Net 台站峰值观测集成到统计与重大事件流程中，收紧全局与会话级数据源配置语义，并改进 EQSC 台风增强标志的处理及管理后台体验。

New Features:
- 在专用数据库表中持久化和聚合 S-Net 台站峰值烈度，并在管理后台统计及重大事件时间线中展示这些数据。
- 在管理后台仪表盘中新增 S-Net 历史最大烈度卡片，以及与现有最大震级视图并列的统计备注卡片。

Bug Fixes:
- 确保会话级数据源开关遵守全局数据源门控，使会话无法启用已在全局层面禁用的数据源。
- 修复会话配置编辑逻辑，使其基于有效配置（全局配置加覆盖项）进行操作，并计算最小化的覆盖差异，避免出现 UI 显示为禁用但仍发生推送的情况。

Enhancements:
- 优化 S-Net 推送去重机制，使用前 N 个被触发台站的指纹，并将峰值归档与推送发送解耦。
- 将 EQSC 通道启用与台风增强子能力分离，并在健康状态上报、连接负载和日志记录中传播这一拆分。
- 改进统计卡片的视觉布局和样式，包括统一卡片高度、更新最大震级与 S-Net 卡片设计，以及响应式调整。
- 通过将 S-Net 峰值信息插入概要文本并更新各类管理提示与通知，来澄清统计文案输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate S-Net station peak observations into the statistics and major-event flows, tighten global vs session data source configuration semantics, and enhance EQSC typhoon enrichment flag handling and admin UX.

New Features:
- Persist and aggregate S-Net station peak intensities in a dedicated database table and expose them in admin stats and major events timelines.
- Add admin dashboard cards for S-Net historical maximum intensity and a statistics notes card alongside the existing max-magnitude view.

Bug Fixes:
- Ensure session-level data source toggles respect a global data source gate so sessions cannot override disabled global sources.
- Fix session configuration editing to operate on the effective configuration (global plus overrides) and to compute minimal overrides, avoiding cases where UI appears disabled but pushes still occur.

Enhancements:
- Refine S-Net push de-duplication using a fingerprint over the top N triggered stations and decouple peak archiving from push emission.
- Separate EQSC channel enablement from the typhoon enrichment sub-capability and propagate the split through health reporting, connection payloads, and logging.
- Improve the visual layout and styling of statistics cards, including unified card heights and updated max-magnitude and S-Net card designs, with responsive tweaks.
- Clarify statistics text output by inserting S-Net peak information into summary text and updating various admin hints and notifications.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 S-Net 测站历史最大震度、Top 3 峰值及最近观测统计。
  * 重大事件时间轴支持展示 S-Net 峰值事件及测站信息。
  * EQSC 新增通道总开关，可独立控制台风数据富化。

* **界面优化**
  * 重构统计页卡片布局、配色与响应式显示。
  * 新增统计口径说明卡片，补充数据展示说明。

* **配置改进**
  * 会话配置正确展示并保存实际生效设置。
  * 全局专属配置不再允许通过会话覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->