### PR TITLE
feat(message): 支持推送文本 Emoji 过滤三档模式

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -548,7 +548,7 @@
     }
   },
   "message_format": {
-    "description": "🎨 地震消息格式配置",
+    "description": "🎨 预警消息格式配置",
     "type": "object",
     "hint": "自定义预警消息的视觉呈现方式",
     "items": {
@@ -638,6 +638,17 @@
           "Aurora",
           "DarkNight"
         ]
+      },
+      "emoji_filter_mode": {
+        "description": "推送文本 Emoji 过滤",
+        "type": "string",
+        "options": [
+          "默认",
+          "简洁",
+          "关闭"
+        ],
+        "default": "默认",
+        "hint": "仅作用于预警推送链路中的推送文本，不影响插件指令回复等其他场景。默认：保留全部 emoji（现有行为）；简洁：仅保留用于指示烈度/震度的方形/圆形图标，以及气象预警颜色等级等描述严重性的指示图标；关闭：不输出任何 emoji。"
       }
     }
   },

--- a/core/message/builders/text_message_builder.py
+++ b/core/message/builders/text_message_builder.py
@@ -12,6 +12,7 @@ from astrbot.api import logger
 from astrbot.api.event import MessageChain
 from astrbot.api.message_components import Plain
 
+from ....utils.emoji_filter import filter_push_text_emoji
 from ...domain.event_models import EventEnvelope
 from ..presenters.presenter_registry import present_message
 
@@ -37,6 +38,8 @@ class TextMessageBuilder:
         detailed_jma = config.get("detailed_jma_intensity", False)
         # 日本震度是否按地域汇总展示，默认开启。
         jma_region = config.get("jma_region_intensity", True)
+        # 推送文本 emoji 过滤仅在此出口生效，指令回复不经过本构建器。
+        emoji_filter_mode = config.get("emoji_filter_mode", "默认")
 
         options = {
             "timezone": display_timezone,
@@ -65,4 +68,6 @@ class TextMessageBuilder:
             logger.warning(f"[灾害预警] 未知事件类型: {type(data)}")
             message_text = f"🚨[未知事件]\n📋事件ID：{event.id}\n⏰时间：{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
 
+        # 仅过滤推送链路文本；Presenter 本身仍按完整样式生成，便于其他场景复用。
+        message_text = filter_push_text_emoji(message_text, emoji_filter_mode)
         return MessageChain([Plain(message_text)])

--- a/core/message/builders/text_message_builder.py
+++ b/core/message/builders/text_message_builder.py
@@ -12,7 +12,10 @@ from astrbot.api import logger
 from astrbot.api.event import MessageChain
 from astrbot.api.message_components import Plain
 
-from ....utils.emoji_filter import filter_push_text_emoji
+from ....utils.emoji_filter import (
+    EMOJI_FILTER_MODE_DEFAULT,
+    filter_push_text_emoji,
+)
 from ...domain.event_models import EventEnvelope
 from ..presenters.presenter_registry import present_message
 
@@ -39,7 +42,7 @@ class TextMessageBuilder:
         # 日本震度是否按地域汇总展示，默认开启。
         jma_region = config.get("jma_region_intensity", True)
         # 推送文本 emoji 过滤仅在此出口生效，指令回复不经过本构建器。
-        emoji_filter_mode = config.get("emoji_filter_mode", "默认")
+        emoji_filter_mode = config.get("emoji_filter_mode", EMOJI_FILTER_MODE_DEFAULT)
 
         options = {
             "timezone": display_timezone,

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -174,6 +174,9 @@ class PushExecutionService:
                         "jma_region_intensity": message_format_config.get(
                             "jma_region_intensity", True
                         ),
+                        "emoji_filter_mode": message_format_config.get(
+                            "emoji_filter_mode", "默认"
+                        ),
                     },
                     "weather": {
                         "enable_weather_icon": weather_config.get(

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -14,6 +14,7 @@ from astrbot.api import logger
 from astrbot.api.event import MessageChain
 from astrbot.api.message_components import Plain
 
+from ....utils.emoji_filter import EMOJI_FILTER_MODE_DEFAULT
 from ...domain.event_models import EventEnvelope
 
 
@@ -175,7 +176,7 @@ class PushExecutionService:
                             "jma_region_intensity", True
                         ),
                         "emoji_filter_mode": message_format_config.get(
-                            "emoji_filter_mode", "默认"
+                            "emoji_filter_mode", EMOJI_FILTER_MODE_DEFAULT
                         ),
                     },
                     "weather": {

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from astrbot.api import logger
 
+from ....utils.emoji_filter import (
+    EMOJI_FILTER_MODE_DEFAULT,
+    is_known_emoji_filter_mode,
+    normalize_emoji_filter_mode,
+)
 from ....utils.map_tile_sources import (
     MAP_SOURCE_NAME_TO_ID,
     MAP_TILE_SOURCES,
@@ -872,41 +877,24 @@ class ConfigValidator:
                 f"[灾害预警] 配置警告: GQ模板 {gq_template} 不在标准列表中，请确认是否为自定义模板。"
             )
 
-        # 推送文本 Emoji 过滤模式校验
+        # 推送文本 Emoji 过滤模式校验（规范化逻辑统一委托给 emoji_filter）
         emoji_filter_mode = cfg.get("emoji_filter_mode")
-        valid_emoji_modes = ["默认", "简洁", "关闭"]
         if emoji_filter_mode is None:
-            cfg["emoji_filter_mode"] = "默认"
+            cfg["emoji_filter_mode"] = EMOJI_FILTER_MODE_DEFAULT
         elif not isinstance(emoji_filter_mode, str):
             logger.warning(
                 f"[灾害预警] 配置警告: emoji 过滤模式类型错误 "
-                f"({type(emoji_filter_mode).__name__})，已重置为 默认。"
+                f"({type(emoji_filter_mode).__name__})，"
+                f"已重置为 {EMOJI_FILTER_MODE_DEFAULT}。"
             )
-            cfg["emoji_filter_mode"] = "默认"
+            cfg["emoji_filter_mode"] = EMOJI_FILTER_MODE_DEFAULT
         else:
-            normalized_mode = emoji_filter_mode.strip()
-            aliases = {
-                "default": "默认",
-                "full": "默认",
-                "minimal": "简洁",
-                "simple": "简洁",
-                "compact": "简洁",
-                "off": "关闭",
-                "none": "关闭",
-                "disable": "关闭",
-                "disabled": "关闭",
-                "close": "关闭",
-            }
-            if normalized_mode in valid_emoji_modes:
-                cfg["emoji_filter_mode"] = normalized_mode
-            elif normalized_mode.lower() in aliases:
-                cfg["emoji_filter_mode"] = aliases[normalized_mode.lower()]
-            else:
+            if not is_known_emoji_filter_mode(emoji_filter_mode):
                 logger.warning(
                     f"[灾害预警] 配置警告: emoji_filter_mode={emoji_filter_mode} 无效，"
-                    "已重置为 默认。"
+                    f"已重置为 {EMOJI_FILTER_MODE_DEFAULT}。"
                 )
-                cfg["emoji_filter_mode"] = "默认"
+            cfg["emoji_filter_mode"] = normalize_emoji_filter_mode(emoji_filter_mode)
 
         # Playwright 模式校验
         pw_mode = cfg.get("playwright_mode")

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -872,6 +872,42 @@ class ConfigValidator:
                 f"[灾害预警] 配置警告: GQ模板 {gq_template} 不在标准列表中，请确认是否为自定义模板。"
             )
 
+        # 推送文本 Emoji 过滤模式校验
+        emoji_filter_mode = cfg.get("emoji_filter_mode")
+        valid_emoji_modes = ["默认", "简洁", "关闭"]
+        if emoji_filter_mode is None:
+            cfg["emoji_filter_mode"] = "默认"
+        elif not isinstance(emoji_filter_mode, str):
+            logger.warning(
+                f"[灾害预警] 配置警告: emoji 过滤模式类型错误 "
+                f"({type(emoji_filter_mode).__name__})，已重置为 默认。"
+            )
+            cfg["emoji_filter_mode"] = "默认"
+        else:
+            normalized_mode = emoji_filter_mode.strip()
+            aliases = {
+                "default": "默认",
+                "full": "默认",
+                "minimal": "简洁",
+                "simple": "简洁",
+                "compact": "简洁",
+                "off": "关闭",
+                "none": "关闭",
+                "disable": "关闭",
+                "disabled": "关闭",
+                "close": "关闭",
+            }
+            if normalized_mode in valid_emoji_modes:
+                cfg["emoji_filter_mode"] = normalized_mode
+            elif normalized_mode.lower() in aliases:
+                cfg["emoji_filter_mode"] = aliases[normalized_mode.lower()]
+            else:
+                logger.warning(
+                    f"[灾害预警] 配置警告: emoji_filter_mode={emoji_filter_mode} 无效，"
+                    "已重置为 默认。"
+                )
+                cfg["emoji_filter_mode"] = "默认"
+
         # Playwright 模式校验
         pw_mode = cfg.get("playwright_mode")
         valid_modes = ["local", "remote"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,7 @@ from .emoji_filter import (
     EMOJI_FILTER_MODE_MINIMAL,
     EMOJI_FILTER_MODE_OFF,
     filter_push_text_emoji,
+    is_known_emoji_filter_mode,
     normalize_emoji_filter_mode,
 )
 from .geolocation import close_geoip_session, fetch_location_from_ip, get_geoip_session
@@ -22,6 +23,7 @@ __all__ = [
     "EMOJI_FILTER_MODE_MINIMAL",
     "EMOJI_FILTER_MODE_OFF",
     "filter_push_text_emoji",
+    "is_known_emoji_filter_mode",
     "normalize_emoji_filter_mode",
     "close_geoip_session",
     "fetch_location_from_ip",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,9 +1,16 @@
 """
 插件辅助工具子包。
-包含 IP 物理定位（GeoIP）、地图瓦片 URL 映射、时区转换格式化、版本识别探测以及烈度制式转换等基础通用库。
+包含 IP 物理定位（GeoIP）、地图瓦片 URL 映射、时区转换格式化、emoji过滤、版本识别探测以及烈度制式转换等基础通用库。
 """
 
 from .converters import ScaleConverter
+from .emoji_filter import (
+    EMOJI_FILTER_MODE_DEFAULT,
+    EMOJI_FILTER_MODE_MINIMAL,
+    EMOJI_FILTER_MODE_OFF,
+    filter_push_text_emoji,
+    normalize_emoji_filter_mode,
+)
 from .geolocation import close_geoip_session, fetch_location_from_ip, get_geoip_session
 from .map_tile_sources import get_tile_url, get_tile_url_js, normalize_map_source
 from .time_converter import TimeConverter
@@ -11,6 +18,11 @@ from .version import get_astrbot_version, get_astrbot_version_info, get_plugin_v
 
 __all__ = [
     "ScaleConverter",
+    "EMOJI_FILTER_MODE_DEFAULT",
+    "EMOJI_FILTER_MODE_MINIMAL",
+    "EMOJI_FILTER_MODE_OFF",
+    "filter_push_text_emoji",
+    "normalize_emoji_filter_mode",
     "close_geoip_session",
     "fetch_location_from_ip",
     "get_geoip_session",

--- a/utils/emoji_filter.py
+++ b/utils/emoji_filter.py
@@ -22,6 +22,20 @@ VALID_EMOJI_FILTER_MODES: Final[frozenset[str]] = frozenset(
     }
 )
 
+# 英文/历史别名 → 标准三档（校验层与运行时共用，避免双份映射漂移）
+_EMOJI_FILTER_MODE_ALIASES: Final[dict[str, str]] = {
+    "default": EMOJI_FILTER_MODE_DEFAULT,
+    "full": EMOJI_FILTER_MODE_DEFAULT,
+    "minimal": EMOJI_FILTER_MODE_MINIMAL,
+    "simple": EMOJI_FILTER_MODE_MINIMAL,
+    "compact": EMOJI_FILTER_MODE_MINIMAL,
+    "off": EMOJI_FILTER_MODE_OFF,
+    "none": EMOJI_FILTER_MODE_OFF,
+    "disable": EMOJI_FILTER_MODE_OFF,
+    "disabled": EMOJI_FILTER_MODE_OFF,
+    "close": EMOJI_FILTER_MODE_OFF,
+}
+
 # 简洁模式白名单：烈度/震度方形/圆形指示器，以及气象/台风等严重性颜色指示图标。
 # 与 earthquake_presenter / weather_constants / typhoon_display_format 中的指示器对齐。
 SEVERITY_INDICATOR_EMOJIS: Final[frozenset[str]] = frozenset(
@@ -49,7 +63,8 @@ SEVERITY_INDICATOR_EMOJIS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# 覆盖常见 emoji 序列：基础符号、补充符号、旗帜、肤色修饰、ZWJ 组合、变体选择符等。
+# 覆盖推送文本中常见的 emoji 序列。
+# 刻意不整段吞并箭头/杂项技术符号区，避免把正文中的 → 等普通符号误删。
 # 不依赖第三方库，避免为展示层过滤引入额外运行时依赖。
 _EMOJI_PATTERN = re.compile(
     "("
@@ -61,27 +76,19 @@ _EMOJI_PATTERN = re.compile(
     r"[\U0001F300-\U0001F5FF]"  # 杂项符号与象形文字
     r"|[\U0001F600-\U0001F64F]"  # 表情符号
     r"|[\U0001F680-\U0001F6FF]"  # 交通与地图符号
-    r"|[\U0001F700-\U0001F77F]"  # 炼金术符号
     r"|[\U0001F780-\U0001F7FF]"  # 几何图形扩展（含彩色方块/圆形）
-    r"|[\U0001F800-\U0001F8FF]"  # 补充箭头-C
     r"|[\U0001F900-\U0001F9FF]"  # 补充符号与象形文字
-    r"|[\U0001FA00-\U0001FA6F]"  # 国际象棋符号
     r"|[\U0001FA70-\U0001FAFF]"  # 符号与象形文字扩展-A
-    r"|[\U00002700-\U000027BF]"  # 装饰符号
-    r"|[\U00002600-\U000026FF]"  # 杂项符号
-    r"|[\U00002300-\U000023FF]"  # 杂项技术符号
-    r"|[\U00002B00-\U00002BFF]"  # 杂项符号与箭头
-    r"|[\U00002900-\U0000297F]"  # 补充箭头-B
-    r"|[\U00002190-\U000021FF]"  # 箭头
-    r"|[\U00003030\U0000303D\U00003297\U00003299]"  # 波浪线/部分封闭表意文字
-    r"|[\U000000A9\U000000AE\U0000203C\U00002049\U00002122\U00002139]"  # 版权/注册/叹号问号等
-    r"|[\U00002194-\U00002199\U000021A9\U000021AA]"  # 双向箭头与弯箭头
+    r"|[\U00002700-\U000027BF]"  # 装饰符号（含 ⚡ 等）
+    r"|[\U00002600-\U000026FF]"  # 杂项符号（含 ⚠☀☁ 等）
+    # 下列为“确实会以 emoji 形态出现”的精确子集，而非整段 Unicode 区
     r"|[\U0000231A\U0000231B\U00002328\U000023CF]"  # 手表/沙漏/键盘/弹出
     r"|[\U000023E9-\U000023F3\U000023F8-\U000023FA]"  # 播放控制与计时符号
-    r"|[\U000024C2\U000025AA\U000025AB\U000025B6\U000025C0]"  # 圆圈字母与几何播放符
+    r"|[\U000025AA\U000025AB\U000025B6\U000025C0]"  # 几何播放符
     r"|[\U000025FB-\U000025FE]"  # 中等几何方块
     r"|[\U00002B05-\U00002B07\U00002B1B\U00002B1C\U00002B50\U00002B55]"  # 方向箭头/大方块/星/圆
     r"|[\U00002934\U00002935]"  # 弧形箭头
+    r"|[\U00003030\U0000303D\U00003297\U00003299]"  # 波浪线/部分封闭表意文字
     r")"
     r"[\U0001F3FB-\U0001F3FF]?"  # 肤色修饰符
     r"(?:\uFE0E|\uFE0F)?"  # 文本/emoji 变体选择符
@@ -97,10 +104,8 @@ _EMOJI_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
-# 过滤后清理：连续空白压成单空格，但保留换行结构。
-_MULTI_SPACE_PATTERN = re.compile(r"[^\S\n]{2,}")
+# 仅清理“行尾因删除 emoji 残留的水平空白”，不压缩原文空格、不破坏行首缩进。
 _TRAILING_SPACE_PATTERN = re.compile(r"[ \t]+\n")
-_LEADING_SPACE_PATTERN = re.compile(r"\n[ \t]+")
 
 
 def normalize_emoji_filter_mode(mode: str | None) -> str:
@@ -110,39 +115,38 @@ def normalize_emoji_filter_mode(mode: str | None) -> str:
     value = mode.strip()
     if value in VALID_EMOJI_FILTER_MODES:
         return value
-    # 兼容可能的英文别名
-    aliases = {
-        "default": EMOJI_FILTER_MODE_DEFAULT,
-        "full": EMOJI_FILTER_MODE_DEFAULT,
-        "minimal": EMOJI_FILTER_MODE_MINIMAL,
-        "simple": EMOJI_FILTER_MODE_MINIMAL,
-        "compact": EMOJI_FILTER_MODE_MINIMAL,
-        "off": EMOJI_FILTER_MODE_OFF,
-        "none": EMOJI_FILTER_MODE_OFF,
-        "disable": EMOJI_FILTER_MODE_OFF,
-        "disabled": EMOJI_FILTER_MODE_OFF,
-        "close": EMOJI_FILTER_MODE_OFF,
-    }
-    return aliases.get(value.lower(), EMOJI_FILTER_MODE_DEFAULT)
+    return _EMOJI_FILTER_MODE_ALIASES.get(value.lower(), EMOJI_FILTER_MODE_DEFAULT)
+
+
+def is_known_emoji_filter_mode(mode: str | None) -> bool:
+    """判断输入是否为标准三档或已登记别名（空串视为未知）。"""
+    if not isinstance(mode, str):
+        return False
+    value = mode.strip()
+    if not value:
+        return False
+    if value in VALID_EMOJI_FILTER_MODES:
+        return True
+    return value.lower() in _EMOJI_FILTER_MODE_ALIASES
 
 
 def _cleanup_spaces(text: str) -> str:
-    """清理 emoji 删除后残留的多余空白，尽量保持原有换行排版。"""
+    """清理 emoji 删除后残留的行尾空白，尽量保持原有排版。
+
+    - 去掉换行前多余空格/制表符
+    - 去掉整段末尾水平空白
+    - 不删除行首缩进
+    - 不压缩正文中原有的连续空格
+    """
     text = _TRAILING_SPACE_PATTERN.sub("\n", text)
-    text = _LEADING_SPACE_PATTERN.sub("\n", text)
-    text = _MULTI_SPACE_PATTERN.sub(" ", text)
-    return text.strip(" \t")
+    return text.rstrip(" \t")
 
 
 def _is_severity_indicator(emoji: str) -> bool:
     """判断是否为简洁模式应保留的严重性指示图标。"""
     # 去掉变体选择符后再比对，兼容 ⚪︎ / ⚪️ 等写法。
     normalized = emoji.replace("\ufe0f", "").replace("\ufe0e", "")
-    if normalized in SEVERITY_INDICATOR_EMOJIS:
-        return True
-    if emoji in SEVERITY_INDICATOR_EMOJIS:
-        return True
-    return False
+    return normalized in SEVERITY_INDICATOR_EMOJIS
 
 
 def filter_push_text_emoji(text: str, mode: str | None = None) -> str:
@@ -163,11 +167,7 @@ def filter_push_text_emoji(text: str, mode: str | None = None) -> str:
         return text
 
     if normalized_mode == EMOJI_FILTER_MODE_OFF:
-
-        def _remove_all(match: re.Match[str]) -> str:
-            return ""
-
-        filtered = _EMOJI_PATTERN.sub(_remove_all, text)
+        filtered = _EMOJI_PATTERN.sub("", text)
         return _cleanup_spaces(filtered)
 
     # 简洁模式：仅保留严重性指示图标
@@ -186,5 +186,6 @@ __all__ = [
     "VALID_EMOJI_FILTER_MODES",
     "SEVERITY_INDICATOR_EMOJIS",
     "normalize_emoji_filter_mode",
+    "is_known_emoji_filter_mode",
     "filter_push_text_emoji",
 ]

--- a/utils/emoji_filter.py
+++ b/utils/emoji_filter.py
@@ -1,0 +1,190 @@
+"""推送文本 Emoji 过滤工具。
+
+仅供预警推送链路使用：在文本消息构建完成后按配置模式过滤 emoji。
+插件指令回复等其他场景不应调用本模块，以保持其原有展示风格。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# 配置项可选值（与 _conf_schema.json 保持一致）
+EMOJI_FILTER_MODE_DEFAULT: Final[str] = "默认"
+EMOJI_FILTER_MODE_MINIMAL: Final[str] = "简洁"
+EMOJI_FILTER_MODE_OFF: Final[str] = "关闭"
+
+VALID_EMOJI_FILTER_MODES: Final[frozenset[str]] = frozenset(
+    {
+        EMOJI_FILTER_MODE_DEFAULT,
+        EMOJI_FILTER_MODE_MINIMAL,
+        EMOJI_FILTER_MODE_OFF,
+    }
+)
+
+# 简洁模式白名单：烈度/震度方形/圆形指示器，以及气象/台风等严重性颜色指示图标。
+# 与 earthquake_presenter / weather_constants / typhoon_display_format 中的指示器对齐。
+SEVERITY_INDICATOR_EMOJIS: Final[frozenset[str]] = frozenset(
+    {
+        # 圆形颜色指示（EEW / 气象颜色 / 台风等级）
+        "⚪",
+        "⚫",
+        "🔴",
+        "🟠",
+        "🟡",
+        "🟢",
+        "🔵",
+        "🟣",
+        "🟤",
+        # 方形颜色指示（地震情报场景）
+        "⬜",
+        "⬛",
+        "🟥",
+        "🟧",
+        "🟨",
+        "🟩",
+        "🟦",
+        "🟪",
+        "🟫",
+    }
+)
+
+# 覆盖常见 emoji 序列：基础符号、补充符号、旗帜、肤色修饰、ZWJ 组合、变体选择符等。
+# 不依赖第三方库，避免为展示层过滤引入额外运行时依赖。
+_EMOJI_PATTERN = re.compile(
+    "("
+    # 区域指示符国旗（成对出现）
+    r"[\U0001F1E6-\U0001F1FF]{2}"
+    r"|"
+    # 常见 emoji 与符号区段 + 可选肤色 + 可选变体选择符 + 可选零宽连接续接
+    r"(?:"
+    r"[\U0001F300-\U0001F5FF]"  # 杂项符号与象形文字
+    r"|[\U0001F600-\U0001F64F]"  # 表情符号
+    r"|[\U0001F680-\U0001F6FF]"  # 交通与地图符号
+    r"|[\U0001F700-\U0001F77F]"  # 炼金术符号
+    r"|[\U0001F780-\U0001F7FF]"  # 几何图形扩展（含彩色方块/圆形）
+    r"|[\U0001F800-\U0001F8FF]"  # 补充箭头-C
+    r"|[\U0001F900-\U0001F9FF]"  # 补充符号与象形文字
+    r"|[\U0001FA00-\U0001FA6F]"  # 国际象棋符号
+    r"|[\U0001FA70-\U0001FAFF]"  # 符号与象形文字扩展-A
+    r"|[\U00002700-\U000027BF]"  # 装饰符号
+    r"|[\U00002600-\U000026FF]"  # 杂项符号
+    r"|[\U00002300-\U000023FF]"  # 杂项技术符号
+    r"|[\U00002B00-\U00002BFF]"  # 杂项符号与箭头
+    r"|[\U00002900-\U0000297F]"  # 补充箭头-B
+    r"|[\U00002190-\U000021FF]"  # 箭头
+    r"|[\U00003030\U0000303D\U00003297\U00003299]"  # 波浪线/部分封闭表意文字
+    r"|[\U000000A9\U000000AE\U0000203C\U00002049\U00002122\U00002139]"  # 版权/注册/叹号问号等
+    r"|[\U00002194-\U00002199\U000021A9\U000021AA]"  # 双向箭头与弯箭头
+    r"|[\U0000231A\U0000231B\U00002328\U000023CF]"  # 手表/沙漏/键盘/弹出
+    r"|[\U000023E9-\U000023F3\U000023F8-\U000023FA]"  # 播放控制与计时符号
+    r"|[\U000024C2\U000025AA\U000025AB\U000025B6\U000025C0]"  # 圆圈字母与几何播放符
+    r"|[\U000025FB-\U000025FE]"  # 中等几何方块
+    r"|[\U00002B05-\U00002B07\U00002B1B\U00002B1C\U00002B50\U00002B55]"  # 方向箭头/大方块/星/圆
+    r"|[\U00002934\U00002935]"  # 弧形箭头
+    r")"
+    r"[\U0001F3FB-\U0001F3FF]?"  # 肤色修饰符
+    r"(?:\uFE0E|\uFE0F)?"  # 文本/emoji 变体选择符
+    r"(?:"
+    r"\u200D"
+    r"(?:"
+    r"[\U0001F300-\U0001FAFF\U00002700-\U000027BF\U00002600-\U000026FF]"
+    r"[\U0001F3FB-\U0001F3FF]?"
+    r"(?:\uFE0E|\uFE0F)?"
+    r")+"
+    r")?"
+    r")",
+    flags=re.UNICODE,
+)
+
+# 过滤后清理：连续空白压成单空格，但保留换行结构。
+_MULTI_SPACE_PATTERN = re.compile(r"[^\S\n]{2,}")
+_TRAILING_SPACE_PATTERN = re.compile(r"[ \t]+\n")
+_LEADING_SPACE_PATTERN = re.compile(r"\n[ \t]+")
+
+
+def normalize_emoji_filter_mode(mode: str | None) -> str:
+    """将配置值规范化为三档之一；非法值回退为默认。"""
+    if not isinstance(mode, str):
+        return EMOJI_FILTER_MODE_DEFAULT
+    value = mode.strip()
+    if value in VALID_EMOJI_FILTER_MODES:
+        return value
+    # 兼容可能的英文别名
+    aliases = {
+        "default": EMOJI_FILTER_MODE_DEFAULT,
+        "full": EMOJI_FILTER_MODE_DEFAULT,
+        "minimal": EMOJI_FILTER_MODE_MINIMAL,
+        "simple": EMOJI_FILTER_MODE_MINIMAL,
+        "compact": EMOJI_FILTER_MODE_MINIMAL,
+        "off": EMOJI_FILTER_MODE_OFF,
+        "none": EMOJI_FILTER_MODE_OFF,
+        "disable": EMOJI_FILTER_MODE_OFF,
+        "disabled": EMOJI_FILTER_MODE_OFF,
+        "close": EMOJI_FILTER_MODE_OFF,
+    }
+    return aliases.get(value.lower(), EMOJI_FILTER_MODE_DEFAULT)
+
+
+def _cleanup_spaces(text: str) -> str:
+    """清理 emoji 删除后残留的多余空白，尽量保持原有换行排版。"""
+    text = _TRAILING_SPACE_PATTERN.sub("\n", text)
+    text = _LEADING_SPACE_PATTERN.sub("\n", text)
+    text = _MULTI_SPACE_PATTERN.sub(" ", text)
+    return text.strip(" \t")
+
+
+def _is_severity_indicator(emoji: str) -> bool:
+    """判断是否为简洁模式应保留的严重性指示图标。"""
+    # 去掉变体选择符后再比对，兼容 ⚪︎ / ⚪️ 等写法。
+    normalized = emoji.replace("\ufe0f", "").replace("\ufe0e", "")
+    if normalized in SEVERITY_INDICATOR_EMOJIS:
+        return True
+    if emoji in SEVERITY_INDICATOR_EMOJIS:
+        return True
+    return False
+
+
+def filter_push_text_emoji(text: str, mode: str | None = None) -> str:
+    """按模式过滤推送文本中的 emoji。
+
+    参数：
+    - text：原始推送文本
+    - mode：默认 / 简洁 / 关闭
+
+    返回：
+    - 过滤后的文本；默认模式原样返回
+    """
+    if not text:
+        return text
+
+    normalized_mode = normalize_emoji_filter_mode(mode)
+    if normalized_mode == EMOJI_FILTER_MODE_DEFAULT:
+        return text
+
+    if normalized_mode == EMOJI_FILTER_MODE_OFF:
+
+        def _remove_all(match: re.Match[str]) -> str:
+            return ""
+
+        filtered = _EMOJI_PATTERN.sub(_remove_all, text)
+        return _cleanup_spaces(filtered)
+
+    # 简洁模式：仅保留严重性指示图标
+    def _keep_severity(match: re.Match[str]) -> str:
+        token = match.group(0)
+        return token if _is_severity_indicator(token) else ""
+
+    filtered = _EMOJI_PATTERN.sub(_keep_severity, text)
+    return _cleanup_spaces(filtered)
+
+
+__all__ = [
+    "EMOJI_FILTER_MODE_DEFAULT",
+    "EMOJI_FILTER_MODE_MINIMAL",
+    "EMOJI_FILTER_MODE_OFF",
+    "VALID_EMOJI_FILTER_MODES",
+    "SEVERITY_INDICATOR_EMOJIS",
+    "normalize_emoji_filter_mode",
+    "filter_push_text_emoji",
+]


### PR DESCRIPTION
﻿##  描述 / Description

从 #151（`dev/local`）中拆出的独立改动，避免与原 PR 混在一起。

为预警推送文本增加 Emoji 过滤三档模式（默认 / 简洁 / 关闭），便于在部分客户端或场景下减少装饰性 emoji，同时保留烈度/严重性颜色指示图标。

说明：原误推的 4 个 commit 中，S-Net 震度图标样式依赖 `resources/snet_data/SREV/*`，而 `dev/1.6.0` 上尚无这些资源（在 #151 的 S-Net 功能链路中）。因此图标样式 commit 仍保留在 #151 / `dev/local`，本 PR 仅包含 Emoji 过滤相关 3 个 commit。

feat #132 

##  改动点 / Modifications

- 新增 `utils/emoji_filter.py`：推送文本 Emoji 过滤工具（默认/简洁/关闭）
- `_conf_schema.json`：`message_format.emoji_filter_mode` 配置项
- `config_validation_service.py`：模式校验与别名规范化
- `text_message_builder.py`：仅在预警推送文本构建出口应用过滤
- `push_execution_service.py`：消息复用缓存键纳入 `emoji_filter_mode`
- `utils/__init__.py`：导出公共 API

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.

##  运行截图或测试结果 / Screenshots or Test Results

本地快速验证（过滤逻辑）：

```text
MINIMAL: 仅保留烈度/严重性颜色指示图标
OFF: 不输出任何 emoji
DEFAULT: 与原文一致
```

建议在管理端将 `message_format.emoji_filter_mode` 分别设为「默认 / 简洁 / 关闭」后触发一次预警推送核对正文。

##  检查清单 / Checklist

- [x]  如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x]  我的更改经过了良好的测试，**并已在上方提供了运行截图或测试日志**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x]  我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x]  我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

##  CONTRIBUTING

- [x]  我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

为灾害预警推送短信引入可配置的表情符号过滤模式，并在消息构建/推送流水线中应用。

新功能：
- 为灾害预警推送短信添加一个具有三种模式（默认 / 简洁 / 关闭）的表情符号过滤工具。
- 通过全局配置模式中的 `message_format.emoji_filter_mode` 选项暴露表情符号过滤配置。

改进：
- 在配置验证服务中校验并规范化 `emoji_filter_mode` 的取值，包括常见的英文别名。
- 仅对推送短信应用表情符号过滤，同时为其他复用场景保留完整的展示层输出。
- 从 `utils` 包导出表情符号过滤 API，以便在整个代码库中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable emoji filtering modes for disaster warning push text messages and apply them in the message build/push pipeline.

New Features:
- Add an emoji filtering utility with three modes (默认 / 简洁 / 关闭) for disaster warning push text messages.
- Expose emoji filtering configuration via the message_format.emoji_filter_mode option in the global configuration schema.

Enhancements:
- Validate and normalize emoji_filter_mode values, including common English aliases, in the configuration validation service.
- Apply emoji filtering only to push text messages while preserving full presenter output for other reuse scenarios.
- Export emoji filtering APIs from the utils package for reuse across the codebase.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增预警推送文本的 Emoji 过滤设置，支持“默认”“简洁”“关闭”三种模式。
  * “简洁”模式保留严重性指示图标；“关闭”模式移除推送文本中的 Emoji。
  * 配置支持默认值、别名及无效值自动校正。
* **优化**
  * 不同 Emoji 过滤设置将分别生成对应的推送内容，避免内容显示错误。
  * 过滤仅影响推送文本，不影响其他消息场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->