### PR TITLE
feat: 海啸全链路升级、修复GQ最终报支持、页面池恢复重建增强与HTTP基类抽取

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,10 +683,10 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 - **JMA 每收到 N 报推送一次**:
   - 适用于日本气象厅。设置 `jma_report_n = 3` 意味着第 1、3、6、9... 报会被推送。
 - **Global Quake 每收到 N 报推送一次**:
-  - 适用于 GQ。
+  - 适用于 GQ。GQ 在协议升级后会通过 `ARCHIVED` 动作发出归档/最终报。
 - **首报推送保证**: **（插件核心逻辑）** 无论 N 设置为多少，事件的第一报总是会第一时间送达。（固定配置）
-- **最终报总是推送 (`final_report_always_push`)**: 确保用户能看到修正后的最终震级和烈度。
-- **忽略非最终报 (`ignore_non_final_reports`)**: 极致精简配置，只发送第一报和最终报，仅适用于 JMA 相关数据源。
+- **最终报总是推送 (`final_report_always_push`)**: 确保用户能看到修正后的最终震级和烈度。适用于 JMA 与 Global Quake 等支持最终报标记的数据源。
+- **忽略非最终报 (`ignore_non_final_reports`)**: 极致精简配置，只发送第一报和最终报，适用于支持最终报的数据源（如 JMA、Global Quake）。
 
 ```json
 "push_frequency_control": {
@@ -2179,7 +2179,7 @@ graph TB
 >**A**: 这是由于地震预警（EEW）具有随震情演进而不断更新报数的特性（数据会随时间推移变得更精准）。
 >
 > 1. **调大间隔**：您可以在 **推送频率控制 (`push_frequency_control`)** 中调大 `每收到N报推送一次` 的参数。
-> 2. **极简模式**：开启 **是否忽略非最终报 (`ignore_non_final_reports`)**，这样插件只会推送事件的第一报和最后一报。仅适用于 JMA 相关数据源。
+> 2. **极简模式**：开启 **是否忽略非最终报 (`ignore_non_final_reports`)**，这样插件只会推送事件的第一报和最后一报。适用于支持最终报的数据源（如 JMA、Global Quake）。
 
 **Q: 为什么插件预警推送了很多我不关心的地区？**
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -202,12 +202,6 @@
             "default": true,
             "hint": "控制 EQSC 通道是否启用（鉴权、连通性、后续子能力入口）。关闭后所有 EQSC 子能力均不可用。"
           },
-          "typhoon_enrichment": {
-            "description": "启用台风富化",
-            "type": "bool",
-            "default": true,
-            "hint": "启用后，收到 FAN Studio 台风推送时将自动向 EQSC 拉取详细轨迹与风圈。未启用时台风仅使用 FAN Studio 基础数据展示。"
-          },
           "base_url": {
             "description": "EQSC API 基础地址",
             "type": "string",
@@ -221,6 +215,12 @@
             "hint": "从 EQuake 设置界面获取的访问令牌（以 ARh. 开头），用于创建 AccessToken。请妥善保管，不要泄露。",
             "hidden": true
           },
+          "typhoon_enrichment": {
+            "description": "启用台风富化",
+            "type": "bool",
+            "default": true,
+            "hint": "启用后，收到 FAN Studio 台风推送时将自动向 EQSC 拉取详细轨迹与风圈。未启用时台风仅使用 FAN Studio 基础数据展示。"
+          },
           "cache_ttl": {
             "description": "台风数据缓存时间",
             "type": "int",
@@ -230,6 +230,40 @@
               "min": 60,
               "max": 3600,
               "step": 30
+            }
+          },
+          "jma_tsunami": {
+            "description": "日本气象厅：津波予報（EQSC）",
+            "type": "bool",
+            "default": true,
+            "hint": "通过 EQSC HTTP 轮询获取日本气象厅海啸情报，作为 P2P 津波予報的高优先级补充。字段更完整（eventID、震中、区域波高/初波状态等）。"
+          },
+          "jma_tsunami_poll_interval_seconds": {
+            "description": "海啸轮询间隔（秒）",
+            "type": "int",
+            "default": 60,
+            "hint": "单位：秒。EQSC 海啸快照轮询间隔。海啸更新不频繁，建议 30~120 秒。",
+            "slider": {
+              "min": 15,
+              "max": 300,
+              "step": 10
+            }
+          },
+          "jma_tsunami_include_training": {
+            "description": "接收海啸训练报",
+            "type": "bool",
+            "default": false,
+            "hint": "是否推送 EQSC 标记为训练报（isTraining）的海啸情报。默认忽略。"
+          },
+          "tsunami_cache_ttl": {
+            "description": "海啸数据缓存时间",
+            "type": "int",
+            "hint": "单位：秒。EQSC 海啸快照内存缓存有效期，用于短时并发复用；轮询本身会绕过缓存强制刷新。",
+            "default": 60,
+            "slider": {
+              "min": 15,
+              "max": 300,
+              "step": 15
             }
           }
         }
@@ -595,7 +629,7 @@
       "ignore_non_final_reports": {
         "description": "是否忽略非最终报",
         "type": "bool",
-        "hint": "只推送最终报（以及第1报），仅适用于 JMA 相关数据源",
+        "hint": "只推送最终报（以及第1报），适用于支持最终报的数据源（如 JMA、Global Quake）",
         "default": false
       }
     }
@@ -758,6 +792,64 @@
         "type": "bool",
         "hint": "启用后将根据预警类型自动在消息末尾附加中国气象局官方图标。",
         "default": true
+      }
+    }
+  },
+  "tsunami_config": {
+    "description": "🌊 海啸信息配置",
+    "type": "object",
+    "hint": "配置中国/日本海啸推送的最低警报级别阈值过滤。",
+    "items": {
+      "china_filter": {
+        "description": "中国海啸过滤器",
+        "type": "object",
+        "hint": "针对自然资源部海啸预警中心（Fan Studio）推送。解除通告始终放行。",
+        "items": {
+          "enabled": {
+            "description": "启用中国海啸过滤",
+            "type": "bool",
+            "hint": "关闭时只要数据源开启且通过去重即推送。",
+            "default": false
+          },
+          "min_level": {
+            "description": "最低警报级别",
+            "type": "string",
+            "options": [
+              "信息",
+              "蓝色",
+              "黄色",
+              "橙色",
+              "红色"
+            ],
+            "default": "信息",
+            "hint": "只推送等于或高于此级别的海啸。级别排序：信息 < 蓝色 < 黄色 < 橙色 < 红色"
+          }
+        }
+      },
+      "japan_filter": {
+        "description": "日本海啸过滤器",
+        "type": "object",
+        "hint": "针对日本气象厅海啸情报（P2P / EQSC）。解除通告始终放行。",
+        "items": {
+          "enabled": {
+            "description": "启用日本海啸过滤",
+            "type": "bool",
+            "hint": "关闭时只要数据源开启且通过去重即推送。",
+            "default": false
+          },
+          "min_level": {
+            "description": "最低警报级别",
+            "type": "string",
+            "options": [
+              "若干海面变动",
+              "海啸注意报",
+              "海啸警报",
+              "大海啸警报"
+            ],
+            "default": "若干海面变动",
+            "hint": "只推送等于或高于此级别的海啸。级别排序：若干海面变动 < 海啸注意报 < 海啸警报 < 大海啸警报"
+          }
+        }
       }
     }
   },

--- a/admin/css/views/events.css
+++ b/admin/css/views/events.css
@@ -903,6 +903,261 @@ html.theme-dark .event-filter-source-menu {
     opacity: 0.5;
 }
 
+/* 台风 / 海啸卡片第二行参数摘要 */
+.event-meta-typhoon,
+.event-meta-tsunami {
+    opacity: 0.72;
+    margin-top: 2px;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+}
+
+/* ---- 海啸结构化面板（对齐推送展示器信息密度） ---- */
+.event-tsunami-panel {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+
+.event-tsunami-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.event-tsunami-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.35;
+    border: 1px solid transparent;
+    background: color-mix(in srgb, var(--md-sys-color-surface-variant) 82%, transparent);
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.event-tsunami-chip-icon {
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 1;
+}
+
+.event-tsunami-chip-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.event-tsunami-chip.is-info,
+.event-tsunami-chip.is-default {
+    background: color-mix(in srgb, #0288D1 12%, var(--md-sys-color-surface));
+    color: #0277BD;
+    border-color: color-mix(in srgb, #0288D1 22%, transparent);
+}
+
+.event-tsunami-chip.is-blue {
+    background: color-mix(in srgb, #1E88E5 14%, var(--md-sys-color-surface));
+    color: #1565C0;
+    border-color: color-mix(in srgb, #1E88E5 24%, transparent);
+}
+
+.event-tsunami-chip.is-watch {
+    background: color-mix(in srgb, #F9A825 16%, var(--md-sys-color-surface));
+    color: #F57F17;
+    border-color: color-mix(in srgb, #F9A825 28%, transparent);
+}
+
+.event-tsunami-chip.is-warning {
+    background: color-mix(in srgb, #FB8C00 16%, var(--md-sys-color-surface));
+    color: #EF6C00;
+    border-color: color-mix(in srgb, #FB8C00 28%, transparent);
+}
+
+.event-tsunami-chip.is-major,
+.event-tsunami-chip.is-danger {
+    background: color-mix(in srgb, #E53935 14%, var(--md-sys-color-surface));
+    color: #C62828;
+    border-color: color-mix(in srgb, #E53935 26%, transparent);
+}
+
+.event-tsunami-chip.is-wave,
+.event-tsunami-chip.is-area,
+.event-tsunami-chip.is-station {
+    background: color-mix(in srgb, #00ACC1 12%, var(--md-sys-color-surface));
+    color: #00838F;
+    border-color: color-mix(in srgb, #00ACC1 24%, transparent);
+}
+
+.event-tsunami-chip.is-place,
+.event-tsunami-chip.is-mag {
+    background: color-mix(in srgb, var(--md-sys-color-primary) 12%, var(--md-sys-color-surface));
+    color: var(--md-sys-color-primary);
+    border-color: color-mix(in srgb, var(--md-sys-color-primary) 22%, transparent);
+}
+
+.event-tsunami-chip.is-cancel {
+    background: color-mix(in srgb, #43A047 14%, var(--md-sys-color-surface));
+    color: #2E7D32;
+    border-color: color-mix(in srgb, #43A047 24%, transparent);
+}
+
+.event-tsunami-chip.is-training {
+    background: color-mix(in srgb, #8E24AA 12%, var(--md-sys-color-surface));
+    color: #6A1B9A;
+    border-color: color-mix(in srgb, #8E24AA 24%, transparent);
+}
+
+.event-tsunami-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.event-tsunami-section {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: color-mix(in srgb, #0288D1 7%, var(--md-sys-color-surface));
+    border: 1px solid color-mix(in srgb, #0288D1 14%, transparent);
+}
+
+.event-tsunami-section.is-forecast {
+    background: color-mix(in srgb, #0288D1 8%, var(--md-sys-color-surface));
+}
+
+.event-tsunami-section.is-station {
+    background: color-mix(in srgb, #00838F 8%, var(--md-sys-color-surface));
+    border-color: color-mix(in srgb, #00838F 16%, transparent);
+}
+
+.event-tsunami-section.is-grade {
+    background: color-mix(in srgb, #5E35B1 8%, var(--md-sys-color-surface));
+    border-color: color-mix(in srgb, #5E35B1 16%, transparent);
+}
+
+.event-tsunami-section-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--md-sys-color-on-surface);
+}
+
+.event-tsunami-section-icon {
+    font-size: 13px;
+    line-height: 1;
+}
+
+.event-tsunami-section-title {
+    letter-spacing: 0.01em;
+}
+
+.event-tsunami-section-list {
+    margin: 0;
+    padding-left: 1.1em;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 12px;
+    line-height: 1.45;
+    color: color-mix(in srgb, var(--md-sys-color-on-surface) 82%, transparent);
+}
+
+.event-tsunami-section-list li {
+    word-break: break-word;
+}
+
+.event-tsunami-section-body {
+    font-size: 12px;
+    line-height: 1.45;
+    color: color-mix(in srgb, var(--md-sys-color-on-surface) 82%, transparent);
+    word-break: break-word;
+}
+
+.event-tsunami-panel.is-history .event-tsunami-chip {
+    font-size: 11px;
+    padding: 2px 8px;
+}
+
+.event-tsunami-panel.is-history .event-tsunami-section {
+    padding: 6px 8px;
+}
+
+.event-tsunami-panel.is-history .event-tsunami-section-list,
+.event-tsunami-panel.is-history .event-tsunami-section-body,
+.event-tsunami-panel.is-history .event-tsunami-section-head {
+    font-size: 11px;
+}
+
+body.dark-theme .event-tsunami-chip.is-info,
+body.dark-theme .event-tsunami-chip.is-default {
+    background: rgba(3, 169, 244, 0.16);
+    color: #81D4FA;
+    border-color: rgba(3, 169, 244, 0.28);
+}
+
+body.dark-theme .event-tsunami-chip.is-watch {
+    background: rgba(255, 193, 7, 0.16);
+    color: #FFE082;
+    border-color: rgba(255, 193, 7, 0.28);
+}
+
+body.dark-theme .event-tsunami-chip.is-warning {
+    background: rgba(255, 152, 0, 0.16);
+    color: #FFCC80;
+    border-color: rgba(255, 152, 0, 0.28);
+}
+
+body.dark-theme .event-tsunami-chip.is-major,
+body.dark-theme .event-tsunami-chip.is-danger {
+    background: rgba(244, 67, 54, 0.16);
+    color: #EF9A9A;
+    border-color: rgba(244, 67, 54, 0.28);
+}
+
+body.dark-theme .event-tsunami-chip.is-wave,
+body.dark-theme .event-tsunami-chip.is-area,
+body.dark-theme .event-tsunami-chip.is-station {
+    background: rgba(0, 188, 212, 0.14);
+    color: #80DEEA;
+    border-color: rgba(0, 188, 212, 0.26);
+}
+
+body.dark-theme .event-tsunami-chip.is-cancel {
+    background: rgba(76, 175, 80, 0.16);
+    color: #A5D6A7;
+    border-color: rgba(76, 175, 80, 0.28);
+}
+
+body.dark-theme .event-tsunami-chip.is-training {
+    background: rgba(171, 71, 188, 0.16);
+    color: #CE93D8;
+    border-color: rgba(171, 71, 188, 0.28);
+}
+
+body.dark-theme .event-tsunami-section {
+    background: rgba(3, 169, 244, 0.08);
+    border-color: rgba(3, 169, 244, 0.18);
+}
+
+body.dark-theme .event-tsunami-section.is-station {
+    background: rgba(0, 188, 212, 0.08);
+    border-color: rgba(0, 188, 212, 0.18);
+}
+
+body.dark-theme .event-tsunami-section.is-grade {
+    background: rgba(126, 87, 194, 0.12);
+    border-color: rgba(126, 87, 194, 0.22);
+}
+
 /* 标示地震速报已升级或有新的警报更新徽标 */
 .update-badge {
     display: inline-flex;

--- a/admin/js/components/events/EventCard.jsx
+++ b/admin/js/components/events/EventCard.jsx
@@ -21,13 +21,16 @@ function EventCard({
     isExpanded = false, 
     reportIndex = null 
 }) {
+    const formatters = window.EventFormatSerialization || window.EventFormatters || {};
     const {
         buildEarthquakeTitle,
         getEarthquakeBadgeContent,
         buildWeatherIconFallbackHandler: _rawBuildHandler,
         resolveWeatherColor = () => null,
         resolveWeatherFallbackUrl = () => null,
-    } = window.EventFormatSerialization || window.EventFormatters || {};
+        buildTsunamiTitle = null,
+        buildTsunamiMeta = null,
+    } = formatters;
     const buildWeatherIconFallbackHandler = _rawBuildHandler || ((_, cb) => (e) => typeof cb === 'function' && cb(e));
     const evt = event || {};
     const eventType = evt.type || evt._groupType || '';
@@ -38,7 +41,7 @@ function EventCard({
     const isWeather = eventType === 'weather_alarm';
     const isTyphoon = eventType === 'typhoon';
     
-    // 生成动态标题文本：地震调用特定算法，气象与台风优先展示 subtitle，其他事件展示 description
+    // 生成动态标题文本：地震调用特定算法，气象与台风优先展示 subtitle，海啸走专用构建器
     const normalizeTyphoonTitle = (value) => {
         const text = String(value || '').trim();
         if (!text) return '';
@@ -47,6 +50,13 @@ function EventCard({
             .replace(/\s*\(\s*/g, '（')
             .replace(/\s*\)\s*/g, '）')
             .replace(/TD\s*No\.?\s*/gi, 'TD');
+    };
+    // 海啸：专用标题构建（兼容旧库「海啸信息 (信息)」与新结构化字段）
+    const resolveTsunamiDisplayTitle = () => {
+        if (typeof buildTsunamiTitle === 'function') {
+            return buildTsunamiTitle(evt) || '海啸情报';
+        }
+        return evt.description || evt.subtitle || evt.place_name || '海啸情报';
     };
     const displayTitle = isEarthquake
         ? buildEarthquakeTitle(evt)
@@ -58,9 +68,30 @@ function EventCard({
                 || normalizeTyphoonTitle(evt.real_event_id)
                 || '未知台风'
             )
-            : ((isWeather)
-                ? (evt.subtitle || evt.description || '未知位置')
-                : (evt.description || '未知位置')));
+            : (isTsunami
+                ? resolveTsunamiDisplayTitle()
+                : ((isWeather)
+                    ? (evt.subtitle || evt.description || '未知位置')
+                    : (evt.description || '未知位置'))));
+    const tsunamiMetaModel = isTsunami && typeof buildTsunamiMeta === 'function'
+        ? buildTsunamiMeta(evt)
+        : null;
+    const tsunamiMeta = (() => {
+        if (!tsunamiMetaModel) return null;
+        // 兼容旧版返回字符串
+        if (typeof tsunamiMetaModel === 'string') {
+            return tsunamiMetaModel
+                ? { chips: [], sections: [], text: tsunamiMetaModel, tone: 'default' }
+                : null;
+        }
+        const chips = Array.isArray(tsunamiMetaModel.chips) ? tsunamiMetaModel.chips : [];
+        const sections = Array.isArray(tsunamiMetaModel.sections) ? tsunamiMetaModel.sections : [];
+        if (!chips.length && !sections.length && !tsunamiMetaModel.text) return null;
+        return tsunamiMetaModel;
+    })();
+    const tsunamiToneClass = tsunamiMeta?.tone
+        ? `is-tone-${tsunamiMeta.tone}`
+        : '';
 
     // 初始化徽标内容与对应 CSS 类名
     let badgeContent = '❓';
@@ -269,6 +300,56 @@ function EventCard({
                 {typhoonMeta && (
                     <div className="event-meta event-meta-typhoon">
                         <span className="event-meta-item">{typhoonMeta}</span>
+                    </div>
+                )}
+                {tsunamiMeta && (
+                    <div className={`event-tsunami-panel ${tsunamiToneClass} ${isHistory ? 'is-history' : ''}`.trim()}>
+                        {Array.isArray(tsunamiMeta.chips) && tsunamiMeta.chips.length > 0 && (
+                            <div className="event-tsunami-chips">
+                                {tsunamiMeta.chips.map((chip) => (
+                                    <span
+                                        key={chip.key || chip.label}
+                                        className={`event-tsunami-chip is-${chip.tone || 'default'}`}
+                                    >
+                                        {chip.icon ? <span className="event-tsunami-chip-icon">{chip.icon}</span> : null}
+                                        <span className="event-tsunami-chip-label">{chip.label}</span>
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                        {Array.isArray(tsunamiMeta.sections) && tsunamiMeta.sections.length > 0 && (
+                            <div className="event-tsunami-sections">
+                                {tsunamiMeta.sections.map((section) => (
+                                    <div
+                                        key={section.key || section.title}
+                                        className={`event-tsunami-section is-${section.tone || 'default'}`}
+                                    >
+                                        <div className="event-tsunami-section-head">
+                                            {section.icon ? <span className="event-tsunami-section-icon">{section.icon}</span> : null}
+                                            <span className="event-tsunami-section-title">{section.title}</span>
+                                        </div>
+                                        {Array.isArray(section.items) && section.items.length > 0 ? (
+                                            <ul className="event-tsunami-section-list">
+                                                {section.items.map((item, idx) => (
+                                                    <li key={`${section.key || 'sec'}-${idx}`}>{item}</li>
+                                                ))}
+                                            </ul>
+                                        ) : (
+                                            section.body ? (
+                                                <div className="event-tsunami-section-body">{section.body}</div>
+                                            ) : null
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        {(!Array.isArray(tsunamiMeta.chips) || !tsunamiMeta.chips.length)
+                            && (!Array.isArray(tsunamiMeta.sections) || !tsunamiMeta.sections.length)
+                            && tsunamiMeta.text ? (
+                            <div className="event-meta event-meta-tsunami">
+                                <span className="event-meta-item">{tsunamiMeta.text}</span>
+                            </div>
+                        ) : null}
                     </div>
                 )}
             </div>

--- a/admin/js/components/events/HorizontalTimeline.jsx
+++ b/admin/js/components/events/HorizontalTimeline.jsx
@@ -597,7 +597,11 @@ function HorizontalTimeline({ style }) {
                                                         }
                                                         return '地震';
                                                     } else if (item.type === 'tsunami') {
-                                                        return item.title || '海啸预警';
+                                                        const fmt = window.EventFormatters || {};
+                                                        if (typeof fmt.buildTsunamiTimelineTitle === 'function') {
+                                                            return fmt.buildTsunamiTimelineTitle(item);
+                                                        }
+                                                        return item.level || item.title || item.description || '海啸预警';
                                                     } else {
                                                         // 气象预警正则压缩标题：提取“发布...信号”中的具体核心词
                                                         const match = item.description ? item.description.match(/发布(.*?)信号/) : null;
@@ -624,6 +628,15 @@ function HorizontalTimeline({ style }) {
                                                         }
                                                         const normalizedDesc = desc.replace(/^M\s*[\d.]+\s*/i, '').trim();
                                                         return normalizedDesc || '未知地点';
+                                                    }
+                                                    if (item.type === 'tsunami') {
+                                                        const fmt = window.EventFormatters || {};
+                                                        if (typeof fmt.buildTsunamiTimelineSubtitle === 'function') {
+                                                            return fmt.buildTsunamiTimelineSubtitle(item);
+                                                        }
+                                                        const place = String(item.place_name || item.subtitle || '').trim();
+                                                        if (place) return place;
+                                                        return desc.length > 12 ? `${desc.substring(0, 12)}...` : (desc || '海啸');
                                                     }
                                                     return desc.length > 12 ? desc.substring(0, 12) + '...' : desc;
                                                 })()}

--- a/admin/js/components/status/ConnectionsGrid.jsx
+++ b/admin/js/components/status/ConnectionsGrid.jsx
@@ -31,18 +31,59 @@ function ConnectionsGrid() {
         let connectionType = target.connectionType || 'websocket';
 
         if (matchedEntries.length > 0) {
-            const primary = matchedEntries[0][1] || {};
+            // 多条命中时优先选“更像真实运行态”的条目，避免 catalog 占位
+            // （status=未连接 / 无 connection_type）盖过 HTTP 通道的正式状态。
+            const rankedEntries = matchedEntries.slice().sort((a, b) => {
+                const infoA = a[1] || {};
+                const infoB = b[1] || {};
+                const score = (info) => {
+                    let value = 0;
+                    const statusText = String(info.status || '');
+                    if (info.connection_type === 'http') value += 8;
+                    if (statusText && statusText !== '未连接') value += 4;
+                    if (Object.prototype.hasOwnProperty.call(info, 'access_token_valid')) value += 2;
+                    if (info.connected) value += 1;
+                    // 明确降权“未连接”占位，防止它抢到 primary
+                    if (statusText === '未连接') value -= 10;
+                    return value;
+                };
+                return score(infoB) - score(infoA);
+            });
+
+            const primary = rankedEntries[0][1] || {};
             connectionType = primary.connection_type || connectionType;
             circuitOpen = !!primary.circuit_open;
             if (primary.status) {
                 statusLabel = String(primary.status);
             }
 
-            const isEnabled = matchedEntries.some(([, info]) => !!info.enabled);
+            // EQSC：若正式条目里带有 access_token_valid，强制用鉴权语义覆盖“未连接”占位
+            if (target.id === 'eqsc') {
+                const authEntry = rankedEntries.find(([, info]) =>
+                    info && Object.prototype.hasOwnProperty.call(info, 'access_token_valid')
+                );
+                if (authEntry) {
+                    const authInfo = authEntry[1] || {};
+                    connectionType = authInfo.connection_type || 'http';
+                    circuitOpen = !!authInfo.circuit_open;
+                    if (authInfo.status) {
+                        statusLabel = String(authInfo.status);
+                    } else if (authInfo.access_token_valid) {
+                        statusLabel = '可用';
+                    } else if (authInfo.enabled) {
+                        statusLabel = circuitOpen ? '熔断中' : '鉴权失效';
+                    }
+                }
+            }
+
+            const isEnabled = rankedEntries.some(([, info]) => !!info.enabled);
             if (isEnabled) {
-                const isConnected = matchedEntries.some(([, info]) => !!info.connected);
+                const isConnected = rankedEntries.some(([, info]) => !!info.connected);
                 status = isConnected ? 'online' : 'offline';
             }
+
+            // 后续 sub_sources / latency 也基于排序后的结果合并，避免脏占位优先。
+            matchedEntries = rankedEntries;
         }
 
         const retryCount = matchedEntries.reduce(
@@ -56,6 +97,21 @@ function ConnectionsGrid() {
                 Object.assign(allSubSources, info.sub_sources);
             }
         });
+
+        // EQSC 只展示业务子开关：台风富化 + 海啸轮询。
+        // catalog 占位可能带上 jma_tsunami_eqsc（source_id），需要过滤掉，避免出现第三条重复海啸。
+        if (target.id === 'eqsc') {
+            const eqscAllowedKeys = new Set([
+                'china_typhoon',
+                'jma_tsunami',
+                'japan_jma_tsunami',
+            ]);
+            Object.keys(allSubSources).forEach((key) => {
+                if (!eqscAllowedKeys.has(key)) {
+                    delete allSubSources[key];
+                }
+            });
+        }
 
         const rawLatency = matchedEntries.length > 0
             ? (matchedEntries[0][1].latency
@@ -144,8 +200,9 @@ function ConnectionsGrid() {
                 displayName: 'EQSC API',
                 connectionType: 'http',
                 matcher: (key) => {
-                    const k = String(key || '').toLowerCase();
-                    return k === 'eqsc' || k.includes('eqsc');
+                    const k = String(key || '').toLowerCase().trim();
+                    // 优先匹配展示名；兼容历史原始键 eqsc，但排除其它误匹配。
+                    return k === 'eqsc api' || k === 'eqsc';
                 },
                 compact: true,
             },
@@ -217,6 +274,9 @@ function ConnectionsGrid() {
             },
             'EQSC API': {
                 china_typhoon: '中国气象局：实时活跃台风',
+                // 与 P2P 子源展示名一致，仅展示一个海啸入口
+                jma_tsunami: '日本气象厅: 海啸予报',
+                japan_jma_tsunami: '日本气象厅: 海啸予报',
             },
         };
 
@@ -299,7 +359,22 @@ function ConnectionsGrid() {
                         </Box>
                         <Box className="connection-sub-source-list">
                             {Object.entries(conn.sub_sources)
-                                .sort(([, a], [, b]) => (a === b ? 0 : a ? -1 : 1))
+                                .sort(([keyA, enabledA], [keyB, enabledB]) => {
+                                    // EQSC：台风在上、海啸在下；其余仍优先展示已启用项
+                                    if (conn.name === 'EQSC API') {
+                                        const eqscOrder = {
+                                            china_typhoon: 0,
+                                            jma_tsunami: 1,
+                                            japan_jma_tsunami: 1,
+                                        };
+                                        const orderA = eqscOrder[keyA];
+                                        const orderB = eqscOrder[keyB];
+                                        if (orderA !== undefined || orderB !== undefined) {
+                                            return (orderA ?? 99) - (orderB ?? 99);
+                                        }
+                                    }
+                                    return enabledA === enabledB ? 0 : enabledA ? -1 : 1;
+                                })
                                 .map(([key, enabled]) => {
                                     const friendlyName = getScopedSourceName(key, conn.name);
                                     return (

--- a/admin/js/utils/eventFormatters.js
+++ b/admin/js/utils/eventFormatters.js
@@ -214,6 +214,501 @@
         return `M ${magText} ${normalizedTitle}`;
     }
 
+    // ---- 海啸列表标题 / 元信息（兼容升级前旧记录）----
+
+    const JP_TSUNAMI_LEVEL_DISPLAY = {
+        Minor: '若干海面变动',
+        Watch: '海啸注意报',
+        Warning: '海啸警报',
+        MajorWarning: '大海啸警报',
+        None: '海啸预报',
+        Unknown: '海啸预报',
+        解除: '海啸解除',
+    };
+
+    const CN_TSUNAMI_COLORS = ['红色', '橙色', '黄色', '蓝色'];
+
+    function cleanTsunamiText(value) {
+        const text = String(value ?? '').trim();
+        if (!text) return '';
+        const lowered = text.toLowerCase();
+        if (['null', 'none', 'unknown', '未知', '未知地点', '未知位置'].includes(lowered)) {
+            return '';
+        }
+        return text;
+    }
+
+    function isGenericTsunamiTitle(text) {
+        const cleaned = cleanTsunamiText(text);
+        if (!cleaned) return true;
+        const generics = new Set([
+            '海啸信息', '海啸情报', '海啸预警', '海啸警报', '海啸解除', '海啸解除通告',
+            '津波予報', '津波注意報', '津波警報', '大津波警報', '津波予報（解除）',
+            '若干の海面変動', '若干海面变动', '海啸注意报', '大海啸警报',
+        ]);
+        if (generics.has(cleaned)) return true;
+        if (
+            cleaned.startsWith('海啸')
+            && /信息|警报|预警|解除|注意报/.test(cleaned)
+            && !cleaned.includes('·')
+            && !/[Mm]j?\s*[\d.]/.test(cleaned)
+            && cleaned.length <= 12
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    function isLegacyTsunamiDescription(description, level) {
+        const text = cleanTsunamiText(description);
+        if (!text) return true;
+        if (text.includes(' (') && text.endsWith(')')) {
+            const idx = text.lastIndexOf(' (');
+            const head = text.slice(0, idx).trim();
+            const levelPart = text.slice(idx + 2, -1).trim();
+            if (head && levelPart) {
+                if (levelPart && head.includes(levelPart)) return true;
+                if (
+                    head === '海啸信息'
+                    || head === `海啸${levelPart}`
+                    || head === `海啸${levelPart}警报`
+                ) {
+                    return true;
+                }
+                const levelText = cleanTsunamiText(level);
+                if (levelText && levelPart === levelText) return true;
+            }
+        }
+        return isGenericTsunamiTitle(text);
+    }
+
+    function resolveTsunamiRegion(evt) {
+        const source = String(evt?.source_id || evt?.source || '').toLowerCase();
+        const infoType = String(evt?.info_type || '').toLowerCase();
+        if (
+            infoType.includes('jma')
+            || source.includes('jma')
+            || source.includes('p2p')
+            || source.includes('eqsc')
+            || source.includes('japan')
+        ) {
+            return 'japan';
+        }
+        if (
+            infoType.includes('cn')
+            || source.includes('fan')
+            || source.includes('china')
+            || source.includes('tsunami_fan')
+        ) {
+            return 'china';
+        }
+        const level = cleanTsunamiText(evt?.level);
+        if (['Minor', 'Watch', 'Warning', 'MajorWarning', 'None', 'Unknown'].includes(level)) {
+            return 'japan';
+        }
+        if (level === '信息' || CN_TSUNAMI_COLORS.includes(level) || level === '解除') {
+            return 'china';
+        }
+        return 'unknown';
+    }
+
+    function formatTsunamiLevelLabel(evt) {
+        const cancelled = Boolean(
+            evt?.is_cancelled
+            || evt?.cancelled
+            || cleanTsunamiText(evt?.level) === '解除'
+            || String(evt?.description || '').includes('解除')
+        );
+        if (cancelled) return '海啸解除';
+
+        const region = resolveTsunamiRegion(evt);
+        const level = cleanTsunamiText(evt?.level);
+
+        if (region === 'japan') {
+            if (JP_TSUNAMI_LEVEL_DISPLAY[level]) return JP_TSUNAMI_LEVEL_DISPLAY[level];
+            const lower = level.toLowerCase();
+            const map = {
+                minor: '若干海面变动',
+                watch: '海啸注意报',
+                warning: '海啸警报',
+                majorwarning: '大海啸警报',
+            };
+            if (map[lower]) return map[lower];
+            return level || '海啸预报';
+        }
+
+        if (level === '信息') return '海啸信息';
+        if (CN_TSUNAMI_COLORS.includes(level)) return `海啸${level}警报`;
+        if (level === '解除') return '海啸解除';
+
+        // 从 description / title 提取颜色
+        const haystack = `${evt?.description || ''} ${evt?.subtitle || ''}`;
+        for (const color of CN_TSUNAMI_COLORS) {
+            if (haystack.includes(color)) return `海啸${color}警报`;
+        }
+        if (haystack.includes('信息')) return '海啸信息';
+        if (level) return level.startsWith('海啸') ? level : `海啸${level}`;
+        return '海啸情报';
+    }
+
+    function formatTsunamiMagnitudeToken(evt) {
+        const raw = evt?.magnitude;
+        if (raw === null || raw === undefined || raw === '') return '';
+        const num = Number(raw);
+        if (!Number.isFinite(num)) return '';
+        const magText = Number.isInteger(num) ? `${num}.0` : String(Number(num.toFixed(1)));
+        const region = resolveTsunamiRegion(evt);
+        return region === 'japan' ? `Mj${magText}` : `M${magText}`;
+    }
+
+    function resolveTsunamiPlaceName(evt) {
+        const candidates = [
+            evt?.place_name,
+            evt?.placeName,
+            evt?.subtitle,
+        ];
+        for (const item of candidates) {
+            const text = cleanTsunamiText(item);
+            if (text && !isGenericTsunamiTitle(text)) return text;
+        }
+        // 旧 description 若已是「级别 · 地点 Mxx」可截取地点
+        const desc = cleanTsunamiText(evt?.description);
+        if (desc && desc.includes('·')) {
+            const parts = desc.split('·').map((p) => p.trim()).filter(Boolean);
+            if (parts.length >= 2) {
+                // 去掉末尾震级
+                let place = parts[1].replace(/\s*M[jJ]?\s*[\d.]+$/, '').trim();
+                place = place.replace(/（第.+?）$/, '').trim();
+                if (place && !isGenericTsunamiTitle(place)) return place;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * 构建海啸列表主标题。
+     * 优先用后端新 description；若是旧「海啸信息 (信息)」则用结构化字段重拼。
+     */
+    function buildTsunamiTitle(evt) {
+        if (!evt || typeof evt !== 'object') return '海啸情报';
+
+        const description = cleanTsunamiText(evt.description);
+        const level = cleanTsunamiText(evt.level);
+        const place = resolveTsunamiPlaceName(evt);
+        const magToken = formatTsunamiMagnitudeToken(evt);
+        const cancelled = Boolean(evt.is_cancelled || evt.cancelled || level === '解除');
+        const isTraining = Boolean(evt.is_training || evt.isTraining);
+
+        // 新 description 已经可读：直接用
+        if (description && !isLegacyTsunamiDescription(description, level)) {
+            // 训练标记兜底
+            if (isTraining && !description.includes('[训练]') && !description.includes('训练')) {
+                return `[训练] ${description}`;
+            }
+            return description;
+        }
+
+        const levelLabel = formatTsunamiLevelLabel(evt);
+        let head = levelLabel;
+        if (isTraining && !head.startsWith('[训练]')) {
+            head = `[训练] ${head}`;
+        }
+
+        const body = [];
+        if (place) {
+            body.push(magToken ? `${place} ${magToken}` : place);
+        } else if (magToken) {
+            body.push(magToken);
+        }
+
+        // 无地点/震级时补波高或预报区（新字段；旧数据可能为空）
+        if (!body.length) {
+            const waveRaw = evt.max_wave_height;
+            if (waveRaw !== null && waveRaw !== undefined && waveRaw !== '') {
+                const waveNum = Number(waveRaw);
+                if (Number.isFinite(waveNum) && waveNum > 0) {
+                    body.push(`最大波高 ${waveNum}m`);
+                } else {
+                    const waveText = cleanTsunamiText(waveRaw);
+                    if (waveText) body.push(`最大波高 ${waveText}`);
+                }
+            }
+            const areaCount = Number(evt.area_count);
+            if (!body.length && Number.isFinite(areaCount) && areaCount > 0) {
+                body.push(`预报区 ${areaCount}`);
+            }
+        }
+
+        if (body.length) {
+            return `${head} · ${body.join(' · ')}`;
+        }
+        return head || '海啸情报';
+    }
+
+    /**
+     * 解析 weather_detail 中的结构化片段（新入库摘要）。
+     * 例：预报区 8，立即到达 2，最大波高 3m（福島県），监测站 4，
+     *     级别分布 海啸警报 3 / 海啸注意报 5，重点预报 ...，监测实况 ...
+     */
+    function parseTsunamiWeatherDetail(detailText) {
+        const detail = cleanTsunamiText(detailText);
+        const result = {
+            regionLabel: '',
+            areaCount: null,
+            immediateCount: null,
+            stationCount: null,
+            maxWaveText: '',
+            maxWaveArea: '',
+            gradeDistribution: '',
+            forecastHighlights: [],
+            stationHighlights: [],
+            depthText: '',
+            batchText: '',
+            raw: detail,
+        };
+        if (!detail) return result;
+
+        if (detail.includes('日本海啸')) result.regionLabel = '日本';
+        else if (detail.includes('中国海啸')) result.regionLabel = '中国';
+
+        const areaMatch = detail.match(/预报区\s*(\d+)/);
+        if (areaMatch) result.areaCount = Number(areaMatch[1]);
+
+        const immediateMatch = detail.match(/立即到达\s*(\d+)/);
+        if (immediateMatch) result.immediateCount = Number(immediateMatch[1]);
+
+        const stationMatch = detail.match(/监测站\s*(\d+)/);
+        if (stationMatch) result.stationCount = Number(stationMatch[1]);
+
+        const waveMatch = detail.match(/最大波高\s*([^，,]+)/);
+        if (waveMatch) {
+            const waveChunk = waveMatch[1].trim();
+            const areaInParen = waveChunk.match(/（([^）]+)）|\(([^)]+)\)/);
+            if (areaInParen) {
+                result.maxWaveArea = (areaInParen[1] || areaInParen[2] || '').trim();
+                result.maxWaveText = waveChunk.replace(/（[^）]+）|\([^)]+\)/g, '').trim();
+            } else {
+                result.maxWaveText = waveChunk;
+            }
+        }
+
+        const gradeMatch = detail.match(/级别分布\s*([^，,]+)/);
+        if (gradeMatch) result.gradeDistribution = gradeMatch[1].trim();
+
+        const forecastMatch = detail.match(/重点预报\s*([^，,]+)/);
+        if (forecastMatch) {
+            result.forecastHighlights = forecastMatch[1]
+                .split(/[；;]/)
+                .map((item) => item.trim())
+                .filter(Boolean);
+        }
+
+        const stationHighlightMatch = detail.match(/监测实况\s*([^，,]+)/);
+        if (stationHighlightMatch) {
+            result.stationHighlights = stationHighlightMatch[1]
+                .split(/[；;]/)
+                .map((item) => item.trim())
+                .filter(Boolean);
+        }
+
+        const depthMatch = detail.match(/深度\s*([\d.]+)\s*km/i);
+        if (depthMatch) result.depthText = `${depthMatch[1]}km`;
+
+        const batchMatch = detail.match(/批次\s*([^\s，,]+)/);
+        if (batchMatch) result.batchText = batchMatch[1];
+
+        return result;
+    }
+
+    function resolveTsunamiLevelTone(evt) {
+        const cancelled = Boolean(
+            evt?.is_cancelled
+            || evt?.cancelled
+            || cleanTsunamiText(evt?.level) === '解除'
+            || String(evt?.description || '').includes('解除')
+        );
+        if (cancelled) return 'cancel';
+        const level = cleanTsunamiText(evt?.level);
+        const haystack = `${level} ${evt?.description || ''} ${evt?.weather_detail || ''}`;
+        if (/MajorWarning|大海啸|红色/.test(haystack)) return 'major';
+        if (/Warning|海啸警报|橙色/.test(haystack) && !/注意/.test(haystack)) return 'warning';
+        if (/Watch|注意报|黄色/.test(haystack)) return 'watch';
+        if (/蓝色/.test(haystack)) return 'blue';
+        if (/Minor|若干|信息|预报/.test(haystack)) return 'info';
+        return 'default';
+    }
+
+    /**
+     * 海啸卡片结构化元信息（对齐推送展示器语义）。
+     * 返回 chips + 重点预报/监测摘要；旧数据字段缺失时自动降级。
+     */
+    function buildTsunamiMeta(evt) {
+        if (!evt || typeof evt !== 'object') {
+            return { chips: [], sections: [], text: '' };
+        }
+
+        const parsed = parseTsunamiWeatherDetail(evt.weather_detail);
+        const chips = [];
+        const sections = [];
+        const levelLabel = formatTsunamiLevelLabel(evt);
+        const tone = resolveTsunamiLevelTone(evt);
+        const place = resolveTsunamiPlaceName(evt);
+        const magToken = formatTsunamiMagnitudeToken(evt);
+        const region = resolveTsunamiRegion(evt);
+
+        const pushChip = (key, icon, label, chipTone = 'default') => {
+            if (!label) return;
+            chips.push({ key, icon, label, tone: chipTone });
+        };
+
+        if (levelLabel) pushChip('level', '📋', levelLabel, tone);
+        if (parsed.regionLabel) pushChip('region', '🌏', parsed.regionLabel, 'default');
+        else if (region === 'japan') pushChip('region', '🌏', '日本', 'default');
+        else if (region === 'china') pushChip('region', '🌏', '中国', 'default');
+
+        if (place) pushChip('place', '🌍', place, 'place');
+        if (magToken) pushChip('mag', '🧭', magToken, 'mag');
+
+        const depthRaw = evt.depth;
+        if (depthRaw !== null && depthRaw !== undefined && depthRaw !== '') {
+            const depthNum = Number(depthRaw);
+            if (Number.isFinite(depthNum)) {
+                const depthText = Number.isInteger(depthNum) ? `${depthNum}` : String(depthNum);
+                pushChip('depth', '⬇️', `深度 ${depthText}km`, 'default');
+            }
+        } else if (parsed.depthText) {
+            pushChip('depth', '⬇️', `深度 ${parsed.depthText}`, 'default');
+        }
+
+        // 波高：结构化字段优先，再回退 weather_detail
+        let waveLabel = '';
+        const waveRaw = evt.max_wave_height;
+        if (waveRaw !== null && waveRaw !== undefined && waveRaw !== '') {
+            const waveNum = Number(waveRaw);
+            if (Number.isFinite(waveNum) && waveNum > 0) {
+                waveLabel = `最大波高 ${waveNum}m`;
+            } else {
+                const waveText = cleanTsunamiText(waveRaw);
+                if (waveText) waveLabel = `最大波高 ${waveText}`;
+            }
+        }
+        if (!waveLabel && parsed.maxWaveText) {
+            waveLabel = `最大波高 ${parsed.maxWaveText}`;
+        }
+        if (waveLabel && parsed.maxWaveArea) {
+            waveLabel = `${waveLabel}（${parsed.maxWaveArea}）`;
+        }
+        if (waveLabel) pushChip('wave', '🌊', waveLabel, 'wave');
+
+        const areaCount = Number(evt.area_count);
+        if (Number.isFinite(areaCount) && areaCount > 0) {
+            pushChip('areas', '📍', `预报区 ${areaCount}`, 'area');
+        } else if (parsed.areaCount) {
+            pushChip('areas', '📍', `预报区 ${parsed.areaCount}`, 'area');
+        }
+
+        const immediate = Number(evt.immediate_area_count);
+        if (Number.isFinite(immediate) && immediate > 0) {
+            pushChip('immediate', '🚨', `立即到达 ${immediate}`, 'danger');
+        } else if (parsed.immediateCount) {
+            pushChip('immediate', '🚨', `立即到达 ${parsed.immediateCount}`, 'danger');
+        }
+
+        if (parsed.stationCount) {
+            pushChip('stations', '📡', `监测站 ${parsed.stationCount}`, 'station');
+        }
+
+        if (parsed.batchText) {
+            pushChip('batch', '#️⃣', `第${parsed.batchText}报`.replace(/^第第/, '第'), 'default');
+        }
+
+        if (evt.is_cancelled || evt.cancelled || cleanTsunamiText(evt.level) === '解除') {
+            pushChip('cancelled', '✅', '已解除', 'cancel');
+        }
+        if (evt.is_training || evt.isTraining) {
+            pushChip('training', '🧪', '训练报', 'training');
+        }
+
+        if (parsed.gradeDistribution) {
+            sections.push({
+                key: 'grade',
+                icon: '📊',
+                title: '级别分布',
+                body: parsed.gradeDistribution,
+                tone: 'grade',
+            });
+        }
+
+        if (parsed.forecastHighlights.length) {
+            // 日本：津波予報区域；中国：沿海预报
+            const forecastTitle = region === 'japan'
+                ? `津波予報区域（${parsed.forecastHighlights.length}）`
+                : `沿海预报（${parsed.forecastHighlights.length}）`;
+            sections.push({
+                key: 'forecasts',
+                icon: region === 'japan' ? '📍' : '',
+                title: forecastTitle,
+                items: parsed.forecastHighlights,
+                tone: 'forecast',
+            });
+        }
+
+        // 监测实况：中国源常见；日本通常无监测站列表，有才展示
+        if (parsed.stationHighlights.length) {
+            sections.push({
+                key: 'stations',
+                icon: '📡',
+                title: `监测实况（${parsed.stationHighlights.length}）`,
+                items: parsed.stationHighlights,
+                tone: 'station',
+            });
+        }
+
+        // 旧数据几乎无结构化字段时，展示原始 weather_detail 兜底
+        if (!chips.length && !sections.length) {
+            const detail = cleanTsunamiText(evt.weather_detail);
+            if (detail) {
+                sections.push({
+                    key: 'fallback',
+                    icon: '📝',
+                    title: '摘要',
+                    body: detail,
+                    tone: 'default',
+                });
+            }
+        }
+
+        const text = [
+            ...chips.map((chip) => chip.label),
+            ...sections.map((section) => {
+                if (section.items && section.items.length) {
+                    return `${section.title}：${section.items.join('；')}`;
+                }
+                return section.body ? `${section.title}：${section.body}` : section.title;
+            }),
+        ].filter(Boolean).join(' · ');
+
+        return { chips, sections, text, tone };
+    }
+
+    /**
+     * 时间轴节点短标题（等级）
+     */
+    function buildTsunamiTimelineTitle(evt) {
+        return formatTsunamiLevelLabel(evt) || '海啸预警';
+    }
+
+    /**
+     * 时间轴副标题（地点优先）
+     */
+    function buildTsunamiTimelineSubtitle(evt) {
+        const place = resolveTsunamiPlaceName(evt);
+        if (place) return place;
+        const title = buildTsunamiTitle(evt);
+        if (title.length > 14) return `${title.slice(0, 14)}…`;
+        return title || '海啸';
+    }
+
     /**
      * 格式化并友好汉化下拉框中的数据源选项
      */
@@ -343,6 +838,16 @@
         normalizeBadgeToneToken,
         getEarthquakeBadgeContent,
         buildEarthquakeTitle,
+        isGenericTsunamiTitle,
+        isLegacyTsunamiDescription,
+        resolveTsunamiRegion,
+        formatTsunamiLevelLabel,
+        buildTsunamiTitle,
+        buildTsunamiMeta,
+        parseTsunamiWeatherDetail,
+        resolveTsunamiLevelTone,
+        buildTsunamiTimelineTitle,
+        buildTsunamiTimelineSubtitle,
         normalizeSourceOption,
         normalizeSourceOptions,
         resolveWeatherColor,

--- a/admin/js/utils/eventFormatters.js
+++ b/admin/js/utils/eventFormatters.js
@@ -396,7 +396,6 @@
         const level = cleanTsunamiText(evt.level);
         const place = resolveTsunamiPlaceName(evt);
         const magToken = formatTsunamiMagnitudeToken(evt);
-        const cancelled = Boolean(evt.is_cancelled || evt.cancelled || level === '解除');
         const isTraining = Boolean(evt.is_training || evt.isTraining);
 
         // 新 description 已经可读：直接用

--- a/admin/js/utils/eventGrouping.js
+++ b/admin/js/utils/eventGrouping.js
@@ -85,6 +85,26 @@
             if (evtType === 'typhoon' && evt.real_event_id) {
                 // 台风用 real_event_id + source 组合，避免不同源同编号误合并
                 groupKey = `typhoon:${evt.real_event_id}:${evt.source || evt.source_id || ''}`;
+            } else if (evtType === 'tsunami') {
+                // 海啸按稳定事件 ID 折叠多报：
+                // unique_id 可能是 "source|uuid" 或裸 uuid；real_event_id / event_id 也可能是业务编号
+                const rawUnique = String(evt.unique_id || '').trim();
+                const bareUnique = rawUnique.includes('|')
+                    ? rawUnique.split('|').pop().trim()
+                    : rawUnique;
+                const stableId = String(
+                    evt.real_event_id
+                    || bareUnique
+                    || evt.event_id
+                    || evt.code
+                    || ''
+                ).trim();
+                const sourceKey = String(evt.source || evt.source_id || '').trim();
+                if (stableId) {
+                    groupKey = `tsunami:${stableId}:${sourceKey || 'unknown'}`;
+                } else {
+                    groupKey = evt.event_id || evt.id || `${evt.time}-${evt.description}`;
+                }
             } else {
                 groupKey = evt.event_id || evt.id || `${evt.time}-${evt.description}`;
             }

--- a/admin/js/utils/eventGrouping.js
+++ b/admin/js/utils/eventGrouping.js
@@ -99,9 +99,36 @@
                     || evt.code
                     || ''
                 ).trim();
-                const sourceKey = String(evt.source || evt.source_id || '').trim();
+                // 规范化中国海啸历史别名，避免 fan_studio_tsunami 与
+                // china_tsunami_fanstudio 被拆成两个分组。
+                const rawSource = String(evt.source || evt.source_id || '').trim();
+                const sourceKey = (() => {
+                    const lower = rawSource.toLowerCase();
+                    if (
+                        lower === 'fan_studio_tsunami'
+                        || lower === 'china_tsunami'
+                        || lower === 'china_tsunami_fanstudio'
+                    ) {
+                        return 'china_tsunami_fanstudio';
+                    }
+                    if (
+                        lower === 'jma_tsunami_p2p'
+                        || lower === 'jma_tsunami'
+                        || lower === 'japan_jma_tsunami'
+                        || lower === 'p2p_tsunami'
+                    ) {
+                        return 'jma_tsunami_p2p';
+                    }
+                    if (
+                        lower === 'jma_tsunami_eqsc'
+                        || lower === 'eqsc_tsunami'
+                    ) {
+                        return 'jma_tsunami_eqsc';
+                    }
+                    return rawSource || 'unknown';
+                })();
                 if (stableId) {
-                    groupKey = `tsunami:${stableId}:${sourceKey || 'unknown'}`;
+                    groupKey = `tsunami:${stableId}:${sourceKey}`;
                 } else {
                     groupKey = evt.event_id || evt.id || `${evt.time}-${evt.description}`;
                 }

--- a/admin/js/utils/formatters.js
+++ b/admin/js/utils/formatters.js
@@ -219,6 +219,7 @@ function normalizeSourceName(source) {
         'p2p_eew': 'jma_p2p',
         'p2p_earthquake': 'jma_p2p_info',
         'p2p_tsunami': 'jma_tsunami_p2p',
+        'eqsc_tsunami': 'jma_tsunami_eqsc',
         'wolfx_jma_eew': 'jma_wolfx',
         'wolfx_cenc_eew': 'cea_wolfx',
         'wolfx_cwa_eew': 'cwa_wolfx',
@@ -259,8 +260,17 @@ function normalizeSourceName(source) {
         '日本气象厅: 紧急地震速报': 'jma_fanstudio',
         '日本气象厅：地震情报': 'jma_p2p_info',
         '日本气象厅: 地震情报': 'jma_p2p_info',
+        // 中文冒号全角/半角 + 预报/予报 历史写法都兼容
         '日本气象厅：海啸预报': 'jma_tsunami_p2p',
-        '日本气象厅: 海啸预报': 'jma_tsunami_p2p'
+        '日本气象厅: 海啸预报': 'jma_tsunami_p2p',
+        '日本气象厅：海啸予报': 'jma_tsunami_p2p',
+        '日本气象厅: 海啸予报': 'jma_tsunami_p2p',
+        '日本气象厅：海啸予报 - P2P': 'jma_tsunami_p2p',
+        '日本气象厅: 海啸予报 - P2P': 'jma_tsunami_p2p',
+        '日本气象厅：海啸予报 - EQSC': 'jma_tsunami_eqsc',
+        '日本气象厅: 海啸予报 - EQSC': 'jma_tsunami_eqsc',
+        '日本气象厅：海啸预报 - EQSC': 'jma_tsunami_eqsc',
+        '日本气象厅: 海啸预报 - EQSC': 'jma_tsunami_eqsc',
     };
 
     return aliasMap[rawSource] || aliasMap[lowerSource] || lowerSource;
@@ -346,7 +356,10 @@ function formatSourceName(source) {
         // P2P (新规范)
         'jma_p2p': '日本气象厅: 紧急地震速报 - P2P',
         'jma_p2p_info': '日本气象厅: 地震情报 - P2P',
-        'jma_tsunami_p2p': '日本气象厅: 海啸予报',
+        'jma_tsunami_p2p': '日本气象厅: 海啸予报 - P2P',
+
+        // EQSC (HTTP 海啸补充源)
+        'jma_tsunami_eqsc': '日本气象厅: 海啸予报 - EQSC',
 
         // Wolfx (新规范)
         'jma_wolfx': '日本气象厅: 紧急地震速报 - Wolfx',

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -37,6 +37,7 @@ from ..parsers.parser_registry import (
 )
 from ..services.config.config_service import ConfigAccessor
 from ..services.config.connection_plan_builder import ConnectionPlanBuilder
+from ..services.eqsc.eqsc_tsunami_poll_service import EqscTsunamiPollService
 from ..services.geo.cn_seis_int_loc_loader import get_district_points
 from ..services.geo.jma_seis_int_loc_loader import get_sect_map
 from ..services.geo.region_service import region_service
@@ -175,6 +176,8 @@ class DisasterWarningService:
         )
         # S-Net MSIL 瓦片轮询（直连 HTTP，不走 WebSocket）
         self.snet_poll_service = SnetPollService(self)
+        # EQSC JMA 海啸 HTTP 轮询（复用 EQSC 令牌，作为 P2P 高优先级补充）
+        self.eqsc_tsunami_poll_service = EqscTsunamiPollService(self)
         self._setup_runtime_services()
 
     def _setup_runtime_services(self) -> None:
@@ -332,7 +335,7 @@ class DisasterWarningService:
             # 预热成功与否都启动保活：失败时循环会按重试间隔继续尝试
             start_keepalive = getattr(enrichment, "start_token_keepalive", None)
             if callable(start_keepalive):
-                start_keepalive()
+                start_keepalive(register_task=self.register_background_task)
 
         warmup_task = asyncio.create_task(
             _warmup_and_keepalive(),

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -62,6 +62,12 @@ class DisasterServiceLifecycleService:
                 snet_poll = getattr(self.service, "snet_poll_service", None)
                 if snet_poll is not None:
                     await snet_poll.start()
+                # EQSC 海啸 HTTP 轮询（依赖 AccessToken，可与 token 预热并行）
+                eqsc_tsunami_poll = getattr(
+                    self.service, "eqsc_tsunami_poll_service", None
+                )
+                if eqsc_tsunami_poll is not None:
+                    await eqsc_tsunami_poll.start()
                 if getattr(self.service, "notification_center", None):
                     await (
                         self.service.notification_center.start()
@@ -164,6 +170,13 @@ class DisasterServiceLifecycleService:
                     await (
                         self.service.http_fetcher.close()
                     )  # 关闭 HTTP 客户端 Session 连接池
+
+                # 先停 EQSC 海啸轮询客户端（共享 token 时不会关闭 token_manager）
+                eqsc_tsunami_poll = getattr(
+                    self.service, "eqsc_tsunami_poll_service", None
+                )
+                if eqsc_tsunami_poll is not None:
+                    await eqsc_tsunami_poll.stop()
 
                 # 关闭台风 EQSC 富化服务的 HTTP 会话与令牌管理器资源
                 typhoon_enrichment = getattr(

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -46,6 +46,8 @@ class TyphoonEnrichmentService:
         eqsc_config = config.get("data_sources", {}).get("eqsc", {})
         if not isinstance(eqsc_config, dict):
             eqsc_config = {}
+        # 保留原始 EQSC 配置，供健康面板读取海啸等子开关
+        self._eqsc_config = eqsc_config
         channel_enabled, typhoon_enrichment = self.resolve_eqsc_flags(eqsc_config)
         # 组总闸：控制 EQSC 通道（鉴权/连通/后续子能力入口）
         self._channel_enabled = channel_enabled
@@ -123,6 +125,12 @@ class TyphoonEnrichmentService:
         config_enabled = bool(self._channel_enabled)
         typhoon_enrichment = bool(self._typhoon_enrichment_enabled)
         access_token_valid = bool(self._token_manager.has_valid_access_token)
+        # 海啸子开关：缺省跟随通道总闸（与配置校验语义一致）
+        raw_eqsc = self._eqsc_config if isinstance(self._eqsc_config, dict) else {}
+        if "jma_tsunami" in raw_eqsc:
+            jma_tsunami = bool(raw_eqsc.get("jma_tsunami"))
+        else:
+            jma_tsunami = config_enabled
         return {
             # enabled：通道可工作（组总闸 + token 已配置）
             "enabled": self.is_channel_enabled,
@@ -130,15 +138,17 @@ class TyphoonEnrichmentService:
             "typhoon_enrichment": typhoon_enrichment,
             # 台风富化实际可工作
             "typhoon_enrichment_active": self.is_enabled,
+            "jma_tsunami": jma_tsunami,
             "token_configured": bool(self._token_manager.is_configured),
             "access_token_valid": access_token_valid,
             "circuit_open": circuit_open,
             "circuit_failures": int(self._circuit_failures),
             "connection_type": "http",
             "provider": "eqsc",
-            # 当前 EQSC 仅展示一个子数据源：中国气象局实时活跃台风
+            # EQSC 子数据源：台风富化在上，海啸仅保留一个入口（与 P2P 同名展示）
             "sub_sources": {
                 "china_typhoon": typhoon_enrichment,
+                "jma_tsunami": jma_tsunami,
             },
         }
 
@@ -174,11 +184,15 @@ class TyphoonEnrichmentService:
             )
             return False
 
-    def start_token_keepalive(self) -> None:
+    def start_token_keepalive(self, *, register_task=None) -> None:
         """启动 AccessToken 后台保活循环（幂等）。
 
         在过期前提前调用 get_access_token 续期，保证状态面板在无台风业务时
         也不会因内存 token 过期而长期显示“鉴权失效”。
+
+        Args:
+            register_task: 可选回调，用于把保活任务登记到服务级后台任务集合，
+                便于停机时统一回收（例如 DisasterService.register_background_task）。
         """
         if not self.is_channel_enabled:
             return
@@ -192,6 +206,13 @@ class TyphoonEnrichmentService:
             self._token_keepalive_loop(),
             name="dw_eqsc_token_keepalive",
         )
+        if callable(register_task):
+            try:
+                register_task(self._token_keepalive_task)
+            except Exception as exc:
+                logger.debug(
+                    f"[灾害预警] 注册 EQSC token 保活任务失败: {type(exc).__name__}: {exc}"
+                )
 
     async def stop_token_keepalive(self) -> None:
         """停止 AccessToken 后台保活循环。"""

--- a/core/domain/tsunami/__init__.py
+++ b/core/domain/tsunami/__init__.py
@@ -1,0 +1,59 @@
+"""海啸领域辅助能力。"""
+
+from .jma_tsunami_normalize import (
+    GRADE_ORDER,
+    GRADE_TITLE_MAP,
+    build_jma_tsunami_content_fingerprint,
+    coerce_bool,
+    normalize_jma_tsunami_areas,
+    resolve_jma_tsunami_max_grade,
+    resolve_jma_tsunami_title,
+)
+from .tsunami_levels import (
+    CN_TSUNAMI_LEVEL_ORDER,
+    JP_TSUNAMI_LEVEL_DISPLAY,
+    JP_TSUNAMI_LEVEL_ORDER,
+    build_tsunami_weather_detail,
+    cn_tsunami_level_weight,
+    jp_tsunami_level_weight,
+    normalize_cn_tsunami_level,
+    normalize_jp_tsunami_level,
+    resolve_tsunami_region,
+    to_optional_float,
+)
+from .tsunami_title import (
+    build_tsunami_list_title,
+    build_tsunami_list_title_from_mapping,
+    format_tsunami_batch_token,
+    format_tsunami_level_label,
+    format_tsunami_magnitude_token,
+    is_generic_tsunami_title,
+    is_legacy_tsunami_description,
+)
+
+__all__ = [
+    "CN_TSUNAMI_LEVEL_ORDER",
+    "GRADE_ORDER",
+    "GRADE_TITLE_MAP",
+    "JP_TSUNAMI_LEVEL_DISPLAY",
+    "JP_TSUNAMI_LEVEL_ORDER",
+    "build_jma_tsunami_content_fingerprint",
+    "build_tsunami_list_title",
+    "build_tsunami_list_title_from_mapping",
+    "build_tsunami_weather_detail",
+    "cn_tsunami_level_weight",
+    "coerce_bool",
+    "format_tsunami_batch_token",
+    "format_tsunami_level_label",
+    "format_tsunami_magnitude_token",
+    "is_generic_tsunami_title",
+    "is_legacy_tsunami_description",
+    "jp_tsunami_level_weight",
+    "normalize_cn_tsunami_level",
+    "normalize_jp_tsunami_level",
+    "normalize_jma_tsunami_areas",
+    "resolve_jma_tsunami_max_grade",
+    "resolve_jma_tsunami_title",
+    "resolve_tsunami_region",
+    "to_optional_float",
+]

--- a/core/domain/tsunami/jma_tsunami_normalize.py
+++ b/core/domain/tsunami/jma_tsunami_normalize.py
@@ -1,0 +1,233 @@
+"""
+日本气象厅海啸情报字段归一化。
+
+统一处理 P2P / EQSC 在等级、区域、布尔值与内容指纹上的差异，
+避免解析器、去重器与展示器各自维护一套规则。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# 等级从低到高；用于取“全域最高警报级别”。
+GRADE_ORDER: list[str] = [
+    "None",
+    "Unknown",
+    "Minor",
+    "Watch",
+    "Warning",
+    "MajorWarning",
+]
+
+# 展示标题映射（日文官方用语）。
+GRADE_TITLE_MAP: dict[str, str] = {
+    "MajorWarning": "大津波警報",
+    "Warning": "津波警報",
+    "Watch": "津波注意報",
+    "Minor": "若干の海面変動",
+    "Unknown": "津波予報",
+    "None": "津波予報",
+    "解除": "津波予報（解除）",
+}
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """宽松解析布尔值，兼容 EQSC 字符串 true/false。"""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "null", "none"}:
+        return False
+    return default
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text or text.lower() in {"null", "none"}:
+        return ""
+    return text
+
+
+def _normalize_grade(raw_grade: Any, *, cancelled: bool = False) -> str:
+    if cancelled:
+        return "解除"
+    grade = _clean_text(raw_grade) or "Unknown"
+    # 兼容偶发大小写差异
+    lowered = grade.lower()
+    mapping = {
+        "majorwarning": "MajorWarning",
+        "warning": "Warning",
+        "watch": "Watch",
+        "minor": "Minor",
+        "none": "None",
+        "unknown": "Unknown",
+        "解除": "解除",
+    }
+    return mapping.get(lowered, grade)
+
+
+def normalize_jma_tsunami_areas(
+    areas: Any,
+    *,
+    cancelled: bool = False,
+) -> list[dict[str, Any]]:
+    """把 P2P / EQSC 区域列表归一为展示与去重共用结构。"""
+    if not isinstance(areas, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for item in areas:
+        if not isinstance(item, dict):
+            continue
+        name = _clean_text(
+            item.get("name") or item.get("forecastArea") or item.get("forecastPoint")
+        )
+        if not name:
+            continue
+
+        first_height = item.get("firstHeight")
+        if not isinstance(first_height, dict):
+            first_height = {}
+        max_height = item.get("maxHeight")
+        if not isinstance(max_height, dict):
+            max_height = {}
+
+        condition = _clean_text(
+            first_height.get("condition")
+            or item.get("condition")
+            or item.get("estimatedArrivalTime")
+        )
+        arrival_time = _clean_text(
+            first_height.get("arrivalTime")
+            or item.get("estimatedArrivalTime")
+            or item.get("arrivalTime")
+        )
+        max_desc = _clean_text(
+            max_height.get("description")
+            or item.get("maxWaveHeight")
+            or item.get("max_height")
+        )
+        max_value_raw = max_height.get("value")
+        if max_value_raw is None:
+            max_value_raw = item.get("maxHeightValue")
+        max_value_text = _clean_text(max_value_raw)
+        max_value: float | None = None
+        if max_value_text:
+            try:
+                max_value = float(max_value_text)
+            except ValueError:
+                max_value = None
+
+        grade = _normalize_grade(
+            item.get("grade") or item.get("warningLevel"), cancelled=cancelled
+        )
+        immediate = coerce_bool(item.get("immediate"), default=False)
+
+        # 展示侧统一消费这些键；保留原始块便于排障。
+        normalized.append(
+            {
+                "name": name,
+                "grade": grade,
+                "immediate": immediate,
+                "condition": condition,
+                "estimatedArrivalTime": arrival_time,
+                "maxWaveHeight": max_desc or max_value_text,
+                "maxHeightValue": max_value,
+                "maxHeightDescription": max_desc,
+                "firstHeight": dict(first_height) if first_height else {},
+                "maxHeight": dict(max_height) if max_height else {},
+            }
+        )
+    return normalized
+
+
+def resolve_jma_tsunami_max_grade(
+    areas: list[dict[str, Any]] | None,
+    *,
+    cancelled: bool = False,
+) -> str:
+    """从归一化区域列表中取最高警报等级。"""
+    if cancelled:
+        return "解除"
+    max_grade = "Unknown"
+    max_idx = 0
+    for area in areas or []:
+        grade = _normalize_grade(area.get("grade"), cancelled=False)
+        if grade not in GRADE_ORDER:
+            continue
+        idx = GRADE_ORDER.index(grade)
+        if idx > max_idx:
+            max_idx = idx
+            max_grade = grade
+    return max_grade
+
+
+def resolve_jma_tsunami_title(
+    max_grade: str,
+    *,
+    cancelled: bool = False,
+) -> str:
+    """根据最高等级生成标题。"""
+    if cancelled or max_grade == "解除":
+        return GRADE_TITLE_MAP["解除"]
+    return GRADE_TITLE_MAP.get(max_grade, "津波予報")
+
+
+def build_jma_tsunami_content_fingerprint(
+    *,
+    event_id: str = "",
+    cancelled: bool = False,
+    max_grade: str = "",
+    areas: list[dict[str, Any]] | None = None,
+    is_training: bool = False,
+) -> str:
+    """构建跨源内容指纹（event + 等级 + 区域核心字段）。"""
+    area_rows: list[dict[str, Any]] = []
+    for area in areas or []:
+        if not isinstance(area, dict):
+            continue
+        area_rows.append(
+            {
+                "name": _clean_text(area.get("name")),
+                "grade": _normalize_grade(area.get("grade"), cancelled=cancelled),
+                "immediate": bool(area.get("immediate")),
+                "condition": _clean_text(area.get("condition")),
+                "arrival": _clean_text(area.get("estimatedArrivalTime")),
+                "height": _clean_text(
+                    area.get("maxWaveHeight") or area.get("maxHeightDescription")
+                ),
+            }
+        )
+    area_rows.sort(
+        key=lambda row: (row["name"], row["grade"], row["condition"], row["height"])
+    )
+    payload = {
+        "event_id": _clean_text(event_id),
+        "cancelled": bool(cancelled),
+        "max_grade": _normalize_grade(max_grade, cancelled=cancelled),
+        "is_training": bool(is_training),
+        "areas": area_rows,
+    }
+    return json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+__all__ = [
+    "GRADE_ORDER",
+    "GRADE_TITLE_MAP",
+    "build_jma_tsunami_content_fingerprint",
+    "coerce_bool",
+    "normalize_jma_tsunami_areas",
+    "resolve_jma_tsunami_max_grade",
+    "resolve_jma_tsunami_title",
+]

--- a/core/domain/tsunami/jma_tsunami_normalize.py
+++ b/core/domain/tsunami/jma_tsunami_normalize.py
@@ -190,7 +190,13 @@ def build_jma_tsunami_content_fingerprint(
     areas: list[dict[str, Any]] | None = None,
     is_training: bool = False,
 ) -> str:
-    """构建跨源内容指纹（event + 等级 + 区域核心字段）。"""
+    """构建跨源内容指纹（等级 + 区域核心字段）。
+
+    注意：P2P 与 EQSC 的 event_id 生成策略不同（回退组合键 vs 官方 eventID），
+    因此跨源去重指纹**故意不纳入 event_id**，避免同内容被拆成两条独立事件。
+    event_id 参数保留仅为兼容旧调用方，不参与哈希。
+    """
+    del event_id  # 跨源一致性：不参与指纹
     area_rows: list[dict[str, Any]] = []
     for area in areas or []:
         if not isinstance(area, dict):
@@ -211,7 +217,6 @@ def build_jma_tsunami_content_fingerprint(
         key=lambda row: (row["name"], row["grade"], row["condition"], row["height"])
     )
     payload = {
-        "event_id": _clean_text(event_id),
         "cancelled": bool(cancelled),
         "max_grade": _normalize_grade(max_grade, cancelled=cancelled),
         "is_training": bool(is_training),

--- a/core/domain/tsunami/tsunami_levels.py
+++ b/core/domain/tsunami/tsunami_levels.py
@@ -1,0 +1,336 @@
+"""
+海啸警报等级权重与归一化。
+
+统一中国（自然资源部）与日本（JMA / EQSC / P2P）的阈值语义，
+供推送过滤、入库摘要与后续统计共用，避免各层各自维护一套映射。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# 中国海啸：信息 < 蓝色 < 黄色 < 橙色 < 红色
+# 解除单独处理：过滤时默认放行（便于收到解除通告）。
+CN_TSUNAMI_LEVEL_ORDER: list[str] = [
+    "信息",
+    "蓝色",
+    "黄色",
+    "橙色",
+    "红色",
+]
+
+CN_TSUNAMI_LEVEL_ALIASES: dict[str, str] = {
+    "信息": "信息",
+    "海啸信息": "信息",
+    "info": "信息",
+    "message": "信息",
+    "蓝色": "蓝色",
+    "蓝色警报": "蓝色",
+    "蓝色预警": "蓝色",
+    "blue": "蓝色",
+    "黄色": "黄色",
+    "黄色警报": "黄色",
+    "黄色预警": "黄色",
+    "yellow": "黄色",
+    "橙色": "橙色",
+    "橙色警报": "橙色",
+    "橙色预警": "橙色",
+    "orange": "橙色",
+    "红色": "红色",
+    "红色警报": "红色",
+    "红色预警": "红色",
+    "red": "红色",
+    "解除": "解除",
+    "取消": "解除",
+    "cancel": "解除",
+    "cancelled": "解除",
+}
+
+# 日本海啸：Minor < Watch < Warning < MajorWarning
+# None / Unknown 视为最低有效等级以下的“预报/未知”。
+JP_TSUNAMI_LEVEL_ORDER: list[str] = [
+    "None",
+    "Unknown",
+    "Minor",
+    "Watch",
+    "Warning",
+    "MajorWarning",
+]
+
+# 配置项/展示用中文名（与 _conf_schema 一致）
+JP_TSUNAMI_LEVEL_DISPLAY: dict[str, str] = {
+    "Minor": "若干海面变动",
+    "Watch": "海啸注意报",
+    "Warning": "海啸警报",
+    "MajorWarning": "大海啸警报",
+}
+
+JP_TSUNAMI_LEVEL_ALIASES: dict[str, str] = {
+    "none": "None",
+    "unknown": "Unknown",
+    "minor": "Minor",
+    "若干の海面変動": "Minor",
+    "若干的海面变动": "Minor",
+    "若干海面变动": "Minor",
+    "watch": "Watch",
+    "津波注意報": "Watch",
+    "海啸注意报": "Watch",
+    "warning": "Warning",
+    "津波警報": "Warning",
+    "海啸警报": "Warning",
+    "majorwarning": "MajorWarning",
+    "大津波警報": "MajorWarning",
+    "大海啸警报": "MajorWarning",
+    "解除": "解除",
+    "cancel": "解除",
+    "cancelled": "解除",
+}
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text or text.lower() in {"null", "none"}:
+        return ""
+    return text
+
+
+def normalize_cn_tsunami_level(raw: Any) -> str:
+    """归一化中国海啸级别。"""
+    text = _clean_text(raw)
+    if not text:
+        return ""
+    # 去掉常见后缀
+    stripped = text.replace("级", "").replace("警报", "").replace("预警", "").strip()
+    lowered = text.lower()
+    if text in CN_TSUNAMI_LEVEL_ALIASES:
+        return CN_TSUNAMI_LEVEL_ALIASES[text]
+    if stripped in CN_TSUNAMI_LEVEL_ALIASES:
+        return CN_TSUNAMI_LEVEL_ALIASES[stripped]
+    if lowered in CN_TSUNAMI_LEVEL_ALIASES:
+        return CN_TSUNAMI_LEVEL_ALIASES[lowered]
+    # 标题内嵌颜色
+    for color in ("红色", "橙色", "黄色", "蓝色"):
+        if color in text:
+            return color
+    if "信息" in text:
+        return "信息"
+    if "解除" in text or "取消" in text:
+        return "解除"
+    return text
+
+
+def normalize_jp_tsunami_level(raw: Any, *, cancelled: bool = False) -> str:
+    """归一化日本海啸级别。"""
+    if cancelled:
+        return "解除"
+    text = _clean_text(raw)
+    if not text:
+        return "Unknown"
+    if text == "解除":
+        return "解除"
+    lowered = text.lower()
+    if lowered in JP_TSUNAMI_LEVEL_ALIASES:
+        return JP_TSUNAMI_LEVEL_ALIASES[lowered]
+    if text in JP_TSUNAMI_LEVEL_ALIASES:
+        return JP_TSUNAMI_LEVEL_ALIASES[text]
+    # 已是标准枚举
+    if text in JP_TSUNAMI_LEVEL_ORDER:
+        return text
+    return text
+
+
+def cn_tsunami_level_weight(raw: Any) -> int:
+    """中国海啸级别权重；未知返回 0，解除返回 -1。"""
+    level = normalize_cn_tsunami_level(raw)
+    if not level:
+        return 0
+    if level == "解除":
+        return -1
+    try:
+        return CN_TSUNAMI_LEVEL_ORDER.index(level) + 1
+    except ValueError:
+        return 0
+
+
+def jp_tsunami_level_weight(raw: Any, *, cancelled: bool = False) -> int:
+    """日本海啸级别权重；未知返回 0，解除返回 -1。"""
+    level = normalize_jp_tsunami_level(raw, cancelled=cancelled)
+    if not level:
+        return 0
+    if level == "解除":
+        return -1
+    try:
+        return JP_TSUNAMI_LEVEL_ORDER.index(level) + 1
+    except ValueError:
+        return 0
+
+
+def resolve_tsunami_region(
+    source_id: str | None, metadata: dict[str, Any] | None = None
+) -> str:
+    """判定海啸区域：china / japan / unknown。"""
+    meta = metadata if isinstance(metadata, dict) else {}
+    family = str(meta.get("source_family") or "").strip().lower()
+    sid = str(source_id or "").strip().lower()
+    if family in {"eqsc", "p2p"} or "jma" in sid or "japan" in sid:
+        return "japan"
+    if family in {"fan_studio", "fanstudio"} or "china" in sid or "fan" in sid:
+        return "china"
+    # 回退：看等级形态
+    level = str(meta.get("level") or "").strip()
+    if level in JP_TSUNAMI_LEVEL_ORDER or level in {"解除"} and meta.get("forecasts"):
+        if any(
+            key in meta
+            for key in ("content_fingerprint", "grade_counts", "issue_hypocenter")
+        ):
+            return "japan"
+    cn_level = normalize_cn_tsunami_level(level)
+    if cn_level in CN_TSUNAMI_LEVEL_ORDER or cn_level == "解除":
+        return "china"
+    return "unknown"
+
+
+def to_optional_float(value: Any) -> float | None:
+    """宽松解析浮点。"""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if number != number:  # NaN
+            return None
+        return number
+    text = _clean_text(value)
+    if not text:
+        return None
+    # 去掉常见单位
+    for token in ("m", "ｍ", "米", "Ｍ"):
+        text = text.replace(token, "")
+    text = text.strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _format_highlight_items(items: list[str] | None, *, limit: int = 5) -> str:
+    """把亮点列表压成可读短串。"""
+    cleaned: list[str] = []
+    for item in items or []:
+        text = str(item or "").strip()
+        if text:
+            cleaned.append(text)
+        if len(cleaned) >= limit:
+            break
+    return "；".join(cleaned)
+
+
+def build_tsunami_weather_detail(
+    *,
+    region: str,
+    level: str,
+    area_count: int | None = None,
+    immediate_area_count: int | None = None,
+    max_wave_height: str | None = None,
+    max_wave_height_value: float | None = None,
+    max_wave_height_area: str | None = None,
+    station_count: int | None = None,
+    cancelled: bool = False,
+    is_training: bool = False,
+    batch: Any = None,
+    magnitude: float | None = None,
+    depth: float | None = None,
+    place_name: str | None = None,
+    grade_counts: dict[str, Any] | None = None,
+    forecast_highlights: list[str] | None = None,
+    station_highlights: list[str] | None = None,
+) -> str:
+    """构建入库用的海啸摘要文本（复用 weather_detail 列）。
+
+    对齐推送展示器语义：区域数、波高、监测站、级别分布与重点亮点。
+    前端列表可解析该文本，旧记录字段缺失时也能优雅降级。
+    """
+    parts: list[str] = []
+    if region == "japan":
+        parts.append("日本海啸")
+    elif region == "china":
+        parts.append("中国海啸")
+    if level:
+        parts.append(f"级别 {level}")
+    if cancelled or level == "解除":
+        parts.append("已解除")
+    if is_training:
+        parts.append("训练报")
+    if place_name:
+        parts.append(f"震中 {place_name}")
+    if magnitude is not None:
+        mag_text = int(magnitude) if float(magnitude).is_integer() else magnitude
+        prefix = "Mj" if region == "japan" else "M"
+        parts.append(f"{prefix}{mag_text}")
+    if depth is not None:
+        depth_text = int(depth) if float(depth).is_integer() else depth
+        parts.append(f"深度 {depth_text}km")
+    if area_count is not None and area_count > 0:
+        parts.append(f"预报区 {area_count}")
+    if immediate_area_count is not None and immediate_area_count > 0:
+        parts.append(f"立即到达 {immediate_area_count}")
+    if max_wave_height:
+        if max_wave_height_area:
+            parts.append(f"最大波高 {max_wave_height}（{max_wave_height_area}）")
+        else:
+            parts.append(f"最大波高 {max_wave_height}")
+    elif max_wave_height_value is not None:
+        if max_wave_height_area:
+            parts.append(f"最大波高 {max_wave_height_value}m（{max_wave_height_area}）")
+        else:
+            parts.append(f"最大波高 {max_wave_height_value}m")
+    if station_count is not None and station_count > 0:
+        parts.append(f"监测站 {station_count}")
+    if batch not in (None, ""):
+        parts.append(f"批次 {batch}")
+
+    # 级别分布：MajorWarning 2 / Warning 5 ...
+    if isinstance(grade_counts, dict) and grade_counts:
+        order = ("MajorWarning", "Warning", "Watch", "Minor")
+        grade_labels = {
+            "MajorWarning": "大海啸警报",
+            "Warning": "海啸警报",
+            "Watch": "海啸注意报",
+            "Minor": "若干海面变动",
+        }
+        grade_parts: list[str] = []
+        for key in order:
+            count = grade_counts.get(key)
+            try:
+                count_int = int(count) if count is not None else 0
+            except (TypeError, ValueError):
+                count_int = 0
+            if count_int > 0:
+                grade_parts.append(f"{grade_labels.get(key, key)} {count_int}")
+        if grade_parts:
+            parts.append(f"级别分布 {' / '.join(grade_parts)}")
+
+    forecast_text = _format_highlight_items(forecast_highlights, limit=6)
+    if forecast_text:
+        parts.append(f"重点预报 {forecast_text}")
+
+    station_text = _format_highlight_items(station_highlights, limit=4)
+    if station_text:
+        parts.append(f"监测实况 {station_text}")
+
+    return "，".join(parts)
+
+
+__all__ = [
+    "CN_TSUNAMI_LEVEL_ORDER",
+    "JP_TSUNAMI_LEVEL_DISPLAY",
+    "JP_TSUNAMI_LEVEL_ORDER",
+    "build_tsunami_weather_detail",
+    "cn_tsunami_level_weight",
+    "jp_tsunami_level_weight",
+    "normalize_cn_tsunami_level",
+    "normalize_jp_tsunami_level",
+    "resolve_tsunami_region",
+    "to_optional_float",
+]

--- a/core/domain/tsunami/tsunami_title.py
+++ b/core/domain/tsunami/tsunami_title.py
@@ -1,0 +1,380 @@
+"""
+海啸列表标题构建。
+
+统一生成管理端事件列表、时间轴与入库 description 使用的短标题，
+避免解析器、统计工厂与前端各自维护一套拼接规则。
+
+设计目标：
+- 一眼可读：级别 + 震中 + 震级
+- 中日语义分离，列表默认中文等级
+- 字段缺失时优雅降级（兼容升级前旧记录）
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .tsunami_levels import (
+    JP_TSUNAMI_LEVEL_DISPLAY,
+    normalize_cn_tsunami_level,
+    normalize_jp_tsunami_level,
+    resolve_tsunami_region,
+    to_optional_float,
+)
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text or text.lower() in {
+        "null",
+        "none",
+        "unknown",
+        "未知",
+        "未知地点",
+        "未知位置",
+    }:
+        return ""
+    return text
+
+
+def is_generic_tsunami_title(text: str) -> bool:
+    """判断是否为无信息量的泛化标题（不应作为地点展示）。"""
+    cleaned = _clean_text(text)
+    if not cleaned:
+        return True
+    generics = {
+        "海啸信息",
+        "海啸情报",
+        "海啸预警",
+        "海啸警报",
+        "海啸解除",
+        "海啸解除通告",
+        "津波予報",
+        "津波注意報",
+        "津波警報",
+        "大津波警報",
+        "津波予報（解除）",
+        "若干の海面変動",
+        "若干海面变动",
+        "海啸注意报",
+        "大海啸警报",
+    }
+    if cleaned in generics:
+        return True
+    # “海啸黄色警报”这类纯等级标题
+    if cleaned.startswith("海啸") and any(
+        token in cleaned for token in ("信息", "警报", "预警", "解除", "注意报")
+    ):
+        # 若包含明显地名特征则不算泛化（极少见）
+        if "·" in cleaned or "M" in cleaned or "Mj" in cleaned:
+            return False
+        # 短标题且无空格分隔地点
+        if len(cleaned) <= 12:
+            return True
+    return False
+
+
+def format_tsunami_level_label(
+    level: Any,
+    *,
+    region: str = "unknown",
+    cancelled: bool = False,
+    raw_title: str = "",
+) -> str:
+    """把标准化等级转为列表用中文主标签。"""
+    if cancelled:
+        return "海啸解除"
+
+    region_key = (region or "unknown").strip().lower()
+    raw_level = _clean_text(level)
+
+    if region_key == "japan":
+        normalized = normalize_jp_tsunami_level(raw_level, cancelled=False)
+        if normalized == "解除":
+            return "海啸解除"
+        display = JP_TSUNAMI_LEVEL_DISPLAY.get(normalized)
+        if display:
+            # JP_TSUNAMI_LEVEL_DISPLAY 已是中文：若干海面变动 / 海啸注意报…
+            if display.startswith("海啸") or display.startswith("若干"):
+                return display
+            return f"海啸{display}"
+        if normalized in {"None", "Unknown"}:
+            return "海啸预报"
+        return raw_level or "海啸预报"
+
+    if region_key == "china":
+        normalized = normalize_cn_tsunami_level(raw_level)
+        if normalized == "解除":
+            return "海啸解除"
+        if normalized == "信息":
+            return "海啸信息"
+        if normalized in {"蓝色", "黄色", "橙色", "红色"}:
+            return f"海啸{normalized}警报"
+        # 回退：原始 title 若已是完整警报名则复用
+        title = _clean_text(raw_title)
+        if title and not is_generic_tsunami_title(title):
+            # title 可能是“海啸黄色警报”，可直接用
+            if title.startswith("海啸"):
+                return title
+        if raw_level:
+            return (
+                f"海啸{raw_level}警报"
+                if "警报" not in raw_level
+                else f"海啸{raw_level}"
+            )
+        return title or "海啸情报"
+
+    # unknown：尽量从 title / level 推断
+    title = _clean_text(raw_title)
+    if title and title.startswith("海啸"):
+        return title
+    if raw_level:
+        cn = normalize_cn_tsunami_level(raw_level)
+        if cn == "信息":
+            return "海啸信息"
+        if cn in {"蓝色", "黄色", "橙色", "红色"}:
+            return f"海啸{cn}警报"
+        if cn == "解除":
+            return "海啸解除"
+        jp = normalize_jp_tsunami_level(raw_level)
+        display = JP_TSUNAMI_LEVEL_DISPLAY.get(jp)
+        if display:
+            return display if display.startswith(("海啸", "若干")) else f"海啸{display}"
+        return raw_level
+    return title or "海啸情报"
+
+
+def format_tsunami_magnitude_token(
+    magnitude: Any,
+    *,
+    region: str = "unknown",
+) -> str:
+    """格式化列表用震级 token：中国 M6.6 / 日本 Mj8.2。"""
+    value = to_optional_float(magnitude)
+    if value is None:
+        return ""
+    if float(value).is_integer():
+        mag_text = f"{int(value)}.0"
+    else:
+        mag_text = f"{value:.1f}".rstrip("0").rstrip(".")
+        if "." not in mag_text:
+            mag_text = f"{mag_text}.0"
+    prefix = "Mj" if (region or "").strip().lower() == "japan" else "M"
+    return f"{prefix}{mag_text}"
+
+
+def format_tsunami_batch_token(batch: Any) -> str:
+    """格式化批次/报次：第3报。"""
+    text = _clean_text(batch)
+    if not text:
+        return ""
+    # 已是“第n报/批”
+    if text.startswith("第") and ("报" in text or "批" in text):
+        return text
+    # 纯数字
+    try:
+        number = int(float(text))
+        if number > 0:
+            return f"第{number}报"
+    except (TypeError, ValueError):
+        pass
+    return f"第{text}报"
+
+
+def build_tsunami_list_title(
+    *,
+    region: str = "unknown",
+    level: str = "",
+    title: str = "",
+    place_name: str = "",
+    magnitude: float | None = None,
+    batch: Any = None,
+    cancelled: bool = False,
+    is_training: bool = False,
+    max_wave_height: str | None = None,
+    area_count: int | None = None,
+) -> str:
+    """构建管理端列表/入库用的海啸短标题。
+
+    示例：
+    - 海啸信息 · 中国台湾省周边海域 M6.6
+    - 海啸黄色警报 · 堪察加东岸远海海域 M8.8
+    - 海啸警报 · 三陸沖 Mj8.2
+    - [训练] 海啸注意报 · 三陸沖
+    - 海啸解除 · 中国台湾省周边海域
+
+    字段全缺时回退：
+    - 有 title 且非垃圾：用 title
+    - 否则「海啸情报」
+    """
+    region_key = (region or "unknown").strip().lower() or "unknown"
+    level_label = format_tsunami_level_label(
+        level,
+        region=region_key,
+        cancelled=cancelled or _clean_text(level) == "解除",
+        raw_title=title,
+    )
+
+    place = _clean_text(place_name)
+    if is_generic_tsunami_title(place):
+        place = ""
+
+    mag_token = format_tsunami_magnitude_token(magnitude, region=region_key)
+    batch_token = format_tsunami_batch_token(batch) if region_key == "china" else ""
+
+    # 主段：级别
+    head = level_label
+    if is_training and not head.startswith("[训练]"):
+        head = f"[训练] {head}"
+
+    body_parts: list[str] = []
+    if place:
+        body_parts.append(place)
+    if mag_token:
+        # 有地点时震级紧跟地点；无地点时单独一段
+        if body_parts:
+            body_parts[-1] = f"{body_parts[-1]} {mag_token}"
+        else:
+            body_parts.append(mag_token)
+
+    # 无地点/震级时，用波高或预报区数补一点辨识度（避免只剩级别）
+    if not body_parts:
+        wave = _clean_text(max_wave_height)
+        if wave:
+            body_parts.append(f"最大波高 {wave}")
+        elif area_count is not None:
+            try:
+                count = int(area_count)
+            except (TypeError, ValueError):
+                count = 0
+            if count > 0:
+                body_parts.append(f"预报区 {count}")
+
+    if batch_token:
+        body_parts.append(f"（{batch_token}）")
+
+    if body_parts:
+        # 批次用括号贴在末尾，其余用 · 连接
+        core: list[str] = []
+        suffix = ""
+        for part in body_parts:
+            if part.startswith("（") and part.endswith("）"):
+                suffix = part
+            else:
+                core.append(part)
+        middle = " · ".join(core) if core else ""
+        if middle and suffix:
+            return f"{head} · {middle}{suffix}"
+        if middle:
+            return f"{head} · {middle}"
+        if suffix:
+            return f"{head}{suffix}"
+        return head
+
+    # 彻底无附加信息：尽量用原始 title，避免再拼 “(level)”
+    raw_title = _clean_text(title)
+    if raw_title and not is_generic_tsunami_title(raw_title):
+        return (
+            f"[训练] {raw_title}"
+            if is_training and "[训练]" not in raw_title
+            else raw_title
+        )
+    return head or "海啸情报"
+
+
+def build_tsunami_list_title_from_mapping(
+    data: dict[str, Any] | None,
+    *,
+    source_id: str = "",
+    default_title: str = "",
+    default_level: str = "",
+) -> str:
+    """从 dict / DB 行 / metadata 构建列表标题（前后端共用语义入口）。"""
+    row = data if isinstance(data, dict) else {}
+    region = resolve_tsunami_region(
+        source_id or row.get("source_id") or row.get("source"), row
+    )
+
+    level = _clean_text(row.get("level") or default_level)
+    title = _clean_text(row.get("title") or row.get("description") or default_title)
+    place_name = _clean_text(
+        row.get("place_name") or row.get("placeName") or row.get("subtitle") or ""
+    )
+    # subtitle 若其实是泛化标题，不当作地点
+    if is_generic_tsunami_title(place_name):
+        place_name = _clean_text(row.get("place_name") or row.get("placeName") or "")
+
+    magnitude = to_optional_float(row.get("magnitude"))
+    cancelled = bool(
+        row.get("is_cancelled")
+        or row.get("cancelled")
+        or level == "解除"
+        or "解除" in title
+    )
+    is_training = bool(row.get("is_training") or row.get("isTraining"))
+    batch = row.get("batch")
+    max_wave = _clean_text(
+        row.get("max_wave_height_text")
+        or row.get("maxWaveHeight")
+        or (
+            f"{row.get('max_wave_height')}m"
+            if isinstance(row.get("max_wave_height"), (int, float))
+            else row.get("max_wave_height")
+        )
+        or ""
+    )
+    area_count = row.get("area_count")
+    try:
+        area_count_int = int(area_count) if area_count is not None else None
+    except (TypeError, ValueError):
+        area_count_int = None
+
+    return build_tsunami_list_title(
+        region=region,
+        level=level,
+        title=title,
+        place_name=place_name,
+        magnitude=magnitude,
+        batch=batch,
+        cancelled=cancelled,
+        is_training=is_training,
+        max_wave_height=max_wave or None,
+        area_count=area_count_int,
+    )
+
+
+def is_legacy_tsunami_description(description: Any, level: Any = None) -> bool:
+    """识别升级前的低质量 description：如「海啸信息 (信息)」。"""
+    text = _clean_text(description)
+    if not text:
+        return True
+    # title (level)
+    if " (" in text and text.endswith(")"):
+        head, _, tail = text.partition(" (")
+        level_part = tail[:-1].strip() if tail.endswith(")") else ""
+        if head and level_part:
+            # 等级括号与主标题高度同义
+            if level_part in head or head in {
+                f"海啸{level_part}",
+                f"海啸{level_part}警报",
+                "海啸信息",
+            }:
+                return True
+            if _clean_text(level) and level_part == _clean_text(level):
+                return True
+    if is_generic_tsunami_title(text):
+        return True
+    return False
+
+
+__all__ = [
+    "build_tsunami_list_title",
+    "build_tsunami_list_title_from_mapping",
+    "format_tsunami_batch_token",
+    "format_tsunami_level_label",
+    "format_tsunami_magnitude_token",
+    "is_generic_tsunami_title",
+    "is_legacy_tsunami_description",
+]

--- a/core/message/logging/filters/event_hash_builder.py
+++ b/core/message/logging/filters/event_hash_builder.py
@@ -122,10 +122,18 @@ class EventHashBuilder:
 
     def generate_tsunami_hash(self, data: dict[str, Any], hash_parts: list[str]) -> str:
         """生成海啸类消息的去重哈希。"""
-        event_id = data.get("id") or data.get("code")
+        # EQSC 使用 eventID；中国海啸常用 id/code；一并兼容
+        event_id = (
+            data.get("id")
+            or data.get("code")
+            or data.get("eventID")
+            or data.get("eventId")
+        )
         if event_id:
             hash_parts.append(f"tid:{event_id}")
-            time_info = data.get("issue_time") or data.get("time")
+            time_info = (
+                data.get("issue_time") or data.get("time") or data.get("register")
+            )
             if time_info:
                 hash_parts.append(f"tt:{str(time_info)[:16]}")
             return "|".join(hash_parts)

--- a/core/message/presenters/tsunami_presenter.py
+++ b/core/message/presenters/tsunami_presenter.py
@@ -7,14 +7,72 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ....utils.time_converter import TimeConverter
 from ...domain.event_context import TsunamiDisplayContext
+from ...domain.tsunami.jma_tsunami_normalize import GRADE_TITLE_MAP, coerce_bool
+from ...domain.tsunami.tsunami_levels import (
+    normalize_cn_tsunami_level,
+    normalize_jp_tsunami_level,
+)
 from ...sources.source_catalog import get_source_entry
 from .base_presenter import BasePresenter
 
+# 中国海啸颜色圆形 emoji（与气象预警一致）
+CN_LEVEL_EMOJI: dict[str, str] = {
+    "信息": "⚪",
+    "蓝色": "🔵",
+    "黄色": "🟡",
+    "橙色": "🟠",
+    "红色": "🔴",
+    "解除": "",
+}
+
+# 日本海啸等级圆形 emoji：
+# 若干海面变动灰、注意黄、警报橙、大津波红；None/Unknown/解除不着色
+JP_LEVEL_EMOJI: dict[str, str] = {
+    "Minor": "⚪",
+    "Watch": "🟡",
+    "Warning": "🟠",
+    "MajorWarning": "🔴",
+    "None": "",
+    "Unknown": "",
+    "解除": "",
+}
+
+
+def _cn_level_emoji(level: Any) -> str:
+    normalized = normalize_cn_tsunami_level(level)
+    if normalized in CN_LEVEL_EMOJI:
+        return CN_LEVEL_EMOJI[normalized]
+    text = str(level or "")
+    for color, emoji in (
+        ("红色", "🔴"),
+        ("橙色", "🟠"),
+        ("黄色", "🟡"),
+        ("蓝色", "🔵"),
+        ("信息", "⚪"),
+    ):
+        if color in text:
+            return emoji
+    return ""
+
+
+def _jp_level_emoji(level: Any, *, cancelled: bool = False) -> str:
+    normalized = normalize_jp_tsunami_level(level, cancelled=cancelled)
+    return JP_LEVEL_EMOJI.get(normalized, "")
+
+
+def _jp_level_label(level: Any, *, cancelled: bool = False) -> str:
+    normalized = normalize_jp_tsunami_level(level, cancelled=cancelled)
+    if cancelled or normalized == "解除":
+        return GRADE_TITLE_MAP.get("解除", "津波予報（解除）")
+    return GRADE_TITLE_MAP.get(normalized, str(level or "").strip() or "津波予報")
+
 
 class TsunamiAlertPresenter(BasePresenter):
-    """通用海啸文本展示器。"""
+    """通用海啸文本展示器（中国自然资源部）。"""
 
     presenter_name = "tsunami_alert_presenter"
 
@@ -26,39 +84,56 @@ class TsunamiAlertPresenter(BasePresenter):
         return f"{abs(latitude):.2f}°{lat_dir}, {abs(longitude):.2f}°{lon_dir}"
 
     @classmethod
+    def _resolve_timezone(
+        cls,
+        display_context: TsunamiDisplayContext,
+        options: dict[str, Any],
+    ) -> str:
+        timezone = options.get("timezone")
+        if timezone:
+            return str(timezone)
+        if display_context.source_id:
+            source_entry = get_source_entry(display_context.source_id)
+            display_name = source_entry.display_name if source_entry is not None else ""
+            if "日本" in display_name or "日本气象厅" in display_name:
+                return "UTC+9"
+        return "UTC+8"
+
+    @classmethod
     def format_message(
         cls,
         display_context: TsunamiDisplayContext,
         options: dict | None = None,
     ) -> str:
         options = options or {}
-        target_timezone = options.get("timezone")
-
-        # 若调用方未指定时区，则按来源默认落到更符合使用习惯的展示时区。
-        if not target_timezone and display_context.source_id:
-            source_entry = get_source_entry(display_context.source_id)
-            display_name = source_entry.display_name if source_entry is not None else ""
-            if "日本" in display_name or "日本气象厅" in display_name:
-                target_timezone = "UTC+9"
-            else:
-                target_timezone = "UTC+8"
-        elif not target_timezone:
-            target_timezone = "UTC+8"
+        target_timezone = cls._resolve_timezone(display_context, options)
 
         is_info = (
             display_context.message_type == "info" or display_context.level == "信息"
         )
-        lines = ["🌊[海啸信息]" if is_info else "🌊[海啸预警]"]
+        org_unit = str(display_context.org_unit or "自然资源部海啸预警中心").strip()
+        header_tag = "海啸信息" if is_info else "海啸预警"
+        lines = [f"🌊[{header_tag}] {org_unit}"]
 
+        level_emoji = _cn_level_emoji(display_context.level)
         if display_context.title:
-            lines.append(f"📋{display_context.title}")
-        if display_context.level:
-            lines.append(f"⚠️级别：{display_context.level}")
-        if display_context.org_unit:
-            lines.append(f"🏢发布：{display_context.org_unit}")
-        if display_context.updated_at:
+            title_line = f"📋{display_context.title}"
+            if level_emoji:
+                title_line += level_emoji
+            lines.append(title_line)
+        elif display_context.level:
+            level_text = str(display_context.level)
+            title_line = (
+                f"📋海啸{level_text}警报" if level_text != "信息" else "📋海啸信息"
+            )
+            if level_emoji:
+                title_line += level_emoji
+            lines.append(title_line)
+
+        time_value = display_context.updated_at or display_context.issued_at
+        if time_value:
             lines.append(
-                f"🕒最近更新时间：{TimeConverter.format_time(display_context.updated_at, target_timezone)}"
+                f"🕒最近更新时间：{TimeConverter.format_time(time_value, target_timezone)}"
             )
 
         place_name = display_context.place_name or display_context.subtitle
@@ -66,83 +141,100 @@ class TsunamiAlertPresenter(BasePresenter):
         lon = display_context.longitude
         if place_name:
             if lat is not None and lon is not None:
-                coords = cls._format_coordinates(lat, lon)
-                lines.append(f"🌍震源：{place_name} ({coords})")
+                try:
+                    coords = cls._format_coordinates(float(lat), float(lon))
+                    lines.append(f"🌍震源：{place_name} ({coords})")
+                except (TypeError, ValueError):
+                    lines.append(f"🌍震源：{place_name}")
             else:
                 lines.append(f"🌍震源：{place_name}")
 
-        shock_parts = []
+        shock_parts: list[str] = []
         if display_context.magnitude is not None:
             shock_parts.append(f"M {display_context.magnitude}")
         if display_context.depth is not None:
-            shock_parts.append(f"深度{display_context.depth} km")
+            depth = display_context.depth
+            depth_text = int(depth) if float(depth).is_integer() else depth
+            shock_parts.append(f"深度 {depth_text}km")
         if shock_parts:
             lines.append(f"🧭参数：{' / '.join(shock_parts)}")
 
-        forecasts = display_context.forecasts
+        forecasts = [
+            item for item in (display_context.forecasts or []) if isinstance(item, dict)
+        ]
         if forecasts:
-            lines.append(f"📈沿海预报：{len(forecasts)}个区域")
-            # 信息类消息比预警类消息更偏概览，因此展示区域数略少。
-            show_n = 2 if is_info else 3
-            for forecast in forecasts[:show_n]:
+            lines.append(f"📈沿海预报：{len(forecasts)} 个区域")
+            # 海啸事件默认不折叠区域，尽量全部展示
+            for forecast in forecasts:
                 area_name = (
                     forecast.get("forecastArea")
                     or forecast.get("forecastPoint")
                     or forecast.get("name")
                     or ""
                 )
+                area_name = str(area_name).strip()
                 if not area_name:
                     continue
                 area_info = f"  • {area_name}"
-                grade = forecast.get("warningLevel") or forecast.get("grade")
-                if grade:
-                    area_info += f" [{grade}]"
-                arrival_time = forecast.get("estimatedArrivalTime")
+                grade = forecast.get("warningLevel") or forecast.get("grade") or ""
+                grade_text = str(grade).strip()
+                if grade_text:
+                    grade_emoji = _cn_level_emoji(grade_text)
+                    area_info += f" [{grade_text}]"
+                    if grade_emoji:
+                        area_info += grade_emoji
+                arrival_time = str(forecast.get("estimatedArrivalTime") or "").strip()
                 if arrival_time:
                     area_info += f" 预计{arrival_time}到达"
-                max_wave = forecast.get("maxWaveHeight")
+                max_wave = str(forecast.get("maxWaveHeight") or "").strip()
                 if max_wave:
-                    area_info += f" 波高 {max_wave}cm"
+                    # 文档样例多为 cm 数值区间；若已带单位则原样
+                    if any(
+                        token in max_wave for token in ("cm", "CM", "米", "m", "ｍ")
+                    ):
+                        area_info += f" 波高 🌊 {max_wave}"
+                    else:
+                        area_info += f" 波高 🌊 {max_wave}cm"
                 lines.append(area_info)
-            if len(forecasts) > show_n:
-                lines.append(f"  ...其余{len(forecasts) - show_n}个区域")
 
-        monitoring_stations = display_context.monitoring_stations
+        monitoring_stations = [
+            item
+            for item in (display_context.monitoring_stations or [])
+            if isinstance(item, dict)
+        ]
         if monitoring_stations:
-            lines.append(f"📡监测实况：{len(monitoring_stations)}个站点")
-            if not is_info:
-                for station in monitoring_stations[:2]:
-                    station_name = (
-                        station.get("stationName") or station.get("name") or "监测站"
-                    )
-                    location = station.get("location") or ""
-                    wave = station.get("maxWaveHeight") or ""
-                    station_line = f"  • {station_name}"
-                    if location:
-                        station_line += f"({location})"
-                    if wave:
-                        station_line += f" 最大波幅 {wave}cm"
-                    lines.append(station_line)
+            lines.append(f"📡监测实况：{len(monitoring_stations)} 个站点")
+            for station in monitoring_stations:
+                station_name = (
+                    station.get("stationName") or station.get("name") or "监测站"
+                )
+                location = str(station.get("location") or "").strip()
+                wave = str(station.get("maxWaveHeight") or "").strip()
+                station_line = f"  • {station_name}"
+                if location:
+                    station_line += f"({location})"
+                if wave:
+                    if any(token in wave for token in ("cm", "CM", "米", "m", "ｍ")):
+                        station_line += f" 最大波幅 🌊 {wave}"
+                    else:
+                        station_line += f" 最大波幅 🌊 {wave}cm"
+                lines.append(station_line)
 
-        if display_context.batch:
-            lines.append(f"🧾批次：{display_context.batch}")
         if display_context.details_url:
             lines.append("🔗详情：")
-            lines.append(display_context.details_url)
+            lines.append(str(display_context.details_url).strip())
 
         map_name_mapping = {
             "earthquake": "震中图",
             "amplitude": "最大波幅图",
             "coastal": "沿岸预报图",
         }
-        for map_key, map_url in display_context.map_urls.items():
+        for map_key, map_url in (display_context.map_urls or {}).items():
             if isinstance(map_url, str) and map_url.strip():
                 map_label = map_name_mapping.get(map_key, map_key)
                 lines.append(f"🗺️{map_label}：")
                 lines.append(map_url.strip())
 
-        if display_context.code:
-            lines.append(f"🔄事件编号：{display_context.code}")
         return "\n".join(lines)
 
     @classmethod
@@ -158,9 +250,222 @@ class TsunamiAlertPresenter(BasePresenter):
 
 
 class JmaTsunamiPresenter(BasePresenter):
-    """日本气象厅海啸预报文本展示器。"""
+    """日本气象厅海啸预报文本展示器。
+
+    同时服务 P2P 与 EQSC，输出风格统一：
+    - 标题行带 [解除]/[训练报] 标记
+    - 等级圆形 emoji
+    - 区域默认全部展示
+    """
 
     presenter_name = "jma_tsunami_presenter"
+
+    # 等级展示：优先日文官方用语，未知值原样回退
+    LEVEL_MAPPING = {
+        **GRADE_TITLE_MAP,
+        "Unknown": "不明",
+        "None": "なし",
+    }
+
+    @staticmethod
+    def _meta(display_context: TsunamiDisplayContext) -> dict[str, Any]:
+        metadata = display_context.metadata
+        return metadata if isinstance(metadata, dict) else {}
+
+    @staticmethod
+    def _format_dt(value: Any, timezone: str) -> str:
+        """格式化时间供展示。
+
+        解析语义：
+        - 无时区（naive）的 JMA/EQSC 时间按 UTC+9（JST）解释；
+        - 已有时区则保留。
+
+        展示语义：
+        - 最终文本一律按调用方传入的 timezone（用户 display_timezone）输出，
+          复用 TimeConverter.format_time 的统一样式。
+        """
+        if value is None:
+            return ""
+        if hasattr(value, "tzinfo"):
+            display_time = value
+            if display_time.tzinfo is None:
+                display_time = display_time.replace(
+                    tzinfo=TimeConverter.TIMEZONES["JST"]
+                )
+            return TimeConverter.format_time(display_time, timezone)
+        text = str(value).strip()
+        if not text:
+            return ""
+        parsed = TimeConverter.parse_datetime(text)
+        if parsed is None:
+            return text
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=TimeConverter.TIMEZONES["JST"])
+        return TimeConverter.format_time(parsed, timezone)
+
+    @classmethod
+    def _resolve_timezone(
+        cls,
+        display_context: TsunamiDisplayContext,
+        options: dict[str, Any],
+    ) -> str:
+        """解析展示时区：优先用户配置，缺省回退 UTC+8。"""
+        del display_context
+        timezone = options.get("timezone")
+        if timezone:
+            return str(timezone)
+        return "UTC+8"
+
+    @classmethod
+    def _build_header(
+        cls,
+        *,
+        cancelled: bool,
+        is_training: bool,
+    ) -> str:
+        """构建标题行。
+
+        示例：
+        - 🌊[津波予報] 日本气象厅
+        - 🌊[津波予報] [解除] 日本气象厅
+        - 🌊[津波予報] [训练报] 日本气象厅
+        """
+        tags: list[str] = []
+        if cancelled:
+            tags.append("[解除]")
+        if is_training:
+            tags.append("[训练报]")
+        if tags:
+            return f"🌊[津波予報] {' '.join(tags)} 日本气象厅"
+        return "🌊[津波予報] 日本气象厅"
+
+    @classmethod
+    def _append_hypocenter_lines(
+        cls,
+        lines: list[str],
+        display_context: TsunamiDisplayContext,
+        metadata: dict[str, Any],
+        timezone: str,
+    ) -> None:
+        """追加关联地震信息。"""
+        place_name = (
+            display_context.place_name
+            or display_context.subtitle
+            or str(metadata.get("place_name") or "").strip()
+        )
+        magnitude = display_context.magnitude
+        if magnitude is None:
+            magnitude = metadata.get("magnitude")
+        shock_time = metadata.get("shock_time") or metadata.get("origin_time_raw")
+
+        # 示例：🌍震源参数：三陸沖 Mj 8.2
+        if place_name and magnitude is not None and magnitude != "":
+            lines.append(f"🌍震源参数：{place_name} Mj {magnitude}")
+        elif place_name:
+            lines.append(f"🌍震源参数：{place_name}")
+        elif magnitude is not None and magnitude != "":
+            lines.append(f"🌍震源参数：Mj {magnitude}")
+
+        if shock_time:
+            shock_text = cls._format_dt(shock_time, timezone)
+            if shock_text:
+                lines.append(f"⏱️发震时刻：{shock_text}")
+
+    @classmethod
+    def _append_area_lines(
+        cls,
+        lines: list[str],
+        forecasts: list[dict[str, Any]],
+        metadata: dict[str, Any],
+        *,
+        cancelled: bool,
+    ) -> None:
+        """追加区域预报详情（默认全部展示，不折叠）。"""
+        if not forecasts:
+            return
+
+        grade_counts = metadata.get("grade_counts")
+        if isinstance(grade_counts, dict) and grade_counts:
+            summary_parts = []
+            for grade in ("MajorWarning", "Warning", "Watch", "Minor"):
+                count = grade_counts.get(grade)
+                if count:
+                    label = cls.LEVEL_MAPPING.get(grade, grade)
+                    summary_parts.append(f"{label} {count}")
+            if summary_parts:
+                lines.append(f"📊级别分布：{' / '.join(summary_parts)}")
+
+        max_wave = str(metadata.get("max_wave_height") or "").strip()
+        max_wave_area = str(metadata.get("max_wave_height_area") or "").strip()
+        if max_wave:
+            if max_wave_area:
+                lines.append(f"🌊全域最大预估波高：{max_wave}（{max_wave_area}）")
+            else:
+                lines.append(f"🌊全域最大预估波高：{max_wave}")
+
+        immediate_areas: list[dict[str, Any]] = []
+        normal_areas: list[dict[str, Any]] = []
+        for forecast in forecasts:
+            if not isinstance(forecast, dict):
+                continue
+            area_name = str(forecast.get("name") or "").strip()
+            if not area_name:
+                continue
+            if coerce_bool(forecast.get("immediate"), default=False):
+                immediate_areas.append(forecast)
+            else:
+                normal_areas.append(forecast)
+
+        if immediate_areas:
+            lines.append("🚨预测将立即发生海啸的区域：")
+            for area in immediate_areas:
+                lines.append(cls._format_area_line(area, cancelled=cancelled))
+
+        if normal_areas:
+            lines.append(f"📍津波予報区域（{len(normal_areas)}）：")
+            for area in normal_areas:
+                lines.append(cls._format_area_line(area, cancelled=cancelled))
+
+    @classmethod
+    def _format_area_line(
+        cls,
+        forecast: dict[str, Any],
+        *,
+        cancelled: bool = False,
+    ) -> str:
+        """格式化单个预报区。
+
+        示例：  • 🟠福島県 [津波警報] (14:25頃) 🌊５ｍ
+        """
+        area_name = str(forecast.get("name") or "").strip()
+        grade = str(forecast.get("grade") or "").strip()
+        grade_label = _jp_level_label(grade, cancelled=cancelled) if grade else ""
+        grade_emoji = _jp_level_emoji(grade, cancelled=cancelled)
+
+        # emoji 放在区域名前
+        if grade_emoji:
+            area_info = f"  • {grade_emoji}{area_name}"
+        else:
+            area_info = f"  • {area_name}"
+        if grade_label:
+            area_info += f" [{grade_label}]"
+
+        time_info: list[str] = []
+        arrival_time = str(forecast.get("estimatedArrivalTime") or "").strip()
+        condition = str(forecast.get("condition") or "").strip()
+        if arrival_time:
+            time_info.append(arrival_time)
+        if condition and condition != arrival_time:
+            time_info.append(condition)
+        if time_info:
+            area_info += f" ({' / '.join(time_info)})"
+
+        max_wave = str(
+            forecast.get("maxWaveHeight") or forecast.get("maxHeightDescription") or ""
+        ).strip()
+        if max_wave:
+            area_info += f" 🌊{max_wave}"
+        return area_info
 
     @classmethod
     def format_message(
@@ -170,94 +475,69 @@ class JmaTsunamiPresenter(BasePresenter):
     ) -> str:
         """格式化日本气象厅海啸预报消息。"""
         options = options or {}
-        timezone = options.get("timezone", "UTC+8")
+        timezone = cls._resolve_timezone(display_context, options)
+        metadata = cls._meta(display_context)
 
-        lines = ["🌊[津波予報] 日本气象厅"]
+        cancelled = bool(
+            display_context.level == "解除"
+            or coerce_bool(metadata.get("cancelled"), default=False)
+        )
+        is_training = coerce_bool(metadata.get("is_training"), default=False)
 
-        if display_context.title:
-            lines.append(f"📋{display_context.title}")
-
-        level_mapping = {
-            "MajorWarning": "大津波警報",
-            "Warning": "津波警報",
-            "Watch": "津波注意報",
-            "Unknown": "不明",
-            "解除": "解除",
-        }
-
-        if display_context.level:
-            japanese_level = level_mapping.get(
-                display_context.level, display_context.level
+        lines = [
+            cls._build_header(
+                cancelled=cancelled,
+                is_training=is_training,
             )
-            lines.append(f"⚠️級別：{japanese_level}")
+        ]
 
-        if display_context.org_unit:
-            lines.append(f"🏢発表：{display_context.org_unit}")
+        # 标题 + 等级 emoji（解除通常不附圆形色）
+        title = str(display_context.title or "").strip()
+        level = str(display_context.level or "").strip()
+        level_label = _jp_level_label(level, cancelled=cancelled)
+        level_emoji = _jp_level_emoji(level, cancelled=cancelled)
+        if title:
+            title_line = f"📋{title}"
+            if level_emoji and not cancelled:
+                title_line += level_emoji
+            lines.append(title_line)
+        elif level_label:
+            title_line = f"📋{level_label}"
+            if level_emoji and not cancelled:
+                title_line += level_emoji
+            lines.append(title_line)
 
         if display_context.issued_at:
-            display_time = display_context.issued_at
-            if display_time.tzinfo is None:
-                display_time = TimeConverter.parse_datetime(display_time).replace(
-                    tzinfo=TimeConverter.TIMEZONES["JST"]
-                )
             lines.append(
-                f"⏰発表時刻：{TimeConverter.format_time(display_time, timezone)}"
+                f"⏰发表时间：{cls._format_dt(display_context.issued_at, timezone)}"
+            )
+        elif metadata.get("issue_time_raw"):
+            lines.append(
+                f"⏰发表时间：{cls._format_dt(metadata.get('issue_time_raw'), timezone)}"
             )
 
-        forecasts = display_context.forecasts
-        if forecasts:
-            # 日本气象厅海啸预报会区分“预计立即到达”与普通区域，分别展示更利于阅读。
-            immediate_areas: list[str] = []
-            normal_areas: list[str] = []
+        cls._append_hypocenter_lines(lines, display_context, metadata, timezone)
 
-            for forecast in forecasts:
-                area_name = forecast.get("name", "")
-                if not area_name:
-                    continue
-                if forecast.get("immediate", False):
-                    immediate_areas.append(area_name)
-                else:
-                    normal_areas.append(area_name)
-
-            if immediate_areas:
-                lines.append("🚨预测将立即发生海啸的区域：")
-                for area in immediate_areas[:3]:
-                    lines.append(f"  • {area}")
-                if len(immediate_areas) > 3:
-                    lines.append(f"  ...其他{len(immediate_areas) - 3}区域")
-
-            if normal_areas:
-                lines.append("📍津波予報区域：")
-                for area in normal_areas[:5]:
-                    area_info = f"  • {area}"
-                    curr_forecast = next(
-                        (f for f in forecasts if f.get("name") == area), {}
-                    )
-
-                    arrival_time = curr_forecast.get("estimatedArrivalTime")
-                    condition = curr_forecast.get("condition")
-                    time_info = []
-                    if arrival_time:
-                        time_info.append(f"{arrival_time}")
-                    if condition:
-                        time_info.append(f"{condition}")
-                    if time_info:
-                        area_info += f" ({' '.join(time_info)})"
-
-                    max_wave = curr_forecast.get("maxWaveHeight")
-                    if max_wave:
-                        area_info += f" 🌊{max_wave}"
-
-                    lines.append(area_info)
-
-                if len(normal_areas) > 5:
-                    lines.append(f"  ...其他{len(normal_areas) - 5}区域")
-
-        if display_context.code:
-            lines.append(f"🔄事件ID：{display_context.code}")
-
-        if display_context.level == "解除":
+        # 解除：精简正文，突出无需担心
+        if cancelled:
             lines.append("✅津波の心配はありません（无需担心海啸）")
+            return "\n".join(lines)
+
+        # 非解除：区域与波高详情；标题与区域块之间可空一行增强可读性
+        forecasts = [
+            item for item in (display_context.forecasts or []) if isinstance(item, dict)
+        ]
+        if forecasts or metadata.get("max_wave_height") or metadata.get("grade_counts"):
+            # 震源块与区域块之间空一行（与示例一致）
+            if any(line.startswith("🌍") or line.startswith("⏱️") for line in lines):
+                lines.append("")
+            cls._append_area_lines(lines, forecasts, metadata, cancelled=False)
+
+        expires_at = metadata.get("expires_at") or metadata.get("expires_at_raw")
+        if expires_at:
+            expires_text = cls._format_dt(expires_at, timezone)
+            if expires_text:
+                lines.append(f"⌛有效期至：{expires_text}")
 
         return "\n".join(lines)
 

--- a/core/message/presenters/tsunami_presenter.py
+++ b/core/message/presenters/tsunami_presenter.py
@@ -109,9 +109,7 @@ class TsunamiAlertPresenter(BasePresenter):
         target_timezone = cls._resolve_timezone(display_context, options)
 
         normalized_level = normalize_cn_tsunami_level(display_context.level)
-        is_info = (
-            display_context.message_type == "info" or normalized_level == "信息"
-        )
+        is_info = display_context.message_type == "info" or normalized_level == "信息"
         org_unit = str(display_context.org_unit or "自然资源部海啸预警中心").strip()
         header_tag = "海啸信息" if is_info else "海啸预警"
         lines = [f"🌊[{header_tag}] {org_unit}"]

--- a/core/message/presenters/tsunami_presenter.py
+++ b/core/message/presenters/tsunami_presenter.py
@@ -108,8 +108,9 @@ class TsunamiAlertPresenter(BasePresenter):
         options = options or {}
         target_timezone = cls._resolve_timezone(display_context, options)
 
+        normalized_level = normalize_cn_tsunami_level(display_context.level)
         is_info = (
-            display_context.message_type == "info" or display_context.level == "信息"
+            display_context.message_type == "info" or normalized_level == "信息"
         )
         org_unit = str(display_context.org_unit or "自然资源部海啸预警中心").strip()
         header_tag = "海啸信息" if is_info else "海啸预警"
@@ -122,10 +123,16 @@ class TsunamiAlertPresenter(BasePresenter):
                 title_line += level_emoji
             lines.append(title_line)
         elif display_context.level:
-            level_text = str(display_context.level)
-            title_line = (
-                f"📋海啸{level_text}警报" if level_text != "信息" else "📋海啸信息"
-            )
+            # 使用归一化等级，避免「海啸信息/info」等变体被拼成“海啸xxx警报”
+            if normalized_level == "信息":
+                title_line = "📋海啸信息"
+            elif normalized_level in {"蓝色", "黄色", "橙色", "红色"}:
+                title_line = f"📋海啸{normalized_level}警报"
+            elif normalized_level == "解除":
+                title_line = "📋海啸解除"
+            else:
+                level_text = str(display_context.level)
+                title_line = f"📋海啸{level_text}警报"
             if level_emoji:
                 title_line += level_emoji
             lines.append(title_line)
@@ -380,10 +387,10 @@ class JmaTsunamiPresenter(BasePresenter):
         *,
         cancelled: bool,
     ) -> None:
-        """追加区域预报详情（默认全部展示，不折叠）。"""
-        if not forecasts:
-            return
+        """追加区域预报详情（默认全部展示，不折叠）。
 
+        即使 forecasts 为空，仍输出 grade_counts / max_wave_height 等摘要字段。
+        """
         grade_counts = metadata.get("grade_counts")
         if isinstance(grade_counts, dict) and grade_counts:
             summary_parts = []
@@ -402,6 +409,9 @@ class JmaTsunamiPresenter(BasePresenter):
                 lines.append(f"🌊全域最大预估波高：{max_wave}（{max_wave_area}）")
             else:
                 lines.append(f"🌊全域最大预估波高：{max_wave}")
+
+        if not forecasts:
+            return
 
         immediate_areas: list[dict[str, Any]] = []
         normal_areas: list[dict[str, Any]] = []

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -65,12 +65,270 @@ class BrowserManager:
             return None
         return {"width": width, "height": height}
 
+    @staticmethod
+    def _is_target_closed_error(error: Exception | str | None) -> bool:
+        """判断是否为 Playwright 目标/浏览器已关闭类错误。"""
+        message = str(error or "").lower()
+        return any(
+            marker in message
+            for marker in (
+                "target page, context or browser has been closed",
+                "browser has been closed",
+                "target closed",
+                "page has been closed",
+                "context has been closed",
+            )
+        )
+
     def _truncate_debug_text(self, value, limit: int = 240) -> str:
         """截断浏览器侧日志文本，避免单条日志过长。"""
         text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
         if len(text) <= limit:
             return text
         return f"{text[:limit]}..."
+
+    async def _is_page_usable(self, page: Page | None) -> bool:
+        """检查页面是否仍可用于渲染。"""
+        if page is None:
+            return False
+        try:
+            if page.is_closed():
+                return False
+            # 轻量探测：页面所属浏览器/上下文若已失效，这里会抛出。
+            _ = page.context
+            # 给探测加超时，避免页面卡死时把归还/取用流程一起拖死。
+            await asyncio.wait_for(page.evaluate("() => true"), timeout=1.0)
+            return True
+        except Exception:
+            return False
+
+    async def _is_browser_alive(self) -> bool:
+        """检查本地浏览器进程是否仍可用。"""
+        if self._closed or self._browser is None:
+            return False
+        try:
+            # Playwright Browser.is_connected() 在进程崩溃后会返回 False。
+            is_connected = getattr(self._browser, "is_connected", None)
+            if callable(is_connected):
+                return bool(is_connected())
+            return True
+        except Exception:
+            return False
+
+    async def _ensure_local_browser_ready(self) -> bool:
+        """确保本地浏览器与页面池可用；必要时自动重建。"""
+        if self._mode != "local":
+            return self._initialized and not self._closed
+
+        if self._closed:
+            return False
+
+        # 快路径：已初始化且浏览器仍连接时直接复用。
+        if self._initialized and await self._is_browser_alive():
+            return True
+
+        # 慢路径：加初始化锁，避免并发渲染同时触发多次重建。
+        async with self._init_lock:
+            if self._closed:
+                return False
+            if self._initialized and await self._is_browser_alive():
+                return True
+
+            logger.warning("[灾害预警] 检测到浏览器不可用，尝试重新初始化...")
+            try:
+                # 注意：这里不能调用 initialize() 内部的 _init_lock（同协程重入会卡死），
+                # 因此在已持有锁的情况下直接执行重建步骤。
+                await self._cleanup()
+                self._closed = False
+
+                logger.info(f"[灾害预警] 正在启动浏览器（模式：{self._mode}）...")
+                start_time = time.time()
+                self._playwright = await async_playwright().start()
+                self._browser = await self._playwright.chromium.launch(
+                    args=["--no-sandbox", "--disable-setuid-sandbox"]
+                )
+                logger.info("[灾害预警] 本地浏览器启动成功")
+                await self._initialize_local_page_pool()
+                elapsed = time.time() - start_time
+                self._initialized = True
+                logger.info(
+                    f"[灾害预警] 浏览器重建完成，耗时 {elapsed:.2f}秒，页面池大小: {self.pool_size}"
+                )
+                return await self._is_browser_alive()
+            except Exception as reinit_err:
+                logger.error(f"[灾害预警] 浏览器重新初始化失败: {reinit_err}")
+                await self._cleanup()
+                return False
+
+    async def _create_local_page(self) -> Page:
+        """创建本地页面池中的新页面。"""
+        if not self._browser:
+            raise RuntimeError("浏览器未就绪，无法创建页面")
+        return await self._browser.new_page(
+            viewport=dict(self.DEFAULT_VIEWPORT),
+            device_scale_factor=2,
+        )
+
+    async def _return_page_to_pool(self, page: Page | None) -> None:
+        """仅在页面仍可用时归还页面池，避免把坏页重新投入复用。"""
+        if page is None:
+            return
+        try:
+            if await self._is_page_usable(page):
+                await self._page_pool.put(page)
+                return
+        except Exception as return_err:
+            logger.debug(f"[灾害预警] 归还页面到池失败: {return_err}")
+
+        # 页面已不可用：尽量关闭，并补一个新页面维持池容量。
+        try:
+            if not page.is_closed():
+                await page.close()
+        except Exception:
+            pass
+        await self._replenish_page_pool()
+
+    async def _acquire_usable_page(self, timeout: float = 5.0) -> Page | None:
+        """从页面池获取可用页面；遇到坏页时丢弃并补充，必要时直接新建。"""
+        if not await self._ensure_local_browser_ready():
+            return None
+
+        deadline = time.time() + max(timeout, 0.1)
+        discarded = 0
+
+        while time.time() < deadline:
+            remaining = max(0.05, deadline - time.time())
+            page: Page | None = None
+            try:
+                page = await asyncio.wait_for(self._page_pool.get(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+
+            if await self._is_page_usable(page):
+                return page
+
+            discarded += 1
+            try:
+                if page and not page.is_closed():
+                    await page.close()
+            except Exception:
+                pass
+
+            # 坏页不回池，异步补齐容量后继续取下一个。
+            await self._replenish_page_pool()
+
+        if discarded:
+            logger.warning(
+                f"[灾害预警] 页面池中发现 {discarded} 个不可用页面，已丢弃并尝试补充"
+            )
+
+        # 池中暂时没有可用页时，直接新建一个应急页面。
+        try:
+            if await self._ensure_local_browser_ready():
+                page = await self._create_local_page()
+                logger.debug("[灾害预警] 页面池暂无可用页，已直接创建应急页面")
+                return page
+        except Exception as create_err:
+            logger.error(f"[灾害预警] 创建应急页面失败: {create_err}")
+
+        return None
+
+    async def _replenish_page_pool(self) -> None:
+        """在页面损坏或关闭后，尽量把页面池补回到目标容量。"""
+        if self._mode != "local" or self._closed:
+            return
+
+        async with self._page_creation_lock:
+            if not await self._ensure_local_browser_ready():
+                return
+
+            while self._page_pool.qsize() < self.pool_size:
+                try:
+                    new_page = await self._create_local_page()
+                    await self._page_pool.put(new_page)
+                    logger.debug(
+                        f"[灾害预警] 已补充页面，当前池大小: {self._page_pool.qsize()}/{self.pool_size}"
+                    )
+                except Exception as recover_err:
+                    logger.error(f"[灾害预警] 页面恢复失败: {recover_err}")
+                    break
+
+    async def _wait_for_fonts_ready(self, page: Page, timeout_ms: int = 1500) -> None:
+        """等待网页字体就绪，超时后继续截图，避免卡死在 fonts.ready。"""
+        try:
+            await page.evaluate(
+                """
+                async (timeoutMs) => {
+                    if (!document.fonts || !document.fonts.ready) {
+                        return "unsupported";
+                    }
+                    const timeoutPromise = new Promise((resolve) => {
+                        setTimeout(() => resolve("timeout"), timeoutMs);
+                    });
+                    const readyPromise = document.fonts.ready
+                        .then(() => "ready")
+                        .catch(() => "error");
+                    return await Promise.race([readyPromise, timeoutPromise]);
+                }
+                """,
+                timeout_ms,
+            )
+        except Exception as font_err:
+            # 字体等待失败不应阻断截图；Playwright 截图本身仍会再做一次字体检查。
+            logger.debug(f"[灾害预警] 等待字体就绪失败，继续截图: {font_err}")
+
+    async def _screenshot_card(
+        self,
+        page: Page,
+        selector: str,
+        output_path: str,
+        *,
+        timeout_ms: int = 10000,
+    ) -> None:
+        """对卡片元素截图，并在字体等待超时场景下做一次降级重试。"""
+        await self._wait_for_fonts_ready(page, timeout_ms=1500)
+        card = page.locator(selector)
+        try:
+            await card.screenshot(
+                path=output_path,
+                omit_background=True,
+                timeout=timeout_ms,
+            )
+            return
+        except Exception as first_err:
+            # Playwright 默认截图会等待字体加载；若仍超时，强制结束字体加载后重试一次。
+            message = str(first_err).lower()
+            if "font" not in message and "timeout" not in message:
+                raise
+
+            logger.warning(
+                f"[灾害预警] 卡片截图超时，尝试强制结束字体加载后重试: {first_err}"
+            )
+            try:
+                await page.evaluate(
+                    """
+                    async () => {
+                        try {
+                            if (document.fonts && document.fonts.ready) {
+                                // 主动触发一次 ready 竞争，尽量让后续截图不再长时间阻塞。
+                                await Promise.race([
+                                    document.fonts.ready,
+                                    new Promise((resolve) => setTimeout(resolve, 50)),
+                                ]);
+                            }
+                        } catch (e) {}
+                        return true;
+                    }
+                    """
+                )
+            except Exception:
+                pass
+
+            await card.screenshot(
+                path=output_path,
+                omit_background=True,
+                timeout=min(timeout_ms, 5000),
+            )
 
     async def _log_page_diagnostics(self, page: Page, *, reason: str) -> None:
         """输出页面级诊断信息，辅助定位资源加载、脚本执行与选择器状态问题。"""
@@ -277,15 +535,13 @@ class BrowserManager:
             )
 
         # 本地模式：使用 Playwright
-        if not self._initialized:
-            logger.warning("[灾害预警] 浏览器未初始化，尝试初始化...")
-            await self.initialize()
-
-        if self._closed:
-            logger.error("[灾害预警] 浏览器已关闭，无法渲染")
+        if not await self._ensure_local_browser_ready():
+            logger.error("[灾害预警] 浏览器不可用，无法渲染")
             return None
 
         page: Page | None = None
+        page_returned = False
+        render_succeeded = False
         start_time = time.time()
 
         acquired_semaphore = False
@@ -302,11 +558,10 @@ class BrowserManager:
                 return None
 
             try:
-                # 本地模式：从池中获取页面
-                try:
-                    page = await asyncio.wait_for(self._page_pool.get(), timeout=5.0)
-                except asyncio.TimeoutError:
-                    logger.error("[灾害预警] 从池中获取页面对象超时")
+                # 本地模式：从池中获取可用页面；坏页直接丢弃并补充。
+                page = await self._acquire_usable_page()
+                if page is None:
+                    logger.error("[灾害预警] 无法获取可用页面对象")
                     return None
 
                 try:
@@ -371,7 +626,11 @@ class BrowserManager:
 
                         # 使用 file:// 协议加载，支持相对路径
                         file_url = f"file://{temp_html}"
-                        await page.goto(file_url, wait_until="domcontentloaded")
+                        await page.goto(
+                            file_url,
+                            wait_until="domcontentloaded",
+                            timeout=30000,
+                        )
                     finally:
                         # 清理临时 HTML 文件
                         if temp_html and os.path.exists(temp_html):
@@ -434,11 +693,13 @@ class BrowserManager:
                             selector, state="visible", timeout=1000
                         )
 
-                    # 定位卡片元素
-                    card = page.locator(selector)
-
-                    # 截图：只截取元素，背景透明
-                    await card.screenshot(path=output_path, omit_background=True)
+                    # 截图：只截取元素，背景透明；字体等待超时会自动降级重试。
+                    await self._screenshot_card(
+                        page,
+                        selector,
+                        output_path,
+                        timeout_ms=10000,
+                    )
 
                     elapsed = time.time() - start_time
 
@@ -455,6 +716,7 @@ class BrowserManager:
                             f"[灾害预警] 卡片渲染成功，耗时 {elapsed:.3f}秒",
                             is_event_linked=True,
                         )
+                        render_succeeded = True
                         return output_path
                     else:
                         logger.warning("[灾害预警] 截图未生成文件")
@@ -464,18 +726,29 @@ class BrowserManager:
                         return None
 
                 finally:
-                    # 本地模式：恢复默认视口后归还页面到池
-                    if page:
-                        if resolved_viewport:
+                    # 成功：恢复视口后归还；失败：直接丢弃坏页并补池，避免污染后续渲染。
+                    if page and not page_returned:
+                        if render_succeeded:
+                            if resolved_viewport:
+                                try:
+                                    if await self._is_page_usable(page):
+                                        await page.set_viewport_size(
+                                            dict(self.DEFAULT_VIEWPORT)
+                                        )
+                                except Exception as restore_err:
+                                    logger.debug(
+                                        f"[灾害预警] 恢复默认视口失败: {restore_err}"
+                                    )
+                            await self._return_page_to_pool(page)
+                        else:
                             try:
-                                await page.set_viewport_size(
-                                    dict(self.DEFAULT_VIEWPORT)
-                                )
-                            except Exception as restore_err:
-                                logger.debug(
-                                    f"[灾害预警] 恢复默认视口失败: {restore_err}"
-                                )
-                        await self._page_pool.put(page)
+                                if not page.is_closed():
+                                    await page.close()
+                                    logger.debug("[灾害预警] 已关闭损坏的页面")
+                            except Exception:
+                                pass
+                            await self._replenish_page_pool()
+                        page_returned = True
             finally:
                 # 释放信号量
                 if acquired_semaphore:
@@ -488,27 +761,21 @@ class BrowserManager:
                 await self._telemetry.track_error(
                     e, module="core.browser_manager.render_card"
                 )
-            # 如果页面损坏，关闭它并恢复页面池（仅本地模式）
-            if page:
+
+            # 内层 finally 通常已处理页面回收；这里再兜底一次，避免异常路径泄漏坏页。
+            if page and not page_returned:
                 try:
-                    await page.close()
-                    logger.debug("[灾害预警] 已关闭损坏的页面")
+                    if not page.is_closed():
+                        await page.close()
+                        logger.debug("[灾害预警] 已关闭损坏的页面")
                 except Exception:
                     pass
+                page_returned = True
+                await self._replenish_page_pool()
 
-                # 恢复页面池
-                async with self._page_creation_lock:
-                    try:
-                        if self._browser and not self._closed:
-                            if self._page_pool.qsize() < self.pool_size:
-                                new_page = await self._browser.new_page(
-                                    viewport=dict(self.DEFAULT_VIEWPORT),
-                                    device_scale_factor=2,
-                                )
-                                await self._page_pool.put(new_page)
-                                logger.debug("[灾害预警] 已重新创建页面")
-                    except Exception as recover_err:
-                        logger.error(f"[灾害预警] 页面恢复失败: {recover_err}")
+            # 目标关闭类错误即使页面已回收，也主动确认浏览器可恢复。
+            if self._is_target_closed_error(e):
+                await self._ensure_local_browser_ready()
 
             return None
 

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -169,13 +169,38 @@ class BrowserManager:
             device_scale_factor=2,
         )
 
+    async def _put_page_into_pool(self, page: Page) -> bool:
+        """非阻塞入池；池满时关闭多余页面，避免 put 永久阻塞。"""
+        try:
+            self._page_pool.put_nowait(page)
+            return True
+        except asyncio.QueueFull:
+            logger.debug("[灾害预警] 页面池已满，关闭多余页面")
+            try:
+                if not page.is_closed():
+                    await page.close()
+            except Exception:
+                pass
+            return False
+        except Exception as put_err:
+            logger.debug(f"[灾害预警] 页面入池失败: {put_err}")
+            try:
+                if not page.is_closed():
+                    await page.close()
+            except Exception:
+                pass
+            return False
+
     async def _return_page_to_pool(self, page: Page | None) -> None:
         """仅在页面仍可用时归还页面池，避免把坏页重新投入复用。"""
         if page is None:
             return
         try:
             if await self._is_page_usable(page):
-                await self._page_pool.put(page)
+                if await self._put_page_into_pool(page):
+                    return
+                # 入池失败（满/异常）时页面已关闭，仍尝试补齐容量
+                await self._replenish_page_pool()
                 return
         except Exception as return_err:
             logger.debug(f"[灾害预警] 归还页面到池失败: {return_err}")
@@ -245,7 +270,9 @@ class BrowserManager:
             while self._page_pool.qsize() < self.pool_size:
                 try:
                     new_page = await self._create_local_page()
-                    await self._page_pool.put(new_page)
+                    if not await self._put_page_into_pool(new_page):
+                        # 池已满：停止补充
+                        break
                     logger.debug(
                         f"[灾害预警] 已补充页面，当前池大小: {self._page_pool.qsize()}/{self.pool_size}"
                     )
@@ -255,23 +282,28 @@ class BrowserManager:
 
     async def _wait_for_fonts_ready(self, page: Page, timeout_ms: int = 1500) -> None:
         """等待网页字体就绪，超时后继续截图，避免卡死在 fonts.ready。"""
+        # JS 侧有 timeoutMs 竞速；Python 侧再加 wait_for，防止连接挂死时永久占用页面。
+        python_timeout = max(1.0, (timeout_ms / 1000.0) + 1.0)
         try:
-            await page.evaluate(
-                """
-                async (timeoutMs) => {
-                    if (!document.fonts || !document.fonts.ready) {
-                        return "unsupported";
+            await asyncio.wait_for(
+                page.evaluate(
+                    """
+                    async (timeoutMs) => {
+                        if (!document.fonts || !document.fonts.ready) {
+                            return "unsupported";
+                        }
+                        const timeoutPromise = new Promise((resolve) => {
+                            setTimeout(() => resolve("timeout"), timeoutMs);
+                        });
+                        const readyPromise = document.fonts.ready
+                            .then(() => "ready")
+                            .catch(() => "error");
+                        return await Promise.race([readyPromise, timeoutPromise]);
                     }
-                    const timeoutPromise = new Promise((resolve) => {
-                        setTimeout(() => resolve("timeout"), timeoutMs);
-                    });
-                    const readyPromise = document.fonts.ready
-                        .then(() => "ready")
-                        .catch(() => "error");
-                    return await Promise.race([readyPromise, timeoutPromise]);
-                }
-                """,
-                timeout_ms,
+                    """,
+                    timeout_ms,
+                ),
+                timeout=python_timeout,
             )
         except Exception as font_err:
             # 字体等待失败不应阻断截图；Playwright 截图本身仍会再做一次字体检查。
@@ -431,7 +463,8 @@ class BrowserManager:
                     ),
                     timeout=10.0,
                 )
-                await self._page_pool.put(page)
+                if not await self._put_page_into_pool(page):
+                    break
                 logger.debug(f"[灾害预警] 页面 {i + 1}/{self.pool_size} 已创建")
             except asyncio.TimeoutError:
                 logger.error(f"[灾害预警] 创建页面 {i + 1} 超时")
@@ -472,7 +505,8 @@ class BrowserManager:
                     page = await asyncio.wait_for(
                         self._context.new_page(), timeout=10.0
                     )
-                    await self._page_pool.put(page)
+                    if not await self._put_page_into_pool(page):
+                        break
                     logger.debug(f"[灾害预警] 页面 {i + 1}/{self.pool_size} 已创建")
                 except asyncio.TimeoutError:
                     logger.error(f"[灾害预警] 创建页面 {i + 1} 超时")
@@ -970,17 +1004,20 @@ class BrowserManager:
             return None
 
     async def close(self):
-        """关闭浏览器管理器"""
-        if self._closed:
-            logger.debug("[灾害预警] 浏览器已关闭，跳过")
-            return
+        """关闭浏览器管理器。
 
-        logger.info("[灾害预警] 正在关闭浏览器...")
-        self._closed = True
+        与 _ensure_local_browser_ready 的重建路径共用 init_lock，
+        避免 close 与 auto-recover 并发导致状态撕裂。
+        """
+        async with self._init_lock:
+            if self._closed:
+                logger.debug("[灾害预警] 浏览器已关闭，跳过")
+                return
 
-        await self._cleanup()
-
-        logger.info("[灾害预警] 浏览器已关闭")
+            logger.info("[灾害预警] 正在关闭浏览器...")
+            self._closed = True
+            await self._cleanup()
+            logger.info("[灾害预警] 浏览器已关闭")
 
     async def _cleanup(self):
         """清理资源，确保前一步失败也不影响后续步骤继续执行。"""

--- a/core/message/runtime/runtime_component_factory.py
+++ b/core/message/runtime/runtime_component_factory.py
@@ -188,6 +188,28 @@ class MessageRuntimeComponentFactory:
         return typhoon_filter_config
 
     @staticmethod
+    def _build_tsunami_config(runtime_config: dict[str, Any]) -> dict[str, Any]:
+        """构建海啸过滤配置，供 TsunamiRule 读取。"""
+        tsunami_config = runtime_config.get("tsunami_config", {})
+        if not isinstance(tsunami_config, dict):
+            tsunami_config = {}
+
+        result: dict[str, Any] = {}
+        for key, default_min in (
+            ("china_filter", "信息"),
+            ("japan_filter", "若干海面变动"),
+        ):
+            block = tsunami_config.get(key)
+            if not isinstance(block, dict):
+                block = {}
+            result[key] = {
+                "enabled": bool(block.get("enabled", False)),
+                "min_level": str(block.get("min_level") or default_min).strip()
+                or default_min,
+            }
+        return result
+
+    @staticmethod
     def build_shared_components(
         runtime_config: dict[str, Any],
         *,
@@ -222,6 +244,9 @@ class MessageRuntimeComponentFactory:
                 emit_enable_log=emit_weather_enable_log,
             ),
             "typhoon_filter": MessageRuntimeComponentFactory._build_typhoon_filter_config(
+                runtime_config
+            ),
+            "tsunami_config": MessageRuntimeComponentFactory._build_tsunami_config(
                 runtime_config
             ),
         }

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -108,13 +108,20 @@ class ConnectionsPayloadBuilder:
             if health
             else typhoon_enrichment
         )
+        if "jma_tsunami" in eqsc_cfg:
+            jma_tsunami_cfg = bool(eqsc_cfg.get("jma_tsunami"))
+        else:
+            jma_tsunami_cfg = config_enabled
+        effective_jma_tsunami = bool(
+            health.get("jma_tsunami", jma_tsunami_cfg) if health else jma_tsunami_cfg
+        )
         circuit_open = bool(health.get("circuit_open", False))
         access_token_valid = bool(health.get("access_token_valid", False))
-        sub_sources = health.get("sub_sources")
-        if not isinstance(sub_sources, dict):
-            sub_sources = {
-                "china_typhoon": effective_typhoon_enrichment,
-            }
+        # 子源展示固定顺序：台风 → 海啸（仅一个海啸入口）
+        sub_sources = {
+            "china_typhoon": effective_typhoon_enrichment,
+            "jma_tsunami": effective_jma_tsunami,
+        }
 
         # HTTP 通道无 WS 重试语义。
         # 活跃连接判定：AccessToken 当前有效即视为 connected。
@@ -151,7 +158,7 @@ class ConnectionsPayloadBuilder:
             "status": status_text,
             "latency": latency,
             "sub_sources": dict(sub_sources),
-            "source_ids": ["eqsc"],
+            "source_ids": ["jma_tsunami_eqsc"],
             "connection_type": "http",
             "provider": "eqsc",
             "circuit_open": circuit_open,
@@ -271,7 +278,22 @@ class ConnectionsPayloadBuilder:
             latency_cache=self.latency_cache,
         )
         connections = dict(snapshot.get("connections", {}))
-        # HTTP 通道不是 WebSocket 连接组，单独合并进连接状态面板
+        # HTTP 通道不是 WebSocket 连接组，单独合并进连接状态面板。
+        # catalog 里 jma_tsunami_eqsc 的 connection_group="eqsc" 会生成占位条目：
+        # - 旧逻辑展示键为原始 "eqsc"，status 默认 “未连接”
+        # - 新逻辑展示键为 "EQSC API"
+        # 两种都要先剔除，再写入正式 HTTP 通道状态，避免前端读到占位“未连接”。
+        for stale_key, info in list(connections.items()):
+            key_lower = str(stale_key or "").strip().lower()
+            provider = ""
+            if isinstance(info, dict):
+                provider = str(info.get("provider") or "").strip().lower()
+            if (
+                key_lower in {"eqsc", "eqsc api"}
+                or key_lower.startswith("eqsc")
+                or provider == "eqsc"
+            ):
+                connections.pop(stale_key, None)
         connections[self.EQSC_DISPLAY_NAME] = self._build_eqsc_connection_info()
         # 覆盖 catalog 占位条目，附带轮询运行态与 HTTP 语义
         connections[self.SNET_DISPLAY_NAME] = self._build_snet_connection_info()

--- a/core/network/http/__init__.py
+++ b/core/network/http/__init__.py
@@ -2,3 +2,15 @@
 HTTP 数据源接入层。
 负责提供 EQSC 等 HTTP API 数据源的令牌管理、客户端与富化服务。
 """
+
+from .eqsc_http_client import EqscHttpClient
+from .eqsc_token_manager import EqscTokenManager
+from .eqsc_tsunami_client import EqscTsunamiClient
+from .eqsc_typhoon_client import EqscTyphoonClient
+
+__all__ = [
+    "EqscHttpClient",
+    "EqscTokenManager",
+    "EqscTsunamiClient",
+    "EqscTyphoonClient",
+]

--- a/core/network/http/eqsc_http_client.py
+++ b/core/network/http/eqsc_http_client.py
@@ -1,0 +1,246 @@
+"""
+EQSC HTTP 客户端公共基类。
+
+统一承接：
+- AccessToken 鉴权请求与 401/403 刷新重试
+- aiohttp 会话生命周期
+- 原始消息日志落盘
+- 简单 TTL 缓存判定
+
+台风 / 海啸等业务客户端只保留各自接口与缓存键策略。
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+
+from astrbot.api import logger
+
+from .eqsc_token_manager import EqscTokenManager
+
+
+class EqscHttpClient:
+    """EQSC HTTP 客户端基类。"""
+
+    def __init__(
+        self,
+        token_manager: EqscTokenManager,
+        config: dict[str, Any],
+        message_logger: Any | None = None,
+        *,
+        owns_token_manager: bool = True,
+        default_cache_ttl: int = 300,
+        cache_ttl_config_key: str = "cache_ttl",
+    ):
+        """初始化公共 HTTP 能力。
+
+        Args:
+            token_manager: EQSC 令牌管理器。
+            config: EQSC 配置字典。
+            message_logger: 可选原始消息记录器。
+            owns_token_manager: close() 时是否关闭 token_manager。
+                共享同一 token_manager 的附属客户端应设为 False。
+            default_cache_ttl: 缓存 TTL 默认值（秒）。
+            cache_ttl_config_key: 从 config 读取 TTL 的键名。
+        """
+        self._token_manager = token_manager
+        self._base_url = str(config.get("base_url", "") or "").strip().rstrip("/")
+        self._message_logger = message_logger
+        self._owns_token_manager = bool(owns_token_manager)
+        try:
+            cache_ttl = int(
+                config.get(cache_ttl_config_key, default_cache_ttl) or default_cache_ttl
+            )
+        except (TypeError, ValueError):
+            cache_ttl = default_cache_ttl
+        self._cache_ttl = max(1, cache_ttl)
+        self._session: aiohttp.ClientSession | None = None
+
+    @property
+    def base_url(self) -> str:
+        """EQSC API 基础地址。"""
+        return self._base_url
+
+    @property
+    def cache_ttl(self) -> int:
+        """当前缓存 TTL（秒）。"""
+        return self._cache_ttl
+
+    @property
+    def token_manager(self) -> EqscTokenManager:
+        """关联的令牌管理器。"""
+        return self._token_manager
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """确保 aiohttp 会话可用。"""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(
+                total=25,
+                connect=8,
+                sock_connect=8,
+                sock_read=15,
+            )
+            self._session = aiohttp.ClientSession(timeout=timeout)
+        return self._session
+
+    async def close(self) -> None:
+        """关闭 HTTP 会话；按所有权决定是否关闭 token_manager。"""
+        if self._session and not self._session.closed:
+            await self._session.close()
+        if self._owns_token_manager:
+            await self._token_manager.close()
+
+    @staticmethod
+    def _is_cache_valid(expires_at: float) -> bool:
+        """检查缓存是否仍然有效。"""
+        return time.time() < expires_at
+
+    @staticmethod
+    def _mask_token(token: str | None) -> str:
+        """脱敏 token，便于 401 排障。"""
+        value = str(token or "").strip()
+        if not value:
+            return "<empty>"
+        if len(value) <= 10:
+            return value[:2] + "***"
+        return f"{value[:6]}...{value[-4:]}(len={len(value)})"
+
+    def _build_request_url(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        """拼接带查询参数的完整请求 URL，供原始日志展示。"""
+        if not params:
+            return url
+        query = urlencode(
+            {str(key): str(value) for key, value in params.items() if value is not None}
+        )
+        if not query:
+            return url
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}{query}"
+
+    def _log_http_response(
+        self,
+        *,
+        url: str,
+        params: dict[str, Any] | None,
+        status_code: int | None,
+        response_data: Any,
+    ) -> None:
+        """将 EQSC HTTP 响应写入原始消息日志（若记录器已启用）。"""
+        if not self._message_logger:
+            return
+        try:
+            log_url = self._build_request_url(url, params)
+            connection_info = {
+                "url": log_url,
+                "status_code": status_code,
+                "connection_type": "http",
+                "provider": "eqsc",
+            }
+            if hasattr(self._message_logger, "log_raw_message"):
+                self._message_logger.log_raw_message(
+                    source="http_eqsc",
+                    message_type="http_response",
+                    payload_data=response_data,
+                    connection_info=connection_info,
+                )
+            else:
+                self._message_logger.log_http_response(
+                    url=log_url,
+                    response_data=response_data,
+                    status_code=status_code,
+                )
+        except Exception as e:
+            logger.debug(f"[灾害预警] EQSC 原始响应日志写入失败: {e}")
+
+    async def _request_json(
+        self,
+        *,
+        url: str,
+        access_token: str,
+        params: dict[str, Any] | None = None,
+        log_label: str,
+        allow_retry_on_auth_error: bool = True,
+    ) -> tuple[int, Any, str]:
+        """发送 EQSC GET 请求，返回 (status, json_or_none, raw_text)。
+
+        遇到 401/403 时会强制刷新 AccessToken 并重试一次。
+        成功响应会同步写入原始消息日志。
+        """
+        session = await self._ensure_session()
+        current_token = access_token
+        last_status = 0
+        last_text = ""
+
+        for attempt in range(2):
+            headers = {"Authorization": f"Bearer {current_token}"}
+            async with session.get(url, headers=headers, params=params) as response:
+                last_status = response.status
+                last_text = (await response.text()).strip()
+                if response.status == 200:
+                    try:
+                        parsed = json.loads(last_text) if last_text else {}
+                        self._log_http_response(
+                            url=url,
+                            params=params,
+                            status_code=response.status,
+                            response_data=parsed,
+                        )
+                        return response.status, parsed, last_text
+                    except Exception:
+                        logger.warning(
+                            f"[灾害预警] {log_label} 响应 JSON 解析失败: {last_text[:200]}"
+                        )
+                        self._log_http_response(
+                            url=url,
+                            params=params,
+                            status_code=response.status,
+                            response_data=last_text[:500] if last_text else "",
+                        )
+                        return response.status, None, last_text
+
+                if response.status in (401, 403):
+                    self._token_manager.invalidate()
+                    logger.warning(
+                        f"[灾害预警] {log_label} 鉴权失败: HTTP {response.status}；"
+                        f"token={self._mask_token(current_token)}"
+                        + (f"；响应: {last_text[:160]}" if last_text else "")
+                    )
+                    if allow_retry_on_auth_error and attempt == 0:
+                        refreshed = await self._token_manager.get_access_token(
+                            force_refresh=True
+                        )
+                        if refreshed and refreshed != current_token:
+                            logger.info(
+                                f"[灾害预警] {log_label} 已刷新 AccessToken，准备重试一次"
+                            )
+                            current_token = refreshed
+                            continue
+                    return response.status, None, last_text
+
+                logger.warning(
+                    f"[灾害预警] {log_label} 失败: HTTP {response.status}"
+                    + (f"；响应: {last_text[:160]}" if last_text else "")
+                )
+                return response.status, None, last_text
+
+        return last_status, None, last_text
+
+    async def _resolve_access_token(
+        self, access_token: str | None = None
+    ) -> str | None:
+        """解析可用 AccessToken：优先使用调用方传入值。"""
+        if access_token:
+            return access_token
+        return await self._token_manager.get_access_token()
+
+
+__all__ = ["EqscHttpClient"]

--- a/core/network/http/eqsc_http_client.py
+++ b/core/network/http/eqsc_http_client.py
@@ -126,6 +126,31 @@ class EqscHttpClient:
         separator = "&" if "?" in url else "?"
         return f"{url}{separator}{query}"
 
+    @staticmethod
+    def _sanitize_log_payload(response_data: Any, *, max_chars: int = 8000) -> Any:
+        """截断过大响应，降低原始日志意外膨胀/敏感字段风险。"""
+        if response_data is None:
+            return None
+        if isinstance(response_data, str):
+            text = response_data
+            if len(text) <= max_chars:
+                return text
+            return f"{text[:max_chars]}...[truncated len={len(text)}]"
+        try:
+            encoded = json.dumps(response_data, ensure_ascii=False)
+        except Exception:
+            text = str(response_data)
+            if len(text) <= max_chars:
+                return text
+            return f"{text[:max_chars]}...[truncated]"
+        if len(encoded) <= max_chars:
+            return response_data
+        return {
+            "_truncated": True,
+            "_original_chars": len(encoded),
+            "preview": encoded[:max_chars],
+        }
+
     def _log_http_response(
         self,
         *,
@@ -139,6 +164,7 @@ class EqscHttpClient:
             return
         try:
             log_url = self._build_request_url(url, params)
+            safe_payload = self._sanitize_log_payload(response_data)
             connection_info = {
                 "url": log_url,
                 "status_code": status_code,
@@ -149,13 +175,13 @@ class EqscHttpClient:
                 self._message_logger.log_raw_message(
                     source="http_eqsc",
                     message_type="http_response",
-                    payload_data=response_data,
+                    payload_data=safe_payload,
                     connection_info=connection_info,
                 )
             else:
                 self._message_logger.log_http_response(
                     url=log_url,
-                    response_data=response_data,
+                    response_data=safe_payload,
                     status_code=status_code,
                 )
         except Exception as e:

--- a/core/network/http/eqsc_tsunami_client.py
+++ b/core/network/http/eqsc_tsunami_client.py
@@ -1,0 +1,107 @@
+"""
+EQSC 海啸 HTTP 客户端。
+
+负责拉取 JMA 海啸最新快照。
+公共鉴权 / 会话 / 日志能力由 EqscHttpClient 提供。
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from astrbot.api import logger
+
+from .eqsc_http_client import EqscHttpClient
+from .eqsc_token_manager import EqscTokenManager
+
+
+class EqscTsunamiClient(EqscHttpClient):
+    """EQSC JMA 海啸数据 HTTP 客户端。"""
+
+    def __init__(
+        self,
+        token_manager: EqscTokenManager,
+        config: dict[str, Any],
+        message_logger: Any | None = None,
+        *,
+        owns_token_manager: bool = False,
+    ):
+        """初始化海啸客户端。
+
+        Args:
+            token_manager: EQSC 令牌管理器（可与台风通道共享）。
+            config: EQSC 配置字典。
+            message_logger: 可选原始消息记录器。
+            owns_token_manager: 为 True 时 close() 会一并关闭 token_manager。
+                默认 False，便于与台风客户端共享同一 token_manager。
+        """
+        super().__init__(
+            token_manager,
+            config,
+            message_logger=message_logger,
+            owns_token_manager=owns_token_manager,
+            # 海啸上游更新不频繁；默认 60 秒缓存，减少重复请求
+            default_cache_ttl=60,
+            cache_ttl_config_key="tsunami_cache_ttl",
+        )
+        # 最新快照缓存：(data, expires_at)
+        self._latest_cache: tuple[dict[str, Any], float] | None = None
+
+    def clear_cache(self) -> None:
+        """清除快照缓存。"""
+        self._latest_cache = None
+
+    async def fetch_latest_tsunami(
+        self,
+        access_token: str | None = None,
+        *,
+        use_cache: bool = True,
+    ) -> dict[str, Any] | None:
+        """获取 EQSC 最新 JMA 海啸情报快照。
+
+        Returns:
+            海啸数据字典；失败返回 None。
+        """
+        if (
+            use_cache
+            and self._latest_cache
+            and self._is_cache_valid(self._latest_cache[1])
+        ):
+            logger.debug("[灾害预警] EQSC 海啸快照命中缓存")
+            return self._latest_cache[0]
+
+        if not self._base_url:
+            logger.warning("[灾害预警] EQSC base_url 为空，无法拉取海啸情报")
+            return None
+
+        access_token = await self._resolve_access_token(access_token)
+        if not access_token:
+            return None
+
+        try:
+            url = f"{self._base_url}/jma_tsunami.json"
+            status, data, _raw = await self._request_json(
+                url=url,
+                access_token=access_token,
+                log_label="EQSC 查询 JMA 海啸情报",
+            )
+            if status != 200 or not isinstance(data, dict):
+                return None
+
+            # 空对象或缺少关键字段时视为无效快照
+            if not data:
+                logger.debug("[灾害预警] EQSC 海啸快照为空")
+                return None
+
+            self._latest_cache = (data, time.time() + self._cache_ttl)
+            logger.debug("[灾害预警] EQSC 海啸快照查询成功并已缓存")
+            return data
+        except Exception as e:
+            logger.error(
+                f"[灾害预警] EQSC 查询海啸情报异常: {type(e).__name__}: {e or repr(e)}"
+            )
+            return None
+
+
+__all__ = ["EqscTsunamiClient"]

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -2,24 +2,21 @@
 EQSC 台风 HTTP 客户端。
 
 负责向 EQSC API 发送台风数据查询请求，并维护简单的内存缓存以减少重复请求。
-成功拉取的 HTTP 响应会同步写入原始消息日志（若已启用），便于排障回溯。
+公共鉴权 / 会话 / 日志能力由 EqscHttpClient 提供。
 """
 
 from __future__ import annotations
 
-import json
 import time
 from typing import Any
-from urllib.parse import urlencode
-
-import aiohttp
 
 from astrbot.api import logger
 
+from .eqsc_http_client import EqscHttpClient
 from .eqsc_token_manager import EqscTokenManager
 
 
-class EqscTyphoonClient:
+class EqscTyphoonClient(EqscHttpClient):
     """EQSC 台风数据 HTTP 客户端。"""
 
     def __init__(
@@ -27,6 +24,8 @@ class EqscTyphoonClient:
         token_manager: EqscTokenManager,
         config: dict[str, Any],
         message_logger: Any | None = None,
+        *,
+        owns_token_manager: bool = True,
     ):
         """初始化台风客户端。
 
@@ -34,189 +33,25 @@ class EqscTyphoonClient:
             token_manager: EQSC 令牌管理器实例。
             config: EQSC 配置字典，包含 cache_ttl 等字段。
             message_logger: 可选原始消息记录器；启用后会落盘 EQSC HTTP 响应。
+            owns_token_manager: close() 时是否关闭 token_manager。
         """
-        self._token_manager = token_manager
-        self._base_url = str(config.get("base_url", "")).strip().rstrip("/")
-        self._message_logger = message_logger
+        super().__init__(
+            token_manager,
+            config,
+            message_logger=message_logger,
+            owns_token_manager=owns_token_manager,
+            default_cache_ttl=300,
+            cache_ttl_config_key="cache_ttl",
+        )
         # 缓存结构: {typhoon_id: (data, expires_at)}
         self._cache: dict[str, tuple[dict[str, Any], float]] = {}
         # 无参查询缓存（全部最新台风列表）
         self._list_cache: tuple[list[dict[str, Any]], float] | None = None
-        # 缓存 TTL（秒），默认 5 分钟，与 EQSC 更新频率一致
-        self._cache_ttl = int(config.get("cache_ttl", 300))
-        self._session: aiohttp.ClientSession | None = None
-
-    async def _ensure_session(self) -> aiohttp.ClientSession:
-        """确保 aiohttp 会话可用。"""
-        if self._session is None or self._session.closed:
-            timeout = aiohttp.ClientTimeout(
-                total=25,
-                connect=8,
-                sock_connect=8,
-                sock_read=15,
-            )
-            self._session = aiohttp.ClientSession(timeout=timeout)
-        return self._session
-
-    async def close(self) -> None:
-        """关闭会话。"""
-        if self._session and not self._session.closed:
-            await self._session.close()
-        await self._token_manager.close()
-
-    def _is_cache_valid(self, expires_at: float) -> bool:
-        """检查缓存是否仍然有效。"""
-        return time.time() < expires_at
 
     def clear_cache(self) -> None:
         """清除所有缓存。"""
         self._cache.clear()
         self._list_cache = None
-
-    @staticmethod
-    def _mask_token(token: str | None) -> str:
-        """脱敏 token，便于 401 排障。"""
-        value = str(token or "").strip()
-        if not value:
-            return "<empty>"
-        if len(value) <= 10:
-            return value[:2] + "***"
-        return f"{value[:6]}...{value[-4:]}(len={len(value)})"
-
-    def _build_request_url(
-        self,
-        url: str,
-        params: dict[str, Any] | None = None,
-    ) -> str:
-        """拼接带查询参数的完整请求 URL，供原始日志展示。"""
-        if not params:
-            return url
-        query = urlencode(
-            {str(key): str(value) for key, value in params.items() if value is not None}
-        )
-        if not query:
-            return url
-        separator = "&" if "?" in url else "?"
-        return f"{url}{separator}{query}"
-
-    def _log_http_response(
-        self,
-        *,
-        url: str,
-        params: dict[str, Any] | None,
-        status_code: int | None,
-        response_data: Any,
-    ) -> None:
-        """将 EQSC HTTP 响应写入原始消息日志（若记录器已启用）。
-
-        优先使用带 source 标识的 log_raw_message，便于在原始日志中区分 EQSC；
-        若记录器仅提供旧版 log_http_response，则回退兼容。
-        """
-        if not self._message_logger:
-            return
-        try:
-            log_url = self._build_request_url(url, params)
-            connection_info = {
-                "url": log_url,
-                "status_code": status_code,
-                "connection_type": "http",
-                "provider": "eqsc",
-            }
-            # 使用独立 source，方便在 raw_messages.log 中筛选 EQSC 报文
-            if hasattr(self._message_logger, "log_raw_message"):
-                self._message_logger.log_raw_message(
-                    source="http_eqsc",
-                    message_type="http_response",
-                    payload_data=response_data,
-                    connection_info=connection_info,
-                )
-            else:
-                self._message_logger.log_http_response(
-                    url=log_url,
-                    response_data=response_data,
-                    status_code=status_code,
-                )
-        except Exception as e:
-            logger.debug(f"[灾害预警] EQSC 原始响应日志写入失败: {e}")
-
-    async def _request_json(
-        self,
-        *,
-        url: str,
-        access_token: str,
-        params: dict[str, Any] | None = None,
-        log_label: str,
-        allow_retry_on_auth_error: bool = True,
-    ) -> tuple[int, Any, str]:
-        """发送 EQSC GET 请求，返回 (status, json_or_none, raw_text)。
-
-        遇到 401/403 时会强制刷新 AccessToken 并重试一次，避免“刚拿到 token
-        但业务接口短暂鉴权失败/旧 token 失效”时直接放弃。
-        成功响应会同步写入原始消息日志，便于回溯 EQSC 报文。
-        """
-        session = await self._ensure_session()
-        current_token = access_token
-        last_status = 0
-        last_text = ""
-
-        for attempt in range(2):
-            headers = {"Authorization": f"Bearer {current_token}"}
-            async with session.get(url, headers=headers, params=params) as response:
-                last_status = response.status
-                last_text = (await response.text()).strip()
-                if response.status == 200:
-                    try:
-                        # 优先用已读文本反序列化，避免二次读 body
-                        parsed = json.loads(last_text) if last_text else {}
-                        self._log_http_response(
-                            url=url,
-                            params=params,
-                            status_code=response.status,
-                            response_data=parsed,
-                        )
-                        return (
-                            response.status,
-                            parsed,
-                            last_text,
-                        )
-                    except Exception:
-                        logger.warning(
-                            f"[灾害预警] {log_label} 响应 JSON 解析失败: {last_text[:200]}"
-                        )
-                        self._log_http_response(
-                            url=url,
-                            params=params,
-                            status_code=response.status,
-                            response_data=last_text[:500] if last_text else "",
-                        )
-                        return response.status, None, last_text
-
-                if response.status in (401, 403):
-                    self._token_manager.invalidate()
-                    logger.warning(
-                        f"[灾害预警] {log_label} 鉴权失败: HTTP {response.status}；"
-                        f"token={self._mask_token(current_token)}"
-                        + (f"；响应: {last_text[:160]}" if last_text else "")
-                    )
-                    if allow_retry_on_auth_error and attempt == 0:
-                        refreshed = await self._token_manager.get_access_token(
-                            force_refresh=True
-                        )
-                        if refreshed and refreshed != current_token:
-                            logger.info(
-                                f"[灾害预警] {log_label} 已刷新 AccessToken，准备重试一次"
-                            )
-                            current_token = refreshed
-                            continue
-                    return response.status, None, last_text
-
-                logger.warning(
-                    f"[灾害预警] {log_label} 失败: HTTP {response.status}"
-                    + (f"；响应: {last_text[:160]}" if last_text else "")
-                )
-                return response.status, None, last_text
-
-        return last_status, None, last_text
 
     async def fetch_typhoon_by_id(
         self,
@@ -243,8 +78,7 @@ class EqscTyphoonClient:
             return cached[0]
 
         # 获取 AccessToken
-        if access_token is None:
-            access_token = await self._token_manager.get_access_token()
+        access_token = await self._resolve_access_token(access_token)
         if not access_token:
             return None
 
@@ -294,8 +128,7 @@ class EqscTyphoonClient:
             return self._list_cache[0]
 
         # 获取 AccessToken
-        if access_token is None:
-            access_token = await self._token_manager.get_access_token()
+        access_token = await self._resolve_access_token(access_token)
         if not access_token:
             return []
 

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -315,6 +315,7 @@ class GlobalQuakeParser(BaseParser):
                 source_enum=source_entry.source_enum if source_entry else "",
                 report_num=report_num,
                 published_at=shock_time,
+                is_final=is_archived,
                 aliases=tuple(
                     item for item in (str(eq_data.id or "").strip(),) if item
                 ),
@@ -445,6 +446,7 @@ class GlobalQuakeParser(BaseParser):
                 source_enum=source_entry.source_enum if source_entry else "",
                 report_num=report_num,
                 published_at=shock_time,
+                is_final=is_archived,
                 aliases=tuple(
                     item for item in (str(eq_data.get("id", "") or "").strip(),) if item
                 ),

--- a/core/parsers/parser_registry.py
+++ b/core/parsers/parser_registry.py
@@ -15,7 +15,7 @@ from .japan_eew_parser import JmaEewFanStudioParser, JmaEewP2PParser, JmaEewWolf
 from .snet_parser import SnetParser
 from .taiwan_earthquake_parser import CwaReportParser
 from .taiwan_eew_parser import CwaEewParser, CwaEewWolfxParser
-from .tsunami_parser import JmaTsunamiP2PParser, TsunamiParser
+from .tsunami_parser import JmaTsunamiEqscParser, JmaTsunamiP2PParser, TsunamiParser
 from .typhoon_parser import TyphoonParser
 from .weather_parser import WeatherAlarmParser
 
@@ -29,6 +29,7 @@ PARSER_CLASS_BY_NAME = {
     "japan_report_parser": JmaEarthquakeP2PParser,
     "china_tsunami_parser": TsunamiParser,
     "japan_tsunami_parser": JmaTsunamiP2PParser,
+    "japan_tsunami_eqsc_parser": JmaTsunamiEqscParser,
     "weather_alarm_parser": WeatherAlarmParser,
     "typhoon_parser": TyphoonParser,
     "global_report_parser": UsgsEarthquakeParser,

--- a/core/parsers/tsunami_parser.py
+++ b/core/parsers/tsunami_parser.py
@@ -10,9 +10,17 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ...utils.plugin_logger import plugin_logger
+from ...utils.time_converter import TimeConverter
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EventEnvelope, TsunamiEvent
 from ..domain.event_payload import SourcePayload
+from ..domain.tsunami.jma_tsunami_normalize import (
+    build_jma_tsunami_content_fingerprint,
+    coerce_bool,
+    normalize_jma_tsunami_areas,
+    resolve_jma_tsunami_max_grade,
+    resolve_jma_tsunami_title,
+)
 from ..sources.source_catalog import get_source_entry
 from .base_parser import BaseParser
 
@@ -236,6 +244,89 @@ class TsunamiParser(BaseParser):
             return None
 
 
+def _ensure_jst_datetime(dt: datetime | None) -> datetime | None:
+    """无时区时间按 JST 解释，已有时区则保留。"""
+    if dt is None:
+        return None
+    if dt.tzinfo is not None:
+        return dt
+    return dt.replace(tzinfo=TimeConverter.TIMEZONES["JST"])
+
+
+def _build_jma_tsunami_envelope(
+    *,
+    source_id: str,
+    source_entry,
+    data: dict[str, Any],
+    provider_family: str,
+    source_family: str,
+    message_type: str,
+    event_id: str,
+    issue_time: datetime | None,
+    title: str,
+    max_grade: str,
+    forecasts: list[dict[str, Any]],
+    metadata_extra: dict[str, Any] | None = None,
+) -> EventEnvelope:
+    """构造统一的 JMA 海啸 EventEnvelope。"""
+    metadata: dict[str, Any] = {
+        "source_family": source_family,
+        "source_enum": source_entry.source_enum if source_entry else "",
+        "source_type": source_entry.source_type.value if source_entry else "tsunami",
+        "org_unit": "日本气象厅",
+        "forecasts": forecasts,
+        "level": max_grade,
+        "message_type": "info"
+        if max_grade in {"Minor", "解除", "None", "Unknown"}
+        else "warning",
+        "content_fingerprint": build_jma_tsunami_content_fingerprint(
+            event_id=event_id,
+            cancelled=max_grade == "解除",
+            max_grade=max_grade,
+            areas=forecasts,
+            is_training=bool((metadata_extra or {}).get("is_training")),
+        ),
+    }
+    if metadata_extra:
+        metadata.update(metadata_extra)
+
+    domain_event = TsunamiEvent(
+        title=title,
+        level=max_grade,
+        issued_at=issue_time,
+        metadata=dict(metadata),
+    )
+    identity = EventIdentity(
+        event_id=event_id,
+        source_id=source_id,
+        event_type="tsunami",
+        provider_family=source_entry.provider_family.value
+        if source_entry
+        else provider_family,
+        source_enum=source_entry.source_enum if source_entry else "",
+        published_at=issue_time,
+        attributes={
+            "parser_name": source_entry.parser_name if source_entry else "",
+            "config_key": source_entry.config_key if source_entry else "",
+        },
+    )
+    return EventEnvelope(
+        identity=identity,
+        event=domain_event,
+        received_at=datetime.now(timezone.utc),
+        payload=SourcePayload(
+            source_id=source_id,
+            provider_family=source_entry.provider_family.value
+            if source_entry
+            else provider_family,
+            message_type=message_type,
+            raw=dict(data),
+            attributes=dict(metadata),
+        ),
+        metadata=metadata,
+    )
+
+
 class JmaTsunamiP2PParser(BaseParser):
     """日本气象厅海啸预报解析器，处理 P2P 来源数据。"""
 
@@ -250,7 +341,7 @@ class JmaTsunamiP2PParser(BaseParser):
             code = data.get("code")
 
             # P2P 中 552 业务码专指日本津波予報（海啸警报），其余直接跳过
-            if code == 552:
+            if code == 552 or str(code) == "552":
                 plugin_logger.debug(
                     f"[灾害预警] {self.source_id} 收到津波予報(code:552)"
                 )
@@ -268,50 +359,18 @@ class JmaTsunamiP2PParser(BaseParser):
     def _parse_tsunami_data(self, data: dict[str, Any]) -> EventEnvelope | None:
         """解析 P2P 海啸数据。"""
         try:
-            issue = data.get("issue", {})
-            areas = data.get("areas", [])
-            cancelled = data.get("cancelled", False)
-
-            # 日本海啸按等级高低依次划分为：MajorWarning（大津波警报）、Warning（津波警报）、Watch（注意报）、None、Unknown
-            max_grade = "Unknown"
-            if cancelled:
-                max_grade = "解除"
-                title = "津波予報（解除）"
-            else:
-                grades = ["None", "Unknown", "Watch", "Warning", "MajorWarning"]
-                max_grade_idx = 0
-                for area in areas:
-                    grade = area.get("grade", "Unknown")
-                    if grade in grades:
-                        idx = grades.index(grade)
-                        # 在所有受影响的海域中找出最严重的警报类型作为主标题
-                        if idx > max_grade_idx:
-                            max_grade_idx = idx
-                            max_grade = grade
-
-                title_map = {
-                    "MajorWarning": "大津波警報",
-                    "Warning": "津波警報",
-                    "Watch": "津波注意報",
-                    "Unknown": "津波予報",
-                }
-                title = title_map.get(max_grade, "津波予報")
+            issue = data.get("issue", {}) if isinstance(data.get("issue"), dict) else {}
+            cancelled = coerce_bool(data.get("cancelled"), default=False)
+            forecasts = normalize_jma_tsunami_areas(
+                data.get("areas", []), cancelled=cancelled
+            )
+            max_grade = resolve_jma_tsunami_max_grade(forecasts, cancelled=cancelled)
+            title = resolve_jma_tsunami_title(max_grade, cancelled=cancelled)
 
             issue_time_raw = issue.get("time") or data.get("time") or ""
-            issue_time = self._parse_datetime(issue_time_raw)
+            issue_time = _ensure_jst_datetime(self._parse_datetime(issue_time_raw))
             source_entry = get_source_entry(self.source_id)
-            metadata = {
-                "source_family": "p2p",
-                "source_enum": source_entry.source_enum if source_entry else "",
-                "source_type": source_entry.source_type.value
-                if source_entry
-                else "tsunami",
-                "code": str(data.get("code", 552)),
-                "org_unit": "日本气象厅",
-                "forecasts": areas,
-            }
 
-            # 使用发布时间、标题等构造回退 ID
             event_id = str(data.get("id", "") or data.get("_id", "") or "").strip()
             if not event_id:
                 stable_parts = [
@@ -326,55 +385,298 @@ class JmaTsunamiP2PParser(BaseParser):
                     else "jma_tsunami_unknown"
                 )
 
-            # 构造海啸领域模型
-            domain_event = TsunamiEvent(
-                title=title,
-                level=max_grade,
-                issued_at=issue_time,
-                metadata=dict(metadata),
-            )
-
-            # 构建唯一的身份标识
-            identity = EventIdentity(
-                event_id=event_id,
+            envelope = _build_jma_tsunami_envelope(
                 source_id=self.source_id,
-                event_type="tsunami",
-                provider_family=source_entry.provider_family.value
-                if source_entry
-                else "p2p",
-                source_enum=source_entry.source_enum if source_entry else "",
-                published_at=issue_time,
-                attributes={
-                    "parser_name": self.source_entry.parser_name
-                    if self.source_entry
-                    else "",
-                    "config_key": source_entry.config_key if source_entry else "",
+                source_entry=source_entry,
+                data=data,
+                provider_family="p2p",
+                source_family="p2p",
+                message_type=str(data.get("code", 552)),
+                event_id=event_id,
+                issue_time=issue_time,
+                title=title,
+                max_grade=max_grade,
+                forecasts=forecasts,
+                metadata_extra={
+                    "code": str(data.get("code", 552)),
+                    "cancelled": cancelled,
                 },
             )
-
-            # 包装并返回统一包裹层
-            envelope = EventEnvelope(
-                identity=identity,
-                event=domain_event,
-                received_at=datetime.now(timezone.utc),
-                payload=SourcePayload(
-                    source_id=self.source_id,
-                    provider_family=source_entry.provider_family.value
-                    if source_entry
-                    else "p2p",
-                    message_type=str(data.get("code", 552)),
-                    raw=dict(data),
-                    attributes=dict(metadata),
-                ),
-                metadata=metadata,
-            )
-
             plugin_logger.info(
-                f"[灾害预警] JMA海啸预报解析成功: {domain_event.title}, 时间: {domain_event.issued_at}",
+                f"[灾害预警] JMA海啸预报解析成功(P2P): {title}, 时间: {issue_time}",
                 is_event_linked=True,
             )
-
             return envelope
         except Exception as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} 解析海啸数据失败: {exc}")
+            return None
+
+
+class JmaTsunamiEqscParser(BaseParser):
+    """日本气象厅海啸情报解析器（EQSC HTTP 快照）。
+
+    对应接口：GET /jma_tsunami.json（需 AccessToken 鉴权）。
+
+    EQSC 相对 P2P 的优势字段：
+    - 稳定 eventID
+    - issueHypocenter（发震时间 / 震央地名 / 震央代码 / 震级 Mj）
+    - 区域级 firstHeight.condition、maxHeight.description/value、immediate
+    - isTraining / expiresAt / cancelled 状态位
+
+    解析目标：把上述字段完整落入 metadata / forecasts，供展示器与跨源去重复用。
+    """
+
+    def __init__(self, message_logger=None):
+        """初始化 EQSC 日本海啸情报解析器。"""
+        super().__init__("jma_tsunami_eqsc", message_logger)
+
+    @staticmethod
+    def _clean_eqsc_text(value: Any) -> str:
+        """清洗 EQSC 常见空值字符串（null/None/空白）。"""
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text or text.lower() in {"null", "none"}:
+            return ""
+        return text
+
+    @staticmethod
+    def _parse_optional_float(value: Any) -> float | None:
+        """宽松解析数值字段（震级、波高等）。"""
+        text = JmaTsunamiEqscParser._clean_eqsc_text(value)
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+
+    def _parse_eqsc_datetime(self, value: Any) -> datetime | None:
+        """解析 EQSC 时间字符串，并按 JST 补齐时区。"""
+        text = self._clean_eqsc_text(value)
+        if not text:
+            return None
+        return _ensure_jst_datetime(self._parse_datetime(text))
+
+    def _extract_hypocenter(self, data: dict[str, Any]) -> dict[str, Any]:
+        """提取 issueHypocenter 关联地震信息。
+
+        文档字段：
+        - originTime: 发震时间（UTC+9）
+        - hypoCenterName: 震央地名
+        - code: 震央代码
+        - magnitude: 震级（Mj）
+        """
+        raw = data.get("issueHypocenter")
+        if not isinstance(raw, dict):
+            raw = {}
+
+        place_name = self._clean_eqsc_text(raw.get("hypoCenterName"))
+        magnitude = self._parse_optional_float(raw.get("magnitude"))
+        shock_time = self._parse_eqsc_datetime(raw.get("originTime"))
+        hypocenter_code = self._clean_eqsc_text(raw.get("code"))
+        origin_time_raw = self._clean_eqsc_text(raw.get("originTime"))
+
+        return {
+            "place_name": place_name,
+            "magnitude": magnitude,
+            "magnitude_raw": self._clean_eqsc_text(raw.get("magnitude")),
+            "shock_time": shock_time,
+            "origin_time_raw": origin_time_raw,
+            "hypocenter_code": hypocenter_code,
+            # 保留原始块，便于日志/排障与后续扩展
+            "issue_hypocenter": {
+                "originTime": origin_time_raw,
+                "hypoCenterName": place_name,
+                "code": hypocenter_code,
+                "magnitude": self._clean_eqsc_text(raw.get("magnitude")),
+            }
+            if (
+                place_name
+                or hypocenter_code
+                or magnitude is not None
+                or origin_time_raw
+            )
+            else {},
+        }
+
+    @staticmethod
+    def _summarize_areas(forecasts: list[dict[str, Any]]) -> dict[str, Any]:
+        """从归一化区域列表生成展示/统计摘要。"""
+        grade_counts: dict[str, int] = {}
+        immediate_names: list[str] = []
+        max_height_value: float | None = None
+        max_height_description = ""
+        max_height_area = ""
+
+        for area in forecasts:
+            grade = str(area.get("grade") or "Unknown")
+            grade_counts[grade] = grade_counts.get(grade, 0) + 1
+
+            if area.get("immediate"):
+                name = str(area.get("name") or "").strip()
+                if name:
+                    immediate_names.append(name)
+
+            value = area.get("maxHeightValue")
+            if isinstance(value, (int, float)):
+                numeric = float(value)
+                if max_height_value is None or numeric > max_height_value:
+                    max_height_value = numeric
+                    max_height_description = str(
+                        area.get("maxHeightDescription")
+                        or area.get("maxWaveHeight")
+                        or ""
+                    ).strip()
+                    max_height_area = str(area.get("name") or "").strip()
+
+        return {
+            "area_count": len(forecasts),
+            "grade_counts": grade_counts,
+            "immediate_area_count": len(immediate_names),
+            "immediate_area_names": immediate_names,
+            "max_wave_height_value": max_height_value,
+            "max_wave_height": max_height_description,
+            "max_wave_height_area": max_height_area,
+        }
+
+    def _resolve_event_id(
+        self,
+        data: dict[str, Any],
+        *,
+        title: str,
+        issue_time_raw: str,
+        place_name: str,
+    ) -> str:
+        """解析稳定事件 ID：优先 eventID，缺失时回退组合键。"""
+        event_id = self._clean_eqsc_text(
+            data.get("eventID") or data.get("eventId") or data.get("id")
+        )
+        if event_id:
+            return event_id
+
+        stable_parts = [part for part in (title, issue_time_raw, place_name) if part]
+        if stable_parts:
+            return "jma_tsunami_eqsc_" + "|".join(stable_parts)
+        return "jma_tsunami_eqsc_unknown"
+
+    def _parse_data(self, data: dict[str, Any]) -> EventEnvelope | None:
+        """解析 EQSC /jma_tsunami.json 最新海啸情报快照。
+
+        顶层字段（文档）：
+        - areas: 海啸预报区列表
+        - issueHypocenter: 关联地震震中信息
+        - cancelled: 有效期是否已结束（字符串 bool）
+        - expiresAt: 若干海面变动取消时间（UTC+9，可为 null）
+        - eventID: 事件 ID
+        - time / register: 发表时间
+        - isTraining: 是否训练报
+        """
+        try:
+            if not isinstance(data, dict) or not data:
+                plugin_logger.debug(f"[灾害预警] {self.source_id} 空快照，跳过")
+                return None
+
+            # ---- 状态位 ----
+            # cancelled=true 表示当前海啸情报有效期已结束（解除语义）
+            cancelled = coerce_bool(data.get("cancelled"), default=False)
+            # isTraining=true 为训练报；默认由轮询服务按配置过滤，这里仍完整保留字段
+            is_training = coerce_bool(data.get("isTraining"), default=False)
+
+            # ---- 区域预报 ----
+            # 归一化后 forecasts 供展示器与跨源内容指纹共用
+            forecasts = normalize_jma_tsunami_areas(
+                data.get("areas", []), cancelled=cancelled
+            )
+            max_grade = resolve_jma_tsunami_max_grade(forecasts, cancelled=cancelled)
+            title = resolve_jma_tsunami_title(max_grade, cancelled=cancelled)
+            area_summary = self._summarize_areas(forecasts)
+
+            # ---- 发表时间 ----
+            # time / register 文档均标注为发表时间；优先 time，register 作回退
+            issue_time_raw = self._clean_eqsc_text(
+                data.get("time") or data.get("register") or data.get("issueTime")
+            )
+            register_time_raw = self._clean_eqsc_text(data.get("register"))
+            issue_time = self._parse_eqsc_datetime(issue_time_raw)
+            register_time = self._parse_eqsc_datetime(register_time_raw)
+
+            # ---- 关联地震（issueHypocenter）----
+            hypocenter = self._extract_hypocenter(data)
+            place_name = str(hypocenter.get("place_name") or "")
+            magnitude = hypocenter.get("magnitude")
+            shock_time = hypocenter.get("shock_time")
+            hypocenter_code = str(hypocenter.get("hypocenter_code") or "")
+
+            # ---- 事件身份 ----
+            event_id = self._resolve_event_id(
+                data,
+                title=title,
+                issue_time_raw=issue_time_raw,
+                place_name=place_name,
+            )
+
+            # ---- 过期/取消时间 ----
+            # expiresAt：若干的海面变动取消时间（UTC+9）；null 表示无
+            expires_at_raw = self._clean_eqsc_text(data.get("expiresAt"))
+            expires_at = self._parse_eqsc_datetime(expires_at_raw)
+
+            source_entry = get_source_entry(self.source_id)
+            envelope = _build_jma_tsunami_envelope(
+                source_id=self.source_id,
+                source_entry=source_entry,
+                data=data,
+                provider_family="eqsc",
+                source_family="eqsc",
+                message_type="jma_tsunami",
+                event_id=event_id,
+                issue_time=issue_time,
+                title=title,
+                max_grade=max_grade,
+                forecasts=forecasts,
+                metadata_extra={
+                    # 事件编号：EQSC 用 eventID；展示侧 code 字段复用该值
+                    "code": event_id,
+                    "event_id": event_id,
+                    # 状态
+                    "cancelled": cancelled,
+                    "is_training": is_training,
+                    "expires_at": expires_at,
+                    "expires_at_raw": expires_at_raw or None,
+                    # 关联地震
+                    "place_name": place_name,
+                    "subtitle": place_name,
+                    "magnitude": magnitude,
+                    "magnitude_raw": hypocenter.get("magnitude_raw") or None,
+                    "shock_time": shock_time,
+                    "origin_time_raw": hypocenter.get("origin_time_raw") or None,
+                    "hypocenter_code": hypocenter_code,
+                    "issue_hypocenter": hypocenter.get("issue_hypocenter") or {},
+                    # 时间线
+                    "issue_time": issue_time,
+                    "issue_time_raw": issue_time_raw or None,
+                    "register_time": register_time,
+                    "register_time_raw": register_time_raw or None,
+                    "update_time": issue_time or register_time,
+                    # 区域摘要（展示器可直接用，避免重复扫描 forecasts）
+                    "area_count": area_summary["area_count"],
+                    "grade_counts": area_summary["grade_counts"],
+                    "immediate_area_count": area_summary["immediate_area_count"],
+                    "immediate_area_names": area_summary["immediate_area_names"],
+                    "max_wave_height": area_summary["max_wave_height"],
+                    "max_wave_height_value": area_summary["max_wave_height_value"],
+                    "max_wave_height_area": area_summary["max_wave_height_area"],
+                },
+            )
+            plugin_logger.info(
+                f"[灾害预警] JMA海啸情报解析成功(EQSC): {title} "
+                f"(事件ID：{event_id}, 涉及地区数：{len(forecasts)}, "
+                f"是否为训练报：{is_training}, 最高级别：{max_grade})",
+                is_event_linked=True,
+            )
+            return envelope
+        except Exception as exc:
+            plugin_logger.error(
+                f"[灾害预警] {self.source_id} 解析 EQSC 海啸数据失败: {exc}"
+            )
             return None

--- a/core/rules/__init__.py
+++ b/core/rules/__init__.py
@@ -12,6 +12,7 @@ from .rule_chain import RuleChain, build_default_rule_chain
 from .rule_result import RuleDecision
 from .source_rule import SourceEnabledRule
 from .time_rule import EventTimeRule
+from .tsunami_rule import TsunamiRule
 from .typhoon_rule import TyphoonRule
 from .weather_rule import WeatherRule
 
@@ -28,5 +29,6 @@ __all__ = [
     "ReportRule",
     "LocalIntensityRule",
     "WeatherRule",
+    "TsunamiRule",
     "TyphoonRule",
 ]

--- a/core/rules/report_rule.py
+++ b/core/rules/report_rule.py
@@ -52,11 +52,12 @@ class ReportRule(BaseRule):
         # 策略 1：日本气象厅，日本预警更新迅速且测定频繁，适合多间隔推送
         if report_policy == "jma":
             push_every_n = int(push_config.get("jma_report_n", 3) or 3)
-        # 策略 2：Global Quake，由于网络波动更新极大，默认每 5 报推一次，不设最终报标志
+        # 策略 2：Global Quake，更新频繁，默认每 5 报推一次；
+        # 新版 GQ 协议已提供 ARCHIVED 归档动作，应作为最终报参与最终报总是推送
         elif report_policy == "global_quake":
             push_every_n = int(push_config.get("gq_report_n", 5) or 5)
-            supports_final = False
-        # 策略 3：中国与台湾预警，不区分最终报
+            supports_final = True
+        # 策略 3：中国与台湾预警，当前策略仍不把 is_final 用于报数放行
         elif report_policy == "cea_cwa":
             supports_final = False
 

--- a/core/rules/rule_chain.py
+++ b/core/rules/rule_chain.py
@@ -13,6 +13,7 @@ from .report_rule import ReportRule
 from .rule_result import RuleDecision
 from .source_rule import SourceEnabledRule
 from .time_rule import EventTimeRule
+from .tsunami_rule import TsunamiRule
 from .typhoon_rule import TyphoonRule
 from .weather_rule import WeatherRule
 
@@ -42,7 +43,7 @@ class RuleChain:
 def build_default_rule_chain() -> RuleChain:
     """构建默认推送规则链。
 
-    默认顺序从基础有效性校验开始，再逐步进入来源、气象、台风、关键词、
+    默认顺序从基础有效性校验开始，再逐步进入来源、气象、台风、海啸、关键词、
     震动强度、报次与本地烈度判断。
     """
     # 顺次装配核心过滤逻辑规则实例
@@ -52,6 +53,7 @@ def build_default_rule_chain() -> RuleChain:
             SourceEnabledRule(),
             WeatherRule(),
             TyphoonRule(),
+            TsunamiRule(),
             KeywordRule(),
             EarthquakeThresholdRule(),
             ReportRule(),

--- a/core/rules/tsunami_rule.py
+++ b/core/rules/tsunami_rule.py
@@ -1,0 +1,204 @@
+"""
+海啸推送规则。
+负责按中国/日本独立阈值过滤海啸事件；解除通告默认放行。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..domain.event_models import TsunamiEvent
+from ..domain.tsunami.tsunami_levels import (
+    cn_tsunami_level_weight,
+    jp_tsunami_level_weight,
+    normalize_cn_tsunami_level,
+    normalize_jp_tsunami_level,
+    resolve_tsunami_region,
+)
+from .base_rule import BaseRule, RuleContext
+from .rule_result import RuleDecision
+
+
+class TsunamiRule(BaseRule):
+    """海啸过滤器规则。"""
+
+    rule_name = "tsunami_rule"
+
+    def evaluate(self, context: RuleContext) -> RuleDecision:
+        """按海啸过滤配置评估是否放行。"""
+        domain_event = context.domain_event
+        if not isinstance(domain_event, TsunamiEvent):
+            return RuleDecision.accept(reason="非海啸事件，跳过海啸规则")
+
+        # 模拟演练模式：不拦截。
+        if context.runtime_config.get("__simulation_bypass_regular_filters", False):
+            return RuleDecision.accept(reason="模拟模式跳过海啸过滤")
+
+        tsunami_config = self._resolve_tsunami_config(context)
+        metadata = (
+            context.envelope.metadata
+            if isinstance(context.envelope.metadata, dict)
+            else {}
+        )
+        event_metadata = (
+            domain_event.metadata if isinstance(domain_event.metadata, dict) else {}
+        )
+        merged_meta = {**event_metadata, **metadata}
+
+        region = resolve_tsunami_region(context.source_id, merged_meta)
+        raw_level = (
+            domain_event.level
+            or merged_meta.get("level")
+            or merged_meta.get("max_grade")
+            or ""
+        )
+        cancelled = bool(
+            merged_meta.get("cancelled")
+            or str(raw_level).strip() in {"解除", "取消"}
+            or "解除" in str(domain_event.title or "")
+        )
+
+        decision_context: dict[str, Any] = {
+            "region": region,
+            "source_id": context.source_id,
+            "raw_level": raw_level,
+            "cancelled": cancelled,
+        }
+
+        if region == "china":
+            return self._evaluate_china(
+                tsunami_config=tsunami_config,
+                raw_level=raw_level,
+                cancelled=cancelled,
+                decision_context=decision_context,
+            )
+        if region == "japan":
+            return self._evaluate_japan(
+                tsunami_config=tsunami_config,
+                raw_level=raw_level,
+                cancelled=cancelled,
+                decision_context=decision_context,
+            )
+
+        # 无法识别区域时不误杀
+        return RuleDecision.accept(
+            reason="海啸区域未知，跳过阈值过滤",
+            context=decision_context,
+        )
+
+    @staticmethod
+    def _resolve_tsunami_config(context: RuleContext) -> dict[str, Any]:
+        """从 policy_state / runtime_config 解析海啸配置。"""
+        policy_cfg = context.policy_state.get("tsunami_config")
+        if isinstance(policy_cfg, dict) and policy_cfg:
+            return policy_cfg
+
+        runtime_cfg = context.runtime_config.get("tsunami_config")
+        if isinstance(runtime_cfg, dict):
+            return runtime_cfg
+        return {}
+
+    @staticmethod
+    def _filter_block(config: dict[str, Any], key: str) -> dict[str, Any]:
+        block = config.get(key)
+        return block if isinstance(block, dict) else {}
+
+    def _evaluate_china(
+        self,
+        *,
+        tsunami_config: dict[str, Any],
+        raw_level: Any,
+        cancelled: bool,
+        decision_context: dict[str, Any],
+    ) -> RuleDecision:
+        china_filter = self._filter_block(tsunami_config, "china_filter")
+        if not china_filter.get("enabled", False):
+            return RuleDecision.accept(
+                reason="中国海啸过滤未启用",
+                context=decision_context,
+            )
+
+        level = normalize_cn_tsunami_level(raw_level)
+        decision_context["normalized_level"] = level
+
+        # 解除通告始终放行，避免漏掉取消信息
+        if cancelled or level == "解除":
+            return RuleDecision.accept(
+                reason="中国海啸解除通告放行",
+                context=decision_context,
+            )
+
+        min_level = str(china_filter.get("min_level") or "信息").strip() or "信息"
+        current_weight = cn_tsunami_level_weight(level)
+        required_weight = cn_tsunami_level_weight(min_level)
+        decision_context["min_level"] = min_level
+        decision_context["current_weight"] = current_weight
+        decision_context["required_weight"] = required_weight
+
+        # 未知等级不误杀
+        if (
+            required_weight > 0
+            and current_weight > 0
+            and current_weight < required_weight
+        ):
+            return RuleDecision.reject(
+                reason="中国海啸级别过滤",
+                detail=f"当前级别 {level or '未知'} 低于最低要求 {min_level}",
+                context=decision_context,
+            )
+        return RuleDecision.accept(
+            reason="中国海啸规则通过",
+            detail=f"级别 {level or '未知'} ≥ {min_level}",
+            context=decision_context,
+        )
+
+    def _evaluate_japan(
+        self,
+        *,
+        tsunami_config: dict[str, Any],
+        raw_level: Any,
+        cancelled: bool,
+        decision_context: dict[str, Any],
+    ) -> RuleDecision:
+        japan_filter = self._filter_block(tsunami_config, "japan_filter")
+        if not japan_filter.get("enabled", False):
+            return RuleDecision.accept(
+                reason="日本海啸过滤未启用",
+                context=decision_context,
+            )
+
+        level = normalize_jp_tsunami_level(raw_level, cancelled=cancelled)
+        decision_context["normalized_level"] = level
+
+        if cancelled or level == "解除":
+            return RuleDecision.accept(
+                reason="日本海啸解除通告放行",
+                context=decision_context,
+            )
+
+        min_level = (
+            str(japan_filter.get("min_level") or "若干海面变动").strip()
+            or "若干海面变动"
+        )
+        current_weight = jp_tsunami_level_weight(level, cancelled=False)
+        # min_level 配置为中文描述，normalize 后与内部枚举统一比较
+        required_weight = jp_tsunami_level_weight(min_level, cancelled=False)
+        decision_context["min_level"] = min_level
+        decision_context["current_weight"] = current_weight
+        decision_context["required_weight"] = required_weight
+
+        if (
+            required_weight > 0
+            and current_weight > 0
+            and current_weight < required_weight
+        ):
+            return RuleDecision.reject(
+                reason="日本海啸级别过滤",
+                detail=f"当前级别 {level or '未知'} 低于最低要求 {min_level}",
+                context=decision_context,
+            )
+        return RuleDecision.accept(
+            reason="日本海啸规则通过",
+            detail=f"级别 {level or '未知'} ≥ {min_level}",
+            context=decision_context,
+        )

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -83,19 +83,25 @@ class ConfigValidator:
                 config["typhoon_config"]
             )
 
-        # 8. 调试配置校验
+        # 8 海啸配置校验
+        if "tsunami_config" in config:
+            config["tsunami_config"] = ConfigValidator._validate_tsunami_config(
+                config["tsunami_config"]
+            )
+
+        # 9. 调试配置校验
         if "debug_config" in config:
             config["debug_config"] = ConfigValidator._validate_debug_config(
                 config["debug_config"]
             )
 
-        # 9. 推送列表校验
+        # 10. 推送列表校验
         if "target_sessions" in config:
             config["target_sessions"] = ConfigValidator._validate_target_sessions(
                 config["target_sessions"], key_name="target_sessions"
             )
 
-        # 10. 离线通知会话列表校验
+        # 11. 离线通知会话列表校验
         if "offline_notification_sessions" in config:
             config["offline_notification_sessions"] = (
                 ConfigValidator._validate_target_sessions(
@@ -104,43 +110,43 @@ class ConfigValidator:
                 )
             )
 
-        # 11. 管理员列表校验
+        # 12. 管理员列表校验
         if "admin_users" in config:
             config["admin_users"] = ConfigValidator._validate_admin_users(
                 config["admin_users"]
             )
 
-        # 12. 消息格式配置校验
+        # 13. 消息格式配置校验
         if "message_format" in config:
             config["message_format"] = ConfigValidator._validate_message_format(
                 config["message_format"]
             )
 
-        # 13. 推送频率控制校验
+        # 14. 推送频率控制校验
         if "push_frequency_control" in config:
             config["push_frequency_control"] = ConfigValidator._validate_push_frequency(
                 config["push_frequency_control"]
             )
 
-        # 14. 时区配置校验
+        # 15. 时区配置校验
         if "display_timezone" in config:
             config["display_timezone"] = ConfigValidator._validate_timezone(
                 config["display_timezone"]
             )
 
-        # 15. 遥测配置校验
+        # 16. 遥测配置校验
         if "telemetry_config" in config:
             config["telemetry_config"] = ConfigValidator._validate_telemetry(
                 config["telemetry_config"]
             )
 
-        # 16. 数据源配置结构校验
+        # 17. 数据源配置结构校验
         if "data_sources" in config:
             config["data_sources"] = ConfigValidator._validate_data_sources(
                 config["data_sources"]
             )
 
-        # 17. 通知中心配置校验
+        # 18. 通知中心配置校验
         if "notification_settings" in config:
             config["notification_settings"] = (
                 ConfigValidator._validate_notification_settings(
@@ -148,7 +154,7 @@ class ConfigValidator:
                 )
             )
 
-        # 18. 顶层开关校验
+        # 19. 顶层开关校验
         if "enabled" in config and not isinstance(config["enabled"], bool):
             config["enabled"] = True
 
@@ -563,6 +569,61 @@ class ConfigValidator:
             )
             return max(minimum, min(maximum, number))
         return number
+
+    @staticmethod
+    def _validate_tsunami_config(cfg: dict[str, Any]) -> dict[str, Any]:
+        """校验海啸配置（中国/日本独立阈值）。"""
+        if not isinstance(cfg, dict):
+            return {}
+
+        china_filter = cfg.get("china_filter", {})
+        if not isinstance(china_filter, dict):
+            china_filter = {}
+        ConfigValidator._ensure_bool(china_filter, "enabled", False)
+        cn_valid = ["信息", "蓝色", "黄色", "橙色", "红色"]
+        cn_min = str(china_filter.get("min_level") or "信息").strip() or "信息"
+        if cn_min not in cn_valid:
+            logger.warning(
+                f"[灾害预警] 配置警告: 中国海啸最低级别 {cn_min} 无效，已修正为 信息。"
+            )
+            cn_min = "信息"
+        china_filter["min_level"] = cn_min
+        cfg["china_filter"] = china_filter
+
+        japan_filter = cfg.get("japan_filter", {})
+        if not isinstance(japan_filter, dict):
+            japan_filter = {}
+        ConfigValidator._ensure_bool(japan_filter, "enabled", False)
+        # 配置侧使用中文描述；兼容历史英文枚举
+        jp_valid = ["若干海面变动", "海啸注意报", "海啸警报", "大海啸警报"]
+        jp_alias = {
+            "minor": "若干海面变动",
+            "watch": "海啸注意报",
+            "warning": "海啸警报",
+            "majorwarning": "大海啸警报",
+            "若干の海面変動": "若干海面变动",
+            "若干的海面变动": "若干海面变动",
+            "若干海面变动": "若干海面变动",
+            "津波注意報": "海啸注意报",
+            "海啸注意报": "海啸注意报",
+            "津波警報": "海啸警报",
+            "海啸警报": "海啸警报",
+            "大津波警報": "大海啸警报",
+            "大海啸警报": "大海啸警报",
+        }
+        jp_raw = (
+            str(japan_filter.get("min_level") or "若干海面变动").strip()
+            or "若干海面变动"
+        )
+        jp_min = jp_alias.get(jp_raw, jp_alias.get(jp_raw.lower(), jp_raw))
+        if jp_min not in jp_valid:
+            logger.warning(
+                f"[灾害预警] 配置警告: 日本海啸最低级别 {jp_raw} 无效，已修正为 若干海面变动。"
+            )
+            jp_min = "若干海面变动"
+        japan_filter["min_level"] = jp_min
+        cfg["japan_filter"] = japan_filter
+        return cfg
 
     @staticmethod
     def _validate_typhoon_config(cfg: dict[str, Any]) -> dict[str, Any]:
@@ -1074,7 +1135,7 @@ class ConfigValidator:
         if isinstance(fan_studio_cfg, dict):
             ConfigValidator._ensure_bool(fan_studio_cfg, "china_typhoon", True)
 
-        # 校验 EQSC 数据源配置（组总闸 + 台风富化子开关）
+        # 校验 EQSC 数据源配置（组总闸 + 台风富化 + 海啸轮询子开关）
         eqsc_cfg = cfg.get("eqsc")
         if isinstance(eqsc_cfg, dict):
             ConfigValidator._ensure_bool(eqsc_cfg, "enabled", False)
@@ -1082,6 +1143,13 @@ class ConfigValidator:
             if "typhoon_enrichment" not in eqsc_cfg:
                 eqsc_cfg["typhoon_enrichment"] = bool(eqsc_cfg.get("enabled", False))
             ConfigValidator._ensure_bool(eqsc_cfg, "typhoon_enrichment", False)
+            # 海啸子开关：缺省时跟随通道总闸，便于旧配置平滑启用
+            if "jma_tsunami" not in eqsc_cfg:
+                eqsc_cfg["jma_tsunami"] = bool(eqsc_cfg.get("enabled", False))
+            ConfigValidator._ensure_bool(eqsc_cfg, "jma_tsunami", False)
+            ConfigValidator._ensure_bool(
+                eqsc_cfg, "jma_tsunami_include_training", False
+            )
 
             # Base URL 校验：确保为非空字符串且去除尾部斜杠
             base_url = eqsc_cfg.get("base_url")
@@ -1127,6 +1195,44 @@ class ConfigValidator:
                 )
                 eqsc_cfg["cache_ttl"] = 300
 
+            # 海啸轮询间隔
+            poll_interval = eqsc_cfg.get("jma_tsunami_poll_interval_seconds")
+            if isinstance(poll_interval, int):
+                if poll_interval < 15:
+                    logger.warning(
+                        f"[灾害预警] 配置警告: EQSC 海啸轮询间隔 {poll_interval} 过短，已修正为 15。"
+                    )
+                    eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 15
+                elif poll_interval > 300:
+                    logger.warning(
+                        f"[灾害预警] 配置警告: EQSC 海啸轮询间隔 {poll_interval} 过长，已修正为 300。"
+                    )
+                    eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 300
+            elif poll_interval is not None:
+                logger.warning(
+                    "[灾害预警] 配置警告: EQSC 海啸轮询间隔类型错误，已重置为 60。"
+                )
+                eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 60
+
+            # 海啸快照缓存 TTL
+            tsunami_cache_ttl = eqsc_cfg.get("tsunami_cache_ttl")
+            if isinstance(tsunami_cache_ttl, int):
+                if tsunami_cache_ttl < 15:
+                    logger.warning(
+                        f"[灾害预警] 配置警告: EQSC 海啸缓存 TTL {tsunami_cache_ttl} 过小，已修正为 15。"
+                    )
+                    eqsc_cfg["tsunami_cache_ttl"] = 15
+                elif tsunami_cache_ttl > 300:
+                    logger.warning(
+                        f"[灾害预警] 配置警告: EQSC 海啸缓存 TTL {tsunami_cache_ttl} 过大，已修正为 300。"
+                    )
+                    eqsc_cfg["tsunami_cache_ttl"] = 300
+            elif tsunami_cache_ttl is not None:
+                logger.warning(
+                    "[灾害预警] 配置警告: EQSC 海啸缓存 TTL 类型错误，已重置为 60。"
+                )
+                eqsc_cfg["tsunami_cache_ttl"] = 60
+
             # EQSC 启用但缺少 RefreshToken 时输出警告
             if (
                 eqsc_cfg.get("enabled")
@@ -1134,7 +1240,7 @@ class ConfigValidator:
             ):
                 logger.warning(
                     "[灾害预警] 配置警告: EQSC 数据源已启用但未配置 refresh_token，"
-                    "鉴权与台风富化将无法正常工作，台风将回退到 FAN Studio 基础数据。"
+                    "鉴权、台风富化与海啸轮询将无法正常工作。"
                 )
 
         return cfg

--- a/core/services/eqsc/__init__.py
+++ b/core/services/eqsc/__init__.py
@@ -1,0 +1,5 @@
+"""EQSC 业务服务包。"""
+
+from .eqsc_tsunami_poll_service import EqscTsunamiPollService
+
+__all__ = ["EqscTsunamiPollService"]

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -228,9 +228,14 @@ class EqscTsunamiPollService:
             return raw
 
         event_id = getattr(event, "id", None)
+        # 仅在成功进入事件流水线后再提交指纹，避免处理失败导致后续漏推。
+        try:
+            await self.service._handle_disaster_event(event)
+        except Exception:
+            # 失败时不更新指纹，下一轮内容未变仍会重试。
+            raise
         self._last_payload_fingerprint = fingerprint
         self._last_event_id = str(event_id) if event_id else None
-        await self.service._handle_disaster_event(event)
         return raw
 
 

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -1,0 +1,237 @@
+"""
+EQSC JMA 海啸情报轮询服务。
+
+独立于 WebSocket 接入：周期性拉取 /jma_tsunami.json，
+经内容指纹去重后进入统一事件流水线，作为 P2P 津波予報的高优先级补充源。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from astrbot.api import logger
+
+from ...domain.tsunami.jma_tsunami_normalize import (
+    build_jma_tsunami_content_fingerprint,
+    coerce_bool,
+    normalize_jma_tsunami_areas,
+    resolve_jma_tsunami_max_grade,
+)
+from ...network.http.eqsc_token_manager import EqscTokenManager
+from ...network.http.eqsc_tsunami_client import EqscTsunamiClient
+from ..query.source_runtime_query_service import SourceRuntimeQueryService
+
+
+class EqscTsunamiPollService:
+    """EQSC JMA 海啸轮询服务。"""
+
+    SOURCE_ID = "jma_tsunami_eqsc"
+    DEFAULT_INTERVAL_SECONDS = 60
+    MIN_INTERVAL_SECONDS = 15
+    MAX_INTERVAL_SECONDS = 300
+
+    def __init__(self, service):
+        self.service = service
+        self._source_runtime_query = SourceRuntimeQueryService(service.config)
+        self._task: asyncio.Task | None = None
+        self._last_payload_fingerprint: str | None = None
+        self._last_event_id: str | None = None
+        self._last_success_at: float | None = None
+        self._consecutive_failures = 0
+        self._client: EqscTsunamiClient | None = None
+        self._owns_token_manager = False
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    def is_enabled(self) -> bool:
+        """数据源是否启用（组总闸 + jma_tsunami 子开关）。"""
+        return self._source_runtime_query.is_source_enabled(self.SOURCE_ID)
+
+    def _eqsc_config(self) -> dict[str, Any]:
+        data_sources = self.service.config.get("data_sources", {})
+        if not isinstance(data_sources, dict):
+            return {}
+        eqsc = data_sources.get("eqsc", {})
+        return eqsc if isinstance(eqsc, dict) else {}
+
+    def _resolve_interval(self) -> int:
+        cfg = self._eqsc_config()
+        try:
+            interval = int(
+                cfg.get(
+                    "jma_tsunami_poll_interval_seconds", self.DEFAULT_INTERVAL_SECONDS
+                )
+            )
+        except (TypeError, ValueError):
+            interval = self.DEFAULT_INTERVAL_SECONDS
+        return max(self.MIN_INTERVAL_SECONDS, min(interval, self.MAX_INTERVAL_SECONDS))
+
+    def _resolve_include_training(self) -> bool:
+        return bool(self._eqsc_config().get("jma_tsunami_include_training", False))
+
+    def _get_shared_token_manager(self) -> EqscTokenManager | None:
+        """优先复用台风富化服务的 token_manager，避免双份鉴权状态。"""
+        enrichment = getattr(self.service, "typhoon_enrichment_service", None)
+        if enrichment is None:
+            return None
+        token_manager = getattr(enrichment, "_token_manager", None)
+        if isinstance(token_manager, EqscTokenManager):
+            return token_manager
+        return None
+
+    def _ensure_client(self) -> EqscTsunamiClient | None:
+        """懒创建海啸客户端；共享 token_manager 时不接管其生命周期。"""
+        if self._client is not None:
+            return self._client
+
+        eqsc_config = self._eqsc_config()
+        message_logger = getattr(self.service, "message_logger", None)
+        shared_tm = self._get_shared_token_manager()
+        if shared_tm is not None:
+            self._client = EqscTsunamiClient(
+                shared_tm,
+                eqsc_config,
+                message_logger=message_logger,
+                owns_token_manager=False,
+            )
+            self._owns_token_manager = False
+            return self._client
+
+        token_manager = EqscTokenManager(eqsc_config)
+        if not token_manager.is_configured:
+            logger.debug("[灾害预警] EQSC 海啸轮询：token 未配置，跳过客户端创建")
+            return None
+        self._client = EqscTsunamiClient(
+            token_manager,
+            eqsc_config,
+            message_logger=message_logger,
+            owns_token_manager=True,
+        )
+        self._owns_token_manager = True
+        return self._client
+
+    def get_runtime_status(self) -> dict[str, Any]:
+        """供健康面板读取的轻量运行态。"""
+        return {
+            "running": self.running,
+            "enabled": self.is_enabled(),
+            "last_success_at": self._last_success_at,
+            "consecutive_failures": int(self._consecutive_failures),
+            "last_event_id": self._last_event_id,
+            "poll_interval_seconds": self._resolve_interval(),
+        }
+
+    async def start(self) -> None:
+        """启动后台轮询任务。"""
+        if self.running:
+            return
+        if not self.is_enabled():
+            logger.info("[灾害预警] EQSC 海啸数据源未启用，跳过轮询启动")
+            return
+        # 通道 token 未配置时仍启动循环，便于配置热更新后自动生效；
+        # 每轮会自行判断并跳过。
+        self._task = asyncio.create_task(self._poll_loop(), name="dw_eqsc_tsunami_poll")
+        self.service.scheduled_tasks.append(self._task)
+        logger.info("[灾害预警] EQSC 海啸轮询任务已启动")
+
+    async def stop(self) -> None:
+        """停止后台轮询并释放客户端。"""
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+    async def _poll_loop(self) -> None:
+        """后台轮询循环。"""
+        try:
+            await self.fetch_once(emit_event=True)
+        except Exception as exc:
+            logger.error(f"[灾害预警] EQSC 海啸首次抓取失败: {exc}")
+
+        while getattr(self.service, "running", False):
+            try:
+                interval = self._resolve_interval()
+                await asyncio.sleep(interval)
+                if not getattr(self.service, "running", False):
+                    break
+                if not self.is_enabled():
+                    logger.debug("[灾害预警] EQSC 海啸已禁用，跳过本轮轮询")
+                    continue
+                await self.fetch_once(emit_event=True)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.error(f"[灾害预警] EQSC 海啸轮询异常: {exc}")
+
+    def _build_snapshot_fingerprint(self, raw: dict[str, Any]) -> str:
+        """基于原始快照构建轮询侧内容指纹。"""
+        cancelled = coerce_bool(raw.get("cancelled"), default=False)
+        is_training = coerce_bool(raw.get("isTraining"), default=False)
+        areas = normalize_jma_tsunami_areas(raw.get("areas"), cancelled=cancelled)
+        max_grade = resolve_jma_tsunami_max_grade(areas, cancelled=cancelled)
+        event_id = str(
+            raw.get("eventID") or raw.get("eventId") or raw.get("id") or ""
+        ).strip()
+        return build_jma_tsunami_content_fingerprint(
+            event_id=event_id,
+            cancelled=cancelled,
+            max_grade=max_grade,
+            areas=areas,
+            is_training=is_training,
+        )
+
+    async def fetch_once(self, *, emit_event: bool = True) -> dict[str, Any] | None:
+        """抓取一轮 EQSC 海啸快照，可选投递事件。"""
+        client = self._ensure_client()
+        if client is None:
+            return None
+
+        # 轮询侧强制绕过短缓存，确保按间隔拿到最新快照；
+        # 客户端缓存仍可用于同间隔内的并发查询复用。
+        raw = await client.fetch_latest_tsunami(use_cache=False)
+        if not isinstance(raw, dict) or not raw:
+            self._consecutive_failures += 1
+            return None
+
+        self._consecutive_failures = 0
+        self._last_success_at = time.time()
+
+        is_training = coerce_bool(raw.get("isTraining"), default=False)
+        if is_training and not self._resolve_include_training():
+            logger.debug("[灾害预警] EQSC 海啸训练报已忽略")
+            return raw
+
+        fingerprint = self._build_snapshot_fingerprint(raw)
+        if fingerprint == self._last_payload_fingerprint:
+            logger.debug("[灾害预警] EQSC 海啸快照内容未变化，跳过推送")
+            return raw
+
+        if not emit_event:
+            self._last_payload_fingerprint = fingerprint
+            return raw
+
+        message = json.dumps(raw, ensure_ascii=False)
+        event = self.service.parse_event(self.SOURCE_ID, message)
+        if event is None:
+            return raw
+
+        event_id = getattr(event, "id", None)
+        self._last_payload_fingerprint = fingerprint
+        self._last_event_id = str(event_id) if event_id else None
+        await self.service._handle_disaster_event(event)
+        return raw
+
+
+__all__ = ["EqscTsunamiPollService"]

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -208,12 +208,15 @@ class EqscTsunamiPollService:
         self._consecutive_failures = 0
         self._last_success_at = time.time()
 
+        fingerprint = self._build_snapshot_fingerprint(raw)
+
         is_training = coerce_bool(raw.get("isTraining"), default=False)
         if is_training and not self._resolve_include_training():
+            # 主动忽略训练报时仍提交指纹，避免每轮重复解析同一训练快照。
+            self._last_payload_fingerprint = fingerprint
             logger.debug("[灾害预警] EQSC 海啸训练报已忽略")
             return raw
 
-        fingerprint = self._build_snapshot_fingerprint(raw)
         if fingerprint == self._last_payload_fingerprint:
             logger.debug("[灾害预警] EQSC 海啸快照内容未变化，跳过推送")
             return raw
@@ -225,6 +228,7 @@ class EqscTsunamiPollService:
         message = json.dumps(raw, ensure_ascii=False)
         event = self.service.parse_event(self.SOURCE_ID, message)
         if event is None:
+            # 解析失败不提交指纹，下一轮可重试（例如短暂脏数据）。
             return raw
 
         event_id = getattr(event, "id", None)

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -10,7 +10,16 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from ....utils.plugin_logger import plugin_logger
-from ...domain.event_models import EarthquakeEvent, EventEnvelope, TyphoonEvent
+from ...domain.event_models import (
+    EarthquakeEvent,
+    EventEnvelope,
+    TsunamiEvent,
+    TyphoonEvent,
+)
+from ...domain.tsunami.jma_tsunami_normalize import (
+    build_jma_tsunami_content_fingerprint,
+    coerce_bool,
+)
 from ...domain.typhoon.typhoon_ids import normalize_typhoon_id
 from ...sources.source_catalog import get_source_entry
 from .event_identity import EventIdentityService
@@ -38,6 +47,11 @@ class EventDeduplicationService:
         # 当同一台风的核心参数（等级、位置、风速、气压、移向移速、风圈半径）
         # 与上次推送完全一致时直接过滤，避免数据源刷屏。
         self._typhoon_cache: dict[str, str] = {}
+        # JMA 海啸跨源去重缓存：
+        # key = content_fingerprint
+        # value = {"source_id", "priority", "event_id"}
+        # EQSC 优先级更高：同内容后到的低优先级源会被吞掉。
+        self._tsunami_cache: dict[str, dict[str, Any]] = {}
 
     @staticmethod
     def _extract_issue_type_from_earthquake(
@@ -203,12 +217,119 @@ class EventDeduplicationService:
         )
         return True
 
+    @staticmethod
+    def _resolve_source_priority(source_id: str) -> int:
+        """读取 catalog 优先级；缺失时回退 0。"""
+        entry = get_source_entry(source_id)
+        if entry is None:
+            return 0
+        try:
+            return int(entry.priority)
+        except (TypeError, ValueError):
+            return 0
+
+    def _extract_tsunami_fingerprint(self, event: EventEnvelope) -> str:
+        """提取海啸内容指纹；优先用解析器写入的 content_fingerprint。"""
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        cached = str(metadata.get("content_fingerprint") or "").strip()
+        if cached:
+            return cached
+
+        domain = event.event
+        if not isinstance(domain, TsunamiEvent):
+            return ""
+        domain_meta = domain.metadata if isinstance(domain.metadata, dict) else {}
+        forecasts = metadata.get("forecasts") or domain_meta.get("forecasts") or []
+        if not isinstance(forecasts, list):
+            forecasts = []
+        cancelled = coerce_bool(
+            metadata.get("cancelled"),
+            default=str(domain.level or "") == "解除",
+        )
+        return build_jma_tsunami_content_fingerprint(
+            event_id=str(
+                event.id or metadata.get("event_id") or metadata.get("code") or ""
+            ),
+            cancelled=cancelled,
+            max_grade=str(domain.level or metadata.get("level") or ""),
+            areas=forecasts,
+            is_training=coerce_bool(metadata.get("is_training"), default=False),
+        )
+
+    def _should_push_tsunami(self, event: EventEnvelope) -> bool:
+        """JMA 海啸跨源去重：同内容指纹只推一次，EQSC 优先。
+
+        规则：
+        1. 指纹未见过 → 放行并记录
+        2. 指纹相同且来源优先级 <= 已记录 → 过滤
+        3. 指纹相同但来源优先级更高（如 EQSC 后到）→ 放行并升级缓存
+           （用于 P2P 先到简报、EQSC 后到完整报的升级场景；
+            若内容完全一致，EQSC 后到仍会因指纹相同且 priority 更高而放行一次，
+            但解析器指纹已含区域细节，EQSC 通常会因更丰富字段产生不同指纹从而放行更新）
+        """
+        if not isinstance(event.event, TsunamiEvent):
+            return True
+
+        source_id = self._get_source_id(event)
+        # 仅对日本海啸双源做跨源去重；中国海啸等保持放行
+        if source_id not in {"jma_tsunami_p2p", "jma_tsunami_eqsc"}:
+            return True
+
+        fingerprint = self._extract_tsunami_fingerprint(event)
+        if not fingerprint:
+            return True
+
+        priority = self._resolve_source_priority(source_id)
+        existing = self._tsunami_cache.get(fingerprint)
+        if existing is None:
+            self._tsunami_cache[fingerprint] = {
+                "source_id": source_id,
+                "priority": priority,
+                "event_id": str(event.id or ""),
+            }
+            return True
+
+        existing_priority = int(existing.get("priority") or 0)
+        existing_source = str(existing.get("source_id") or "")
+        if priority < existing_priority:
+            plugin_logger.info(
+                f"[灾害预警] 海啸内容与 {existing_source} 重复且优先级更低，"
+                f"过滤 {source_id} 推送 (event={event.id})",
+                is_event_linked=True,
+            )
+            return False
+        if priority == existing_priority and existing_source == source_id:
+            plugin_logger.info(
+                f"[灾害预警] 海啸内容未变化，过滤重复推送: {source_id} (event={event.id})",
+                is_event_linked=True,
+            )
+            return False
+        if priority == existing_priority and existing_source != source_id:
+            # 同优先级不同源：先到先得
+            plugin_logger.info(
+                f"[灾害预警] 海啸内容与 {existing_source} 重复，过滤 {source_id} 推送",
+                is_event_linked=True,
+            )
+            return False
+
+        # 更高优先级源后到：放行并升级缓存（例如 EQSC 覆盖 P2P）
+        self._tsunami_cache[fingerprint] = {
+            "source_id": source_id,
+            "priority": priority,
+            "event_id": str(event.id or ""),
+        }
+        plugin_logger.debug(
+            f"[灾害预警] 海啸高优先级源 {source_id} 覆盖 {existing_source}，允许推送"
+        )
+        return True
+
     def should_push_event(self, event: EventEnvelope) -> bool:
         """判断是否应该推送事件。
 
         台风事件走专用核心参数指纹去重链路，
+        海啸事件走 JMA 跨源内容指纹去重（EQSC 优先），
         地震事件进入指纹与报次更新判定链路，
-        其余非地震事件（海啸/气象预警等）直接放行。
+        其余非地震事件直接放行。
         """
         envelope = event
         domain_eq = self._get_domain_earthquake(event)
@@ -217,7 +338,11 @@ class EventDeduplicationService:
         if isinstance(envelope.event, TyphoonEvent):
             return self._should_push_typhoon(envelope)
 
-        # 非地震事件（海啸/气象预警等）直接放行，无需在此进行滑动时间窗口位置碰撞去重
+        # 海啸事件：P2P / EQSC 跨源内容去重
+        if isinstance(envelope.event, TsunamiEvent):
+            return self._should_push_tsunami(envelope)
+
+        # 非地震事件（气象预警等）直接放行，无需在此进行滑动时间窗口位置碰撞去重
         if domain_eq is None:
             return True
 

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -49,9 +49,11 @@ class EventDeduplicationService:
         self._typhoon_cache: dict[str, str] = {}
         # JMA 海啸跨源去重缓存：
         # key = content_fingerprint
-        # value = {"source_id", "priority", "event_id"}
+        # value = {"source_id", "priority", "event_id", "ts"}
         # EQSC 优先级更高：同内容后到的低优先级源会被吞掉。
+        # 带容量上限，防止长跑进程内存无限增长。
         self._tsunami_cache: dict[str, dict[str, Any]] = {}
+        self._tsunami_cache_max_size = 512
 
     @staticmethod
     def _extract_issue_type_from_earthquake(
@@ -256,6 +258,32 @@ class EventDeduplicationService:
             is_training=coerce_bool(metadata.get("is_training"), default=False),
         )
 
+    def _remember_tsunami_fingerprint(
+        self,
+        fingerprint: str,
+        *,
+        source_id: str,
+        priority: int,
+        event_id: str,
+    ) -> None:
+        """写入海啸指纹缓存，并在超限时淘汰最旧条目。"""
+        self._tsunami_cache[fingerprint] = {
+            "source_id": source_id,
+            "priority": priority,
+            "event_id": event_id,
+            "ts": datetime.now(timezone.utc).timestamp(),
+        }
+        overflow = len(self._tsunami_cache) - int(self._tsunami_cache_max_size)
+        if overflow <= 0:
+            return
+        # 按时间戳升序淘汰最旧项
+        ordered = sorted(
+            self._tsunami_cache.items(),
+            key=lambda item: float((item[1] or {}).get("ts") or 0.0),
+        )
+        for key, _ in ordered[:overflow]:
+            self._tsunami_cache.pop(key, None)
+
     def _should_push_tsunami(self, event: EventEnvelope) -> bool:
         """JMA 海啸跨源去重：同内容指纹只推一次，EQSC 优先。
 
@@ -282,11 +310,12 @@ class EventDeduplicationService:
         priority = self._resolve_source_priority(source_id)
         existing = self._tsunami_cache.get(fingerprint)
         if existing is None:
-            self._tsunami_cache[fingerprint] = {
-                "source_id": source_id,
-                "priority": priority,
-                "event_id": str(event.id or ""),
-            }
+            self._remember_tsunami_fingerprint(
+                fingerprint,
+                source_id=source_id,
+                priority=priority,
+                event_id=str(event.id or ""),
+            )
             return True
 
         existing_priority = int(existing.get("priority") or 0)
@@ -313,11 +342,12 @@ class EventDeduplicationService:
             return False
 
         # 更高优先级源后到：放行并升级缓存（例如 EQSC 覆盖 P2P）
-        self._tsunami_cache[fingerprint] = {
-            "source_id": source_id,
-            "priority": priority,
-            "event_id": str(event.id or ""),
-        }
+        self._remember_tsunami_fingerprint(
+            fingerprint,
+            source_id=source_id,
+            priority=priority,
+            event_id=str(event.id or ""),
+        )
         plugin_logger.debug(
             f"[灾害预警] 海啸高优先级源 {source_id} 覆盖 {existing_source}，允许推送"
         )

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -28,6 +28,9 @@ _CONNECTION_DISPLAY_NAME: dict[str, str] = {
     "wolfx_all": "Wolfx",
     "global_quake": "Global Quake",
     "snet_msil": "NIED S-Net",
+    # EQSC 为 HTTP 通道；展示名必须与 ConnectionsPayloadBuilder.EQSC_DISPLAY_NAME
+    # 完全一致，否则 catalog 占位会以原始键 "eqsc" 残留，前端误显示“未连接”。
+    "eqsc": "EQSC API",
 }
 
 

--- a/core/sources/source_catalog.py
+++ b/core/sources/source_catalog.py
@@ -549,6 +549,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         text_presenter_key="tsunami_jma",
         report_policy="none",
         intensity_mode="none",
+        # EQSC 字段更完整，优先级低于 EQSC（数值越大越优先）
         priority=1,
         display_name="日本气象厅",
         description="日本气象厅：津波予報 - P2P地震情报 WebSocket",
@@ -563,6 +564,38 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         provider_message_types=("552",),
         provider_aliases=("p2p_tsunami",),
         routing_tags=("p2p", "japan", "tsunami"),
+    ),
+    # jma_tsunami_eqsc: 日本气象厅海啸情报 - 来自 EQSC HTTP 轮询（高优先级补充源）
+    # 不挂 WebSocket 连接计划：connection_url 留空，由 EqscTsunamiPollService 独立轮询
+    "jma_tsunami_eqsc": SourceEntry(
+        source_id="jma_tsunami_eqsc",
+        source_enum="eqsc_tsunami",
+        source_type=SourceType.TSUNAMI,
+        provider_family=ProviderFamily.EQSC,
+        config_group="eqsc",
+        config_key="jma_tsunami",
+        parser_name="japan_tsunami_eqsc_parser",
+        presentation_type="tsunami",
+        text_presenter_key="tsunami_jma",
+        report_policy="none",
+        intensity_mode="none",
+        # 高于 P2P：字段更完整，跨源去重时优先保留 EQSC
+        priority=3,
+        display_name="日本气象厅",
+        description="日本气象厅：津波予報 - EQSC HTTP 轮询（P2P 高优先级补充）",
+        default_timezone="Asia/Tokyo",
+        publish_time_field="time",
+        fingerprint_prefix="jma_tsunami",
+        connection_group="eqsc",
+        connection_handler="",
+        connection_data_source="jma_tsunami_eqsc",
+        connection_url="",
+        institution_key="japan",
+        institution_display_name="日本気象庁 津波",
+        institution_active_name="日本気象庁",
+        dispatch_family="eqsc_tsunami",
+        provider_aliases=("eqsc_tsunami", "jma_tsunami_eqsc"),
+        routing_tags=("eqsc", "japan", "tsunami", "http"),
     ),
     # china_weather_fanstudio: 中国气象局发布的气象预警
     "china_weather_fanstudio": SourceEntry(

--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -6,9 +6,11 @@
 from .database_manager import DatabaseManager
 from .session_config_manager import SessionConfigManager
 from .statistics_manager import StatisticsManager
+from .tsunami_history_cleanup_service import TsunamiHistoryCleanupService
 
 __all__ = [
     "DatabaseManager",
     "SessionConfigManager",
     "StatisticsManager",
+    "TsunamiHistoryCleanupService",
 ]

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -125,6 +125,25 @@ class DatabaseManager:
             if "pressure" not in columns:
                 # 台风主表 pressure 语义为历史最低中心气压，供气压榜/风王榜重建。
                 await cursor.execute("ALTER TABLE events ADD COLUMN pressure REAL")
+            # 海啸专用摘要列：避免复用台风 wind_speed 等语义冲突字段
+            if "max_wave_height" not in columns:
+                await cursor.execute(
+                    "ALTER TABLE events ADD COLUMN max_wave_height REAL"
+                )
+            if "area_count" not in columns:
+                await cursor.execute("ALTER TABLE events ADD COLUMN area_count INTEGER")
+            if "immediate_area_count" not in columns:
+                await cursor.execute(
+                    "ALTER TABLE events ADD COLUMN immediate_area_count INTEGER"
+                )
+            if "is_cancelled" not in columns:
+                await cursor.execute(
+                    "ALTER TABLE events ADD COLUMN is_cancelled INTEGER DEFAULT 0"
+                )
+            if "is_training" not in columns:
+                await cursor.execute(
+                    "ALTER TABLE events ADD COLUMN is_training INTEGER DEFAULT 0"
+                )
 
         # 检查 event_updates 报次更新表是否存在
         await cursor.execute(
@@ -183,6 +202,11 @@ class DatabaseManager:
                 level           TEXT,
                 wind_speed      REAL,
                 pressure        REAL,
+                max_wave_height REAL,
+                area_count      INTEGER,
+                immediate_area_count INTEGER,
+                is_cancelled    INTEGER DEFAULT 0,
+                is_training     INTEGER DEFAULT 0,
                 time            TEXT,
                 is_major        INTEGER DEFAULT 0,
                 update_count    INTEGER DEFAULT 1,
@@ -284,9 +308,10 @@ class DatabaseManager:
                     real_event_id, unique_id, type, source, source_id,
                     description, subtitle, weather_detail, info_type, place_name, latitude, longitude,
                     magnitude, depth, report_num,
-                    weather_type_code, level, wind_speed, pressure, time,
-                    is_major, update_count, created_at, updated_at
-                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    weather_type_code, level, wind_speed, pressure,
+                    max_wave_height, area_count, immediate_area_count, is_cancelled, is_training,
+                    time, is_major, update_count, created_at, updated_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     event_data.get("real_event_id"),
@@ -308,6 +333,11 @@ class DatabaseManager:
                     event_data.get("level"),
                     event_data.get("wind_speed"),
                     event_data.get("pressure"),
+                    event_data.get("max_wave_height"),
+                    event_data.get("area_count"),
+                    event_data.get("immediate_area_count"),
+                    1 if event_data.get("is_cancelled") else 0,
+                    1 if event_data.get("is_training") else 0,
                     event_time,
                     1 if is_major else 0,
                     event_data.get("update_count", 1),
@@ -519,6 +549,11 @@ class DatabaseManager:
                     level             = ?,
                     wind_speed        = ?,
                     pressure          = ?,
+                    max_wave_height   = ?,
+                    area_count        = ?,
+                    immediate_area_count = ?,
+                    is_cancelled      = ?,
+                    is_training       = ?,
                     is_major          = ?,
                     updated_at        = CURRENT_TIMESTAMP
                 WHERE id = ?
@@ -542,6 +577,11 @@ class DatabaseManager:
                     level_to_store,
                     wind_speed_to_store,
                     pressure_to_store,
+                    event_data.get("max_wave_height"),
+                    event_data.get("area_count"),
+                    event_data.get("immediate_area_count"),
+                    1 if event_data.get("is_cancelled") else 0,
+                    1 if event_data.get("is_training") else 0,
                     1 if is_major else 0,
                     db_id,
                 ),
@@ -815,6 +855,26 @@ class DatabaseManager:
             return events[0]
         except Exception as e:
             logger.error(f"[灾害预警] 查找事件失败: {e}")
+            return None
+
+    async def find_event_by_unique_id(
+        self, unique_id: str, source: str
+    ) -> dict[str, Any] | None:
+        """按 unique_id + source 查找事件。"""
+        try:
+            connection = await self._ensure_connection()
+            cursor = await connection.cursor()
+            await cursor.execute(
+                "SELECT * FROM events WHERE unique_id=? AND source=? LIMIT 1",
+                (unique_id, source),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            events = await self._attach_history([dict(row)])
+            return events[0]
+        except Exception as e:
+            logger.error(f"[灾害预警] 按 unique_id 查找事件失败: {e}")
             return None
 
     async def find_weather_event_by_alarm_id(
@@ -1246,8 +1306,10 @@ class DatabaseManager:
                 params.extend([keyword_like] * 7)
 
             where_sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+            # 前端列表按稳定事件键去重计数，避免海啸等同 unique_id 多行被重复统计
+            dedup_group_expr = "COALESCE(NULLIF(unique_id, ''), NULLIF(real_event_id, ''), CAST(id AS TEXT))"
             await cursor.execute(
-                f"SELECT COUNT(*) FROM events{where_sql}",
+                f"SELECT COUNT(DISTINCT {dedup_group_expr}) FROM events{where_sql}",
                 tuple(params),
             )
             row = await cursor.fetchone()
@@ -1330,19 +1392,38 @@ class DatabaseManager:
             normalized_order = (magnitude_order or "").lower().strip()
             if normalized_order in {"asc", "desc"}:
                 order_sql = (
-                    " ORDER BY "
                     "CASE WHEN magnitude IS NULL THEN 1 ELSE 0 END ASC, "
                     f"magnitude {normalized_order.upper()}, "
                     f"{timeline_order}"
                 )
             else:
-                order_sql = f" ORDER BY {timeline_order}"
+                order_sql = timeline_order
 
-            sql = f"SELECT * FROM events{where_sql}{order_sql} LIMIT ? OFFSET ?"
+            # 按稳定事件键去重后再分页，避免同 unique_id 海啸多行刷屏
+            dedup_group_expr = "COALESCE(NULLIF(unique_id, ''), NULLIF(real_event_id, ''), CAST(id AS TEXT))"
+            sql = f"""
+                WITH ranked AS (
+                    SELECT
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY {dedup_group_expr}
+                            ORDER BY {order_sql}
+                        ) AS rn
+                    FROM events
+                    {where_sql}
+                )
+                SELECT * FROM ranked
+                WHERE rn = 1
+                ORDER BY {order_sql}
+                LIMIT ? OFFSET ?
+            """
             params.extend([limit, offset])
             await cursor.execute(sql, tuple(params))
 
             events = [dict(row) for row in await cursor.fetchall()]
+            # 去掉窗口函数辅助列
+            for event in events:
+                event.pop("rn", None)
             return await self._attach_history(events)
         except Exception as e:
             logger.error(f"[灾害预警] 分页查询失败: {e}")

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -49,14 +49,16 @@ class SessionConfigManager:
     }
 
     # 仅允许全局配置修改的嵌套路径（会话 override 写入时强制剥离）。
-    # S-Net 轮询间隔、EQSC 通道鉴权参数影响全局运行态；
-    # typhoon_enrichment 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
+    # S-Net 轮询间隔、EQSC 通道鉴权/轮询参数影响全局运行态；
+    # typhoon_enrichment / jma_tsunami 允许会话差异（部分会话可单独关闭推送）。
     GLOBAL_ONLY_NESTED_PATHS: tuple[tuple[str, ...], ...] = (
         ("data_sources", "snet", "poll_interval_seconds"),
         ("data_sources", "eqsc", "enabled"),
         ("data_sources", "eqsc", "base_url"),
         ("data_sources", "eqsc", "refresh_token"),
         ("data_sources", "eqsc", "cache_ttl"),
+        ("data_sources", "eqsc", "tsunami_cache_ttl"),
+        ("data_sources", "eqsc", "jma_tsunami_poll_interval_seconds"),
     )
 
     def __init__(self, default_config_ref: dict[str, Any]):

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -42,6 +42,8 @@ class SessionConfigManager:
         "strategies",
         "weather_config",
         "typhoon_config",
+        # 与 typhoon_config / weather_config 一致：允许会话级阈值过滤覆盖
+        "tsunami_config",
         # 会话级额外控制字段（插件自定义）
         "push_enabled",
         # 会话备注名（仅用于日志与前端展示，不参与业务逻辑）

--- a/core/storage/source_compat.py
+++ b/core/storage/source_compat.py
@@ -30,6 +30,7 @@ _ALIAS_MAP: dict[str, str] = {
     "p2p_eew": "jma_p2p",
     "p2p_earthquake": "jma_p2p_info",
     "p2p_tsunami": "jma_tsunami_p2p",
+    "eqsc_tsunami": "jma_tsunami_eqsc",
     "wolfx_jma_eew": "jma_wolfx",
     "wolfx_cenc_eew": "cea_wolfx",
     "wolfx_cwa_eew": "cwa_wolfx",
@@ -66,8 +67,17 @@ _ALIAS_MAP: dict[str, str] = {
     "日本气象厅: 紧急地震速报": "jma_fanstudio",
     "日本气象厅：地震情报": "jma_p2p_info",
     "日本气象厅: 地震情报": "jma_p2p_info",
+    # 中文冒号全角/半角 + 预报/予报 历史写法都兼容
     "日本气象厅：海啸预报": "jma_tsunami_p2p",
     "日本气象厅: 海啸预报": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报": "jma_tsunami_p2p",
+    "日本气象厅: 海啸予报": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报 - P2P": "jma_tsunami_p2p",
+    "日本气象厅: 海啸予报 - P2P": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅: 海啸予报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅：海啸预报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅: 海啸预报 - EQSC": "jma_tsunami_eqsc",
 }
 
 # 展示名称映射表：用于把内部规范 key 转回更友好的前端展示标签。
@@ -87,7 +97,8 @@ _DISPLAY_MAP: dict[str, str] = {
     "typhoon_eqsc_rebuild": "中国气象局：台风历史 - EQSC",
     "jma_p2p": "日本气象厅: 紧急地震速报 - P2P",
     "jma_p2p_info": "日本气象厅: 地震情报 - P2P",
-    "jma_tsunami_p2p": "日本气象厅: 海啸予报",
+    "jma_tsunami_p2p": "日本气象厅: 海啸予报 - P2P",
+    "jma_tsunami_eqsc": "日本气象厅: 海啸予报 - EQSC",
     "jma_wolfx": "日本气象厅: 紧急地震速报 - Wolfx",
     "cea_wolfx": "中国地震预警网 (CEA) - Wolfx",
     "cwa_wolfx": "台湾中央气象署: 强震即时警报 - Wolfx",

--- a/core/storage/statistics_manager.py
+++ b/core/storage/statistics_manager.py
@@ -28,6 +28,7 @@ from .stats.stats_repository import StatsRepository
 from .stats.stats_rule_service import StatsRuleService
 from .stats.stats_session_service import StatsSessionService
 from .stats.stats_state_factory import StatsStateFactory
+from .tsunami_history_cleanup_service import TsunamiHistoryCleanupService
 
 
 class StatisticsManager:
@@ -84,6 +85,12 @@ class StatisticsManager:
         if not self._db_initialized:
             await self.db.initialize()
             self._db_initialized = True
+            # 启动时折叠旧版海啸重复主表行（独立服务，不侵入 DatabaseManager）
+            try:
+                cleanup = TsunamiHistoryCleanupService(self.db)
+                await cleanup.run_once()
+            except Exception as exc:
+                logger.warning(f"[灾害预警] 海啸历史清理跳过/失败: {exc}")
             await self._load_stats()
 
     async def record_push(

--- a/core/storage/stats/event_record_factory.py
+++ b/core/storage/stats/event_record_factory.py
@@ -351,6 +351,73 @@ class EventRecordFactory:
         return [label for _, label in scored[:limit]]
 
     @staticmethod
+    def _merge_tsunami_payload_context(envelope: EventEnvelope, data: TsunamiEvent) -> dict[str, Any]:
+        """合并 payload.attributes / raw / 领域 metadata / envelope.metadata。"""
+        metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
+        event_metadata = data.metadata if isinstance(data.metadata, dict) else {}
+        # SourcePayload.to_dict() 只返回 raw，真正的 attributes 是 dataclass 字段。
+        merged: dict[str, Any] = {}
+        if isinstance(envelope.payload, SourcePayload):
+            payload_attrs = getattr(envelope.payload, "attributes", None)
+            if isinstance(payload_attrs, dict):
+                merged.update(payload_attrs)
+            raw_payload = envelope.payload.to_dict()
+            if isinstance(raw_payload, dict):
+                nested_attrs = raw_payload.get("attributes")
+                if isinstance(nested_attrs, dict):
+                    merged.update(nested_attrs)
+                merged.update(raw_payload)
+        elif isinstance(envelope.payload, dict):
+            nested_attrs = envelope.payload.get("attributes")
+            if isinstance(nested_attrs, dict):
+                merged.update(nested_attrs)
+            merged.update(envelope.payload)
+        merged.update(event_metadata)
+        merged.update(metadata)
+        return merged
+
+    @staticmethod
+    def _absorb_tsunami_hypocenter(merged: dict[str, Any]) -> None:
+        """把 issue_hypocenter 中的震中字段回填到 merged。"""
+        hypocenter = merged.get("issue_hypocenter")
+        if not isinstance(hypocenter, dict):
+            return
+        for key in ("latitude", "longitude", "magnitude", "place_name", "depth"):
+            if merged.get(key) in (None, "") and hypocenter.get(key) not in (None, ""):
+                merged[key] = hypocenter.get(key)
+        if merged.get("place_name") in (None, ""):
+            hypo_name = hypocenter.get("hypoCenterName") or hypocenter.get("place_name")
+            if hypo_name not in (None, ""):
+                merged["place_name"] = hypo_name
+        if merged.get("magnitude") in (None, ""):
+            mag = hypocenter.get("magnitude")
+            if mag not in (None, ""):
+                merged["magnitude"] = mag
+
+    @staticmethod
+    def _resolve_tsunami_place_fields(merged: dict[str, Any]) -> tuple[str, str]:
+        """解析海啸 place_name / subtitle，过滤泛化标题。"""
+        place_name = str(merged.get("place_name") or merged.get("subtitle") or "").strip()
+        subtitle_raw = str(merged.get("subtitle") or "").strip()
+        if subtitle_raw and not is_generic_tsunami_title(subtitle_raw):
+            subtitle = subtitle_raw
+        elif place_name and not is_generic_tsunami_title(place_name):
+            subtitle = place_name
+        else:
+            subtitle = (
+                place_name
+                if place_name and not is_generic_tsunami_title(place_name)
+                else ""
+            )
+            if is_generic_tsunami_title(place_name):
+                place_name = ""
+        if is_generic_tsunami_title(place_name):
+            place_name = ""
+        if not subtitle and place_name:
+            subtitle = place_name
+        return place_name, subtitle
+
+    @staticmethod
     def apply_tsunami_fields(
         record: dict[str, Any],
         event: EventEnvelope,
@@ -367,43 +434,8 @@ class EventRecordFactory:
         if not isinstance(data, TsunamiEvent):
             return record
 
-        metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
-        event_metadata = data.metadata if isinstance(data.metadata, dict) else {}
-        payload = (
-            envelope.payload.to_dict()
-            if isinstance(envelope.payload, SourcePayload)
-            else {}
-        )
-        merged: dict[str, Any] = {}
-        if isinstance(payload, dict):
-            # SourcePayload.to_dict 可能嵌套 attributes
-            attributes = payload.get("attributes")
-            if isinstance(attributes, dict):
-                merged.update(attributes)
-            merged.update(payload)
-        merged.update(event_metadata)
-        merged.update(metadata)
-
-        # 关联地震可能嵌在 issue_hypocenter
-        hypocenter = merged.get("issue_hypocenter")
-        if isinstance(hypocenter, dict):
-            for key in ("latitude", "longitude", "magnitude", "place_name", "depth"):
-                if merged.get(key) in (None, "") and hypocenter.get(key) not in (
-                    None,
-                    "",
-                ):
-                    merged[key] = hypocenter.get(key)
-            # EQSC 原始键名兼容
-            if merged.get("place_name") in (None, ""):
-                hypo_name = hypocenter.get("hypoCenterName") or hypocenter.get(
-                    "place_name"
-                )
-                if hypo_name not in (None, ""):
-                    merged["place_name"] = hypo_name
-            if merged.get("magnitude") in (None, ""):
-                mag = hypocenter.get("magnitude")
-                if mag not in (None, ""):
-                    merged["magnitude"] = mag
+        merged = EventRecordFactory._merge_tsunami_payload_context(envelope, data)
+        EventRecordFactory._absorb_tsunami_hypocenter(merged)
 
         source_id = str(envelope.source_id or record.get("source_id") or "")
         region = resolve_tsunami_region(source_id, merged)
@@ -424,28 +456,7 @@ class EventRecordFactory:
         else:
             level = raw_level
 
-        place_name = str(
-            merged.get("place_name") or merged.get("subtitle") or ""
-        ).strip()
-        # subtitle 固定为震中地名；泛化 title 不当作副标题
-        subtitle_raw = str(merged.get("subtitle") or "").strip()
-        if subtitle_raw and not is_generic_tsunami_title(subtitle_raw):
-            subtitle = subtitle_raw
-        elif place_name and not is_generic_tsunami_title(place_name):
-            subtitle = place_name
-        else:
-            subtitle = (
-                place_name
-                if place_name and not is_generic_tsunami_title(place_name)
-                else ""
-            )
-            if is_generic_tsunami_title(place_name):
-                place_name = ""
-
-        if is_generic_tsunami_title(place_name):
-            place_name = ""
-        if not subtitle and place_name:
-            subtitle = place_name
+        place_name, subtitle = EventRecordFactory._resolve_tsunami_place_fields(merged)
 
         latitude = to_optional_float(merged.get("latitude"))
         longitude = to_optional_float(merged.get("longitude"))

--- a/core/storage/stats/event_record_factory.py
+++ b/core/storage/stats/event_record_factory.py
@@ -351,7 +351,9 @@ class EventRecordFactory:
         return [label for _, label in scored[:limit]]
 
     @staticmethod
-    def _merge_tsunami_payload_context(envelope: EventEnvelope, data: TsunamiEvent) -> dict[str, Any]:
+    def _merge_tsunami_payload_context(
+        envelope: EventEnvelope, data: TsunamiEvent
+    ) -> dict[str, Any]:
         """合并 payload.attributes / raw / 领域 metadata / envelope.metadata。"""
         metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
         event_metadata = data.metadata if isinstance(data.metadata, dict) else {}
@@ -397,7 +399,9 @@ class EventRecordFactory:
     @staticmethod
     def _resolve_tsunami_place_fields(merged: dict[str, Any]) -> tuple[str, str]:
         """解析海啸 place_name / subtitle，过滤泛化标题。"""
-        place_name = str(merged.get("place_name") or merged.get("subtitle") or "").strip()
+        place_name = str(
+            merged.get("place_name") or merged.get("subtitle") or ""
+        ).strip()
         subtitle_raw = str(merged.get("subtitle") or "").strip()
         if subtitle_raw and not is_generic_tsunami_title(subtitle_raw):
             subtitle = subtitle_raw

--- a/core/storage/stats/event_record_factory.py
+++ b/core/storage/stats/event_record_factory.py
@@ -15,6 +15,17 @@ from ...domain.event_models import (
     WeatherEvent,
 )
 from ...domain.event_payload import SourcePayload
+from ...domain.tsunami.tsunami_levels import (
+    build_tsunami_weather_detail,
+    normalize_cn_tsunami_level,
+    normalize_jp_tsunami_level,
+    resolve_tsunami_region,
+    to_optional_float,
+)
+from ...domain.tsunami.tsunami_title import (
+    build_tsunami_list_title,
+    is_generic_tsunami_title,
+)
 from ...domain.typhoon import (
     format_display_name,
     merge_peak_metrics,
@@ -219,23 +230,429 @@ class EventRecordFactory:
         return record
 
     @staticmethod
+    def _build_tsunami_forecast_highlights(
+        forecasts: list[Any],
+        *,
+        region: str,
+        limit: int = 6,
+    ) -> list[str]:
+        """从预报区列表提炼列表用亮点（对齐推送展示器语义）。"""
+        highlights: list[str] = []
+        ordered: list[dict[str, Any]] = []
+        normal: list[dict[str, Any]] = []
+        for item in forecasts or []:
+            if not isinstance(item, dict):
+                continue
+            name = str(
+                item.get("name")
+                or item.get("forecastArea")
+                or item.get("forecastPoint")
+                or ""
+            ).strip()
+            if not name:
+                continue
+            if item.get("immediate"):
+                ordered.append(item)
+            else:
+                normal.append(item)
+
+        def grade_rank(item: dict[str, Any]) -> int:
+            grade = str(item.get("grade") or item.get("warningLevel") or "").strip()
+            order_map = {
+                "MajorWarning": 5,
+                "红色": 5,
+                "Warning": 4,
+                "橙色": 4,
+                "Watch": 3,
+                "黄色": 3,
+                "蓝色": 2,
+                "Minor": 1,
+                "信息": 0,
+            }
+            return order_map.get(grade, 0)
+
+        ordered.extend(sorted(normal, key=grade_rank, reverse=True))
+
+        # 日本等级展示用中文，避免列表亮点出现裸 Warning/Watch
+        jp_grade_labels = {
+            "MajorWarning": "大海啸警报",
+            "Warning": "海啸警报",
+            "Watch": "海啸注意报",
+            "Minor": "若干海面变动",
+            "None": "无",
+            "Unknown": "不明",
+            "解除": "解除",
+        }
+
+        for item in ordered:
+            if len(highlights) >= limit:
+                break
+            name = str(
+                item.get("name")
+                or item.get("forecastArea")
+                or item.get("forecastPoint")
+                or ""
+            ).strip()
+            grade = str(item.get("grade") or item.get("warningLevel") or "").strip()
+            if region == "japan":
+                grade_label = jp_grade_labels.get(grade, grade)
+            else:
+                grade_label = grade
+            arrival = str(
+                item.get("estimatedArrivalTime") or item.get("condition") or ""
+            ).strip()
+            wave = str(
+                item.get("maxWaveHeight") or item.get("maxHeightDescription") or ""
+            ).strip()
+            bits: list[str] = [name]
+            if grade_label:
+                bits.append(f"[{grade_label}]")
+            if item.get("immediate"):
+                bits.append("立即")
+            if arrival:
+                bits.append(arrival)
+            if wave:
+                if region == "china" and not any(
+                    token in wave for token in ("cm", "CM", "米", "m", "ｍ")
+                ):
+                    bits.append(f"波高{wave}cm")
+                else:
+                    bits.append(f"🌊{wave}")
+            highlights.append(" ".join(bits))
+        return highlights
+
+    @staticmethod
+    def _build_tsunami_station_highlights(
+        stations: list[Any],
+        *,
+        limit: int = 4,
+    ) -> list[str]:
+        """从监测站列表提炼亮点。"""
+        scored: list[tuple[float, str]] = []
+        for item in stations or []:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("stationName") or item.get("name") or "监测站").strip()
+            location = str(item.get("location") or "").strip()
+            wave = str(
+                item.get("maxWaveHeight") or item.get("max_wave_height") or ""
+            ).strip()
+            label = name
+            if location:
+                label = f"{name}({location})"
+            if wave:
+                if any(token in wave for token in ("cm", "CM", "米", "m", "ｍ")):
+                    label = f"{label} 最大波幅 {wave}"
+                else:
+                    label = f"{label} 最大波幅 {wave}cm"
+            value = to_optional_float(wave) or 0.0
+            scored.append((value, label))
+        scored.sort(key=lambda row: row[0], reverse=True)
+        return [label for _, label in scored[:limit]]
+
+    @staticmethod
     def apply_tsunami_fields(
         record: dict[str, Any],
         event: EventEnvelope,
     ) -> dict[str, Any]:
-        """填充海啸事件专有字段。"""
+        """填充海啸事件专有字段。
+
+        优先吸收 EQSC 丰富字段（震中、震级、区域摘要、最大波高、训练/解除标记），
+        并兼容中国海啸与 P2P 结构。
+        使用海啸专用列：max_wave_height / area_count / immediate_area_count /
+        is_cancelled / is_training，不复用台风 wind_speed。
+        """
         envelope = _adapt_event_envelope(event)
         data = envelope.event
         if not isinstance(data, TsunamiEvent):
             return record
 
-        # 海啸记录当前主要补齐发布时间与预警级别，结构保持尽量精简。
+        metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
+        event_metadata = data.metadata if isinstance(data.metadata, dict) else {}
+        payload = (
+            envelope.payload.to_dict()
+            if isinstance(envelope.payload, SourcePayload)
+            else {}
+        )
+        merged: dict[str, Any] = {}
+        if isinstance(payload, dict):
+            # SourcePayload.to_dict 可能嵌套 attributes
+            attributes = payload.get("attributes")
+            if isinstance(attributes, dict):
+                merged.update(attributes)
+            merged.update(payload)
+        merged.update(event_metadata)
+        merged.update(metadata)
+
+        # 关联地震可能嵌在 issue_hypocenter
+        hypocenter = merged.get("issue_hypocenter")
+        if isinstance(hypocenter, dict):
+            for key in ("latitude", "longitude", "magnitude", "place_name", "depth"):
+                if merged.get(key) in (None, "") and hypocenter.get(key) not in (
+                    None,
+                    "",
+                ):
+                    merged[key] = hypocenter.get(key)
+            # EQSC 原始键名兼容
+            if merged.get("place_name") in (None, ""):
+                hypo_name = hypocenter.get("hypoCenterName") or hypocenter.get(
+                    "place_name"
+                )
+                if hypo_name not in (None, ""):
+                    merged["place_name"] = hypo_name
+            if merged.get("magnitude") in (None, ""):
+                mag = hypocenter.get("magnitude")
+                if mag not in (None, ""):
+                    merged["magnitude"] = mag
+
+        source_id = str(envelope.source_id or record.get("source_id") or "")
+        region = resolve_tsunami_region(source_id, merged)
+        raw_level = str(
+            data.level or merged.get("level") or merged.get("max_grade") or ""
+        ).strip()
+        cancelled = bool(
+            merged.get("cancelled")
+            or raw_level in {"解除", "取消"}
+            or "解除" in str(data.title or "")
+        )
+        is_training = bool(merged.get("is_training") or merged.get("isTraining"))
+
+        if region == "japan":
+            level = normalize_jp_tsunami_level(raw_level, cancelled=cancelled)
+        elif region == "china":
+            level = normalize_cn_tsunami_level(raw_level)
+        else:
+            level = raw_level
+
+        place_name = str(
+            merged.get("place_name") or merged.get("subtitle") or ""
+        ).strip()
+        # subtitle 固定为震中地名；泛化 title 不当作副标题
+        subtitle_raw = str(merged.get("subtitle") or "").strip()
+        if subtitle_raw and not is_generic_tsunami_title(subtitle_raw):
+            subtitle = subtitle_raw
+        elif place_name and not is_generic_tsunami_title(place_name):
+            subtitle = place_name
+        else:
+            subtitle = (
+                place_name
+                if place_name and not is_generic_tsunami_title(place_name)
+                else ""
+            )
+            if is_generic_tsunami_title(place_name):
+                place_name = ""
+
+        if is_generic_tsunami_title(place_name):
+            place_name = ""
+        if not subtitle and place_name:
+            subtitle = place_name
+
+        latitude = to_optional_float(merged.get("latitude"))
+        longitude = to_optional_float(merged.get("longitude"))
+        magnitude = to_optional_float(merged.get("magnitude"))
+        depth = to_optional_float(merged.get("depth"))
+
+        max_wave_height_value = to_optional_float(
+            merged.get("max_wave_height_value")
+            or merged.get("maxHeightValue")
+            or merged.get("max_wave_height")
+            or merged.get("maxWaveHeight")
+        )
+        max_wave_height_text = str(
+            merged.get("max_wave_height") or merged.get("maxWaveHeight") or ""
+        ).strip()
+        if not max_wave_height_text and max_wave_height_value is not None:
+            max_wave_height_text = f"{max_wave_height_value}m"
+        max_wave_height_area = str(
+            merged.get("max_wave_height_area") or merged.get("maxWaveHeightArea") or ""
+        ).strip()
+
+        forecasts_raw = merged.get("forecasts")
+        forecasts = forecasts_raw if isinstance(forecasts_raw, list) else []
+
+        area_count = merged.get("area_count")
+        if area_count is None and forecasts:
+            area_count = len(forecasts)
+        try:
+            area_count_int = int(area_count) if area_count is not None else None
+        except (TypeError, ValueError):
+            area_count_int = None
+
+        immediate_area_count = merged.get("immediate_area_count")
+        try:
+            immediate_count_int = (
+                int(immediate_area_count) if immediate_area_count is not None else None
+            )
+        except (TypeError, ValueError):
+            immediate_count_int = None
+
+        # 监测站：优先显式计数，再回退列表
+        stations_raw = (
+            merged.get("monitoring_stations")
+            or merged.get("waterLevelMonitoring")
+            or []
+        )
+        stations = stations_raw if isinstance(stations_raw, list) else []
+        station_count = merged.get("station_count") or merged.get(
+            "monitoring_station_count"
+        )
+        if station_count is None and stations:
+            station_count = len(stations)
+        try:
+            station_count_int = (
+                int(station_count) if station_count is not None else None
+            )
+        except (TypeError, ValueError):
+            station_count_int = None
+
+        # 级别分布（JP EQSC）
+        grade_counts = merged.get("grade_counts")
+        if not isinstance(grade_counts, dict):
+            grade_counts = {}
+            for item in forecasts:
+                if not isinstance(item, dict):
+                    continue
+                grade_key = str(
+                    item.get("grade") or item.get("warningLevel") or ""
+                ).strip()
+                if not grade_key:
+                    continue
+                grade_counts[grade_key] = grade_counts.get(grade_key, 0) + 1
+
+        # 从 forecasts / stations 提炼亮点，写入 weather_detail 供列表解析
+        # （列表 API 不回传完整 forecasts，靠摘要文本对齐 presenter 语义）
+        forecast_highlights = EventRecordFactory._build_tsunami_forecast_highlights(
+            forecasts,
+            region=region,
+            limit=6,
+        )
+        station_highlights = EventRecordFactory._build_tsunami_station_highlights(
+            stations,
+            limit=4,
+        )
+
+        # 若波高区缺失，从 forecasts 推断最高波高区
+        if not max_wave_height_area and forecasts:
+            best_area = ""
+            best_value: float | None = None
+            for item in forecasts:
+                if not isinstance(item, dict):
+                    continue
+                name = str(
+                    item.get("name")
+                    or item.get("forecastArea")
+                    or item.get("forecastPoint")
+                    or ""
+                ).strip()
+                value = to_optional_float(
+                    item.get("maxHeightValue")
+                    or item.get("max_wave_height")
+                    or item.get("maxWaveHeight")
+                )
+                if value is None:
+                    continue
+                if best_value is None or value > best_value:
+                    best_value = value
+                    best_area = name
+                    if not max_wave_height_text:
+                        desc = str(
+                            item.get("maxHeightDescription")
+                            or item.get("maxWaveHeight")
+                            or ""
+                        ).strip()
+                        max_wave_height_text = desc or f"{value}m"
+                        max_wave_height_value = value
+            if best_area:
+                max_wave_height_area = best_area
+
+        if immediate_count_int is None and forecasts:
+            immediate_count_int = (
+                sum(
+                    1
+                    for item in forecasts
+                    if isinstance(item, dict) and bool(item.get("immediate"))
+                )
+                or None
+            )
+
+        real_event_id = (
+            str(
+                merged.get("event_id") or merged.get("code") or envelope.id or ""
+            ).strip()
+            or None
+        )
+
+        info_parts: list[str] = []
+        if region == "japan":
+            info_parts.append("jma")
+        elif region == "china":
+            info_parts.append("cn")
+        if cancelled or level == "解除":
+            info_parts.append("cancelled")
+        if is_training:
+            info_parts.append("training")
+        source_family = str(merged.get("source_family") or "").strip()
+        if source_family:
+            info_parts.append(source_family)
+        info_type = "|".join(info_parts) if info_parts else None
+
+        weather_detail = build_tsunami_weather_detail(
+            region=region,
+            level=level,
+            area_count=area_count_int,
+            immediate_area_count=immediate_count_int,
+            max_wave_height=max_wave_height_text or None,
+            max_wave_height_value=max_wave_height_value,
+            max_wave_height_area=max_wave_height_area or None,
+            station_count=station_count_int,
+            cancelled=cancelled,
+            is_training=is_training,
+            batch=merged.get("batch"),
+            magnitude=magnitude,
+            depth=depth,
+            place_name=place_name or None,
+            grade_counts=grade_counts or None,
+            forecast_highlights=forecast_highlights or None,
+            station_highlights=station_highlights or None,
+        )
+
+        # 列表标题始终用结构化字段重建，覆盖旧的「标题 (等级)」模板
+        record["description"] = build_tsunami_list_title(
+            region=region,
+            level=level or raw_level,
+            title=str(data.title or "").strip(),
+            place_name=place_name,
+            magnitude=magnitude,
+            batch=merged.get("batch"),
+            cancelled=cancelled or level == "解除",
+            is_training=is_training,
+            max_wave_height=max_wave_height_text or None,
+            area_count=area_count_int,
+        )
+
         record.update(
             {
                 "time": data.issued_at.isoformat() if data.issued_at else None,
-                "level": data.level,
+                "level": level or raw_level or None,
+                "subtitle": subtitle,
+                "place_name": place_name or None,
+                "weather_detail": weather_detail,
+                "info_type": info_type,
+                "real_event_id": real_event_id,
+                "latitude": latitude,
+                "longitude": longitude,
+                "magnitude": magnitude,
+                "depth": depth,
+                "max_wave_height": max_wave_height_value,
+                "area_count": area_count_int,
+                "immediate_area_count": immediate_count_int,
+                "is_cancelled": bool(cancelled or level == "解除"),
+                "is_training": bool(is_training),
             }
         )
+        # 首报默认 report_num=1；后续合并会在 merger 中递增
+        if record.get("report_num") in (None, "", 0):
+            record["report_num"] = 1
         return record
 
     @staticmethod
@@ -405,7 +822,7 @@ class EventRecordFactory:
             # 气象事件重点补充副标题、详细说明、颜色级别和类型编码。
             EventRecordFactory.apply_weather_fields(record, event)
         elif isinstance(envelope.event, TsunamiEvent):
-            # 海啸事件则补充发布时间与等级字段即可。
+            # 海啸事件补充发布时间、等级、震中与区域摘要（优先 EQSC 字段）。
             EventRecordFactory.apply_tsunami_fields(record, event)
         elif isinstance(envelope.event, TyphoonEvent):
             # 台风事件补充中心位置、强度参数与更新时间。

--- a/core/storage/stats/event_record_merger.py
+++ b/core/storage/stats/event_record_merger.py
@@ -54,8 +54,19 @@ class EventRecordMerger:
                 description=description,
             )
 
-        if isinstance(event.event, (WeatherEvent, TsunamiEvent)):
-            # 气象与海啸事件通常按唯一标识覆盖最新摘要，不维护报次历史。
+        if isinstance(event.event, TsunamiEvent):
+            # 海啸按事件 ID 折叠多报，维护 history + update_count。
+            return EventRecordMerger._merge_tsunami_record(
+                target_list,
+                event,
+                source_id=source_id,
+                event_unique_id=event_unique_id,
+                current_time=current_time,
+                description=description,
+            )
+
+        if isinstance(event.event, WeatherEvent):
+            # 气象事件通常按唯一标识覆盖最新摘要，不维护报次历史。
             return EventRecordMerger._merge_non_earthquake_record(
                 target_list,
                 event,
@@ -64,6 +75,126 @@ class EventRecordMerger:
                 current_time=current_time,
                 description=description,
             )
+
+        return None
+
+    @staticmethod
+    def _normalize_tsunami_event_key(value: Any) -> str:
+        """规范化海啸事件键：支持 source|id / 裸 id。"""
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        if "|" in text:
+            return text.split("|", 1)[-1].strip()
+        return text
+
+    @staticmethod
+    def _resolve_tsunami_event_keys(
+        event: EventEnvelope,
+        *,
+        event_unique_id: str,
+    ) -> tuple[str, str]:
+        """返回 (real_event_id, bare_unique_id)。"""
+        domain_event = event.event
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        event_meta = (
+            domain_event.metadata
+            if isinstance(domain_event, TsunamiEvent)
+            and isinstance(domain_event.metadata, dict)
+            else {}
+        )
+        real_event_id = str(
+            event.id
+            or metadata.get("event_id")
+            or metadata.get("code")
+            or event_meta.get("event_id")
+            or event_meta.get("code")
+            or ""
+        ).strip()
+        bare_unique = EventRecordMerger._normalize_tsunami_event_key(event_unique_id)
+        if not bare_unique:
+            bare_unique = EventRecordMerger._normalize_tsunami_event_key(real_event_id)
+        if not real_event_id:
+            real_event_id = bare_unique
+        return real_event_id, bare_unique
+
+    @staticmethod
+    def _merge_tsunami_record(
+        target_list: list[dict[str, Any]],
+        event: EventEnvelope,
+        *,
+        source_id: str,
+        event_unique_id: str,
+        current_time: str,
+        description: str,
+    ) -> dict[str, Any] | None:
+        """海啸多报合并：同事件 ID 折叠，保留更新历史。"""
+        if not isinstance(event.event, TsunamiEvent):
+            return None
+
+        real_event_id, bare_unique = EventRecordMerger._resolve_tsunami_event_keys(
+            event, event_unique_id=event_unique_id
+        )
+        if not real_event_id and not bare_unique:
+            return None
+
+        cn_aliases = {"fan_studio_tsunami", "china_tsunami_fanstudio"}
+        for i, record in enumerate(target_list):
+            rec_source = str(
+                record.get("source") or record.get("source_id") or ""
+            ).strip()
+            if rec_source and source_id and rec_source != source_id:
+                if not (rec_source in cn_aliases and source_id in cn_aliases):
+                    continue
+
+            rec_real = str(record.get("real_event_id") or "").strip()
+            rec_unique_bare = EventRecordMerger._normalize_tsunami_event_key(
+                record.get("unique_id")
+            )
+            rec_event_id = str(record.get("event_id") or "").strip()
+
+            is_match = False
+            if real_event_id and rec_real and real_event_id == rec_real:
+                is_match = True
+            elif bare_unique and rec_unique_bare and bare_unique == rec_unique_bare:
+                is_match = True
+            elif real_event_id and rec_event_id and real_event_id == rec_event_id:
+                is_match = True
+            elif bare_unique and rec_event_id:
+                if bare_unique == EventRecordMerger._normalize_tsunami_event_key(
+                    rec_event_id
+                ):
+                    is_match = True
+
+            if not is_match:
+                continue
+
+            old_record = record.copy()
+            old_record.pop("history", None)
+            if "history" not in record:
+                record["history"] = []
+            record["history"].insert(0, old_record)
+            if len(record["history"]) > 50:
+                record["history"] = record["history"][:50]
+
+            next_count = int(record.get("update_count", 1) or 1) + 1
+            EventRecordFactory.apply_common_fields(
+                record,
+                event,
+                current_time=current_time,
+                event_unique_id=event_unique_id,
+                description=description,
+                source_id=source_id,
+                update_count=next_count,
+            )
+            EventRecordFactory.apply_tsunami_fields(record, event)
+            if real_event_id:
+                record["real_event_id"] = real_event_id
+            record["report_num"] = next_count
+
+            updated_record = target_list.pop(i)
+            target_list.insert(0, updated_record)
+            return updated_record
 
         return None
 

--- a/core/storage/stats/stats_event_support_service.py
+++ b/core/storage/stats/stats_event_support_service.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ....utils.converters import ScaleConverter
 from ...domain.event_models import (
     EarthquakeEvent,
@@ -14,6 +16,12 @@ from ...domain.event_models import (
     TyphoonEvent,
     WeatherEvent,
 )
+from ...domain.event_payload import SourcePayload
+from ...domain.tsunami.tsunami_levels import (
+    resolve_tsunami_region,
+    to_optional_float,
+)
+from ...domain.tsunami.tsunami_title import build_tsunami_list_title
 
 CHINA_PROVINCES = [
     "北京",
@@ -90,6 +98,53 @@ class StatsEventSupportService:
                 return parsed
         return None
 
+    @staticmethod
+    def _merge_tsunami_context(envelope: EventEnvelope) -> dict[str, Any]:
+        """合并海啸 envelope 各层元数据，供列表标题构建。"""
+        domain_event = envelope.event
+        metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
+        event_metadata = (
+            domain_event.metadata
+            if isinstance(getattr(domain_event, "metadata", None), dict)
+            else {}
+        )
+        merged: dict[str, Any] = {}
+        payload = envelope.payload
+        if isinstance(payload, SourcePayload):
+            payload_dict = payload.to_dict()
+            attributes = payload_dict.get("attributes")
+            if isinstance(attributes, dict):
+                merged.update(attributes)
+            merged.update(payload_dict)
+        elif isinstance(payload, dict):
+            attributes = payload.get("attributes")
+            if isinstance(attributes, dict):
+                merged.update(attributes)
+            merged.update(payload)
+        merged.update(event_metadata)
+        merged.update(metadata)
+
+        hypocenter = merged.get("issue_hypocenter")
+        if isinstance(hypocenter, dict):
+            for key in ("place_name", "magnitude", "latitude", "longitude", "depth"):
+                if merged.get(key) in (None, "") and hypocenter.get(key) not in (
+                    None,
+                    "",
+                ):
+                    merged[key] = hypocenter.get(key)
+            # EQSC 原始键名兼容
+            if merged.get("place_name") in (None, ""):
+                hypo_name = hypocenter.get("hypoCenterName") or hypocenter.get(
+                    "place_name"
+                )
+                if hypo_name not in (None, ""):
+                    merged["place_name"] = hypo_name
+            if merged.get("magnitude") in (None, ""):
+                mag = hypocenter.get("magnitude")
+                if mag not in (None, ""):
+                    merged["magnitude"] = mag
+        return merged
+
     def get_event_description_from_envelope(self, envelope: EventEnvelope) -> str:
         """基于新领域包络生成简短事件描述。"""
         domain_event = envelope.event
@@ -104,7 +159,44 @@ class StatsEventSupportService:
             return f"M{domain_event.magnitude:.1f} {place_name}"
 
         if isinstance(domain_event, TsunamiEvent):
-            return f"{domain_event.title} ({domain_event.level})"
+            # 列表标题：级别 · 震中 震级（字段缺失时优雅降级）
+            merged = self._merge_tsunami_context(envelope)
+            region = resolve_tsunami_region(envelope.source_id, merged)
+            place_name = str(
+                merged.get("place_name") or merged.get("subtitle") or ""
+            ).strip()
+            magnitude = to_optional_float(merged.get("magnitude"))
+            cancelled = bool(
+                merged.get("cancelled")
+                or merged.get("is_cancelled")
+                or domain_event.level == "解除"
+                or "解除" in str(domain_event.title or "")
+            )
+            is_training = bool(merged.get("is_training") or merged.get("isTraining"))
+            max_wave = str(
+                merged.get("max_wave_height") or merged.get("maxWaveHeight") or ""
+            ).strip()
+            area_count = merged.get("area_count")
+            if area_count is None:
+                forecasts = merged.get("forecasts")
+                if isinstance(forecasts, list):
+                    area_count = len(forecasts)
+            try:
+                area_count_int = int(area_count) if area_count is not None else None
+            except (TypeError, ValueError):
+                area_count_int = None
+            return build_tsunami_list_title(
+                region=region,
+                level=str(domain_event.level or merged.get("level") or "").strip(),
+                title=str(domain_event.title or "").strip(),
+                place_name=place_name,
+                magnitude=magnitude,
+                batch=merged.get("batch"),
+                cancelled=cancelled,
+                is_training=is_training,
+                max_wave_height=max_wave or None,
+                area_count=area_count_int,
+            )
 
         if isinstance(domain_event, TyphoonEvent):
             # 台风描述包含名称与当前等级，便于在统计列表中快速识别。

--- a/core/storage/stats/stats_record_service.py
+++ b/core/storage/stats/stats_record_service.py
@@ -87,17 +87,33 @@ class StatsRecordService:
                     if existing:
                         next_count = int(existing.get("update_count", 1) or 1) + 1
                         push_record["update_count"] = next_count
+                        # 以数据库已有行的定位键为准，避免 source/unique_id 别名导致 update 未命中。
+                        existing_source = str(
+                            existing.get("source")
+                            or existing.get("source_id")
+                            or push_record.get("source")
+                            or source_id
+                            or ""
+                        ).strip()
+                        if existing_source:
+                            push_record["source"] = existing_source
+                            push_record.setdefault("source_id", existing_source)
+                        existing_unique = str(existing.get("unique_id") or "").strip()
+                        if existing_unique:
+                            push_record["unique_id"] = existing_unique
+                        existing_real = str(existing.get("real_event_id") or "").strip()
+                        if existing_real:
+                            push_record["real_event_id"] = existing_real
                         # 海啸多报：用 update_count 作为报次，便于前端时间线展示
                         if isinstance(event.event, TsunamiEvent):
                             push_record["report_num"] = next_count
                             if not push_record.get("real_event_id"):
-                                push_record["real_event_id"] = existing.get(
-                                    "real_event_id"
-                                ) or push_record.get("event_id")
+                                push_record["real_event_id"] = (
+                                    existing_real
+                                    or push_record.get("event_id")
+                                )
                         await self.manager.db.update_event(
-                            push_record.get("source")
-                            or existing.get("source")
-                            or source_id,
+                            existing_source or source_id,
                             push_record,
                         )
                     else:

--- a/core/storage/stats/stats_record_service.py
+++ b/core/storage/stats/stats_record_service.py
@@ -109,8 +109,7 @@ class StatsRecordService:
                             push_record["report_num"] = next_count
                             if not push_record.get("real_event_id"):
                                 push_record["real_event_id"] = (
-                                    existing_real
-                                    or push_record.get("event_id")
+                                    existing_real or push_record.get("event_id")
                                 )
                         await self.manager.db.update_event(
                             existing_source or source_id,

--- a/core/storage/stats/stats_record_service.py
+++ b/core/storage/stats/stats_record_service.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 from astrbot.api import logger
 
-from ...domain.event_models import EarthquakeEvent, EventEnvelope, TyphoonEvent
+from ...domain.event_models import (
+    EarthquakeEvent,
+    EventEnvelope,
+    TsunamiEvent,
+)
 from .event_record_factory import EventRecordFactory
 from .event_record_merger import EventRecordMerger
 
@@ -77,28 +81,80 @@ class StatsRecordService:
                 try:
                     if is_major:
                         push_record["is_major"] = True
-                    # 台风事件可能已通过 EQSC 历史重建写入数据库但不在内存列表中，
-                    # 此时走 insert_event 会创建重复主表记录。
-                    # 先检查数据库是否已有该台风，若有则走 update_event 追加新报次。
-                    if isinstance(event.event, TyphoonEvent):
-                        existing = await self.manager.db.find_event_by_real_id(
-                            push_record.get("real_event_id"),
-                            push_record.get("source"),
+                    # 内存列表可能在重启/裁剪后丢失已有记录；写库前再查一次数据库，
+                    # 避免海啸/台风等被反复 insert 成多行。
+                    existing = await self._find_existing_db_record(push_record, event)
+                    if existing:
+                        next_count = int(existing.get("update_count", 1) or 1) + 1
+                        push_record["update_count"] = next_count
+                        # 海啸多报：用 update_count 作为报次，便于前端时间线展示
+                        if isinstance(event.event, TsunamiEvent):
+                            push_record["report_num"] = next_count
+                            if not push_record.get("real_event_id"):
+                                push_record["real_event_id"] = existing.get(
+                                    "real_event_id"
+                                ) or push_record.get("event_id")
+                        await self.manager.db.update_event(
+                            push_record.get("source")
+                            or existing.get("source")
+                            or source_id,
+                            push_record,
                         )
-                        if existing:
-                            # 数据库已有记录（来自 EQSC 重建），走更新而非插入
-                            push_record["update_count"] = (
-                                int(existing.get("update_count", 1) or 1) + 1
-                            )
-                            await self.manager.db.update_event(
-                                push_record.get("source"), push_record
-                            )
-                        else:
-                            await self.manager.db.insert_event(push_record)
                     else:
+                        if isinstance(event.event, TsunamiEvent):
+                            push_record.setdefault("report_num", 1)
                         await self.manager.db.insert_event(push_record)
                 except Exception as e:
                     logger.debug(f"[灾害预警] 保存到数据库失败（可能已存在）: {e}")
 
         if len(target_list) > max_len:
             del target_list[max_len:]
+
+    async def _find_existing_db_record(
+        self,
+        push_record: dict,
+        event: EventEnvelope,
+    ) -> dict | None:
+        """按 real_event_id / unique_id 查找数据库中已有记录。"""
+        source = str(push_record.get("source") or event.source_id or "").strip()
+        real_event_id = str(push_record.get("real_event_id") or "").strip()
+        unique_id = str(push_record.get("unique_id") or "").strip()
+        db = self.manager.db
+
+        if real_event_id and source:
+            existing = await db.find_event_by_real_id(real_event_id, source)
+            if existing:
+                return existing
+
+        if unique_id and source:
+            finder = getattr(db, "find_event_by_unique_id", None)
+            if callable(finder):
+                existing = await finder(unique_id, source)
+                if existing:
+                    return existing
+
+        # 海啸历史数据常见：real_event_id 为空、unique_id 仅为裸 id
+        if isinstance(event.event, TsunamiEvent) and unique_id:
+            finder = getattr(db, "find_event_by_unique_id", None)
+            if callable(finder):
+                bare = unique_id.split("|", 1)[-1]
+                for candidate in dict.fromkeys(
+                    [
+                        unique_id,
+                        bare,
+                        f"{source}|{bare}" if source and bare else "",
+                        f"china_tsunami_fanstudio|{bare}" if bare else "",
+                        f"fan_studio_tsunami|{bare}" if bare else "",
+                    ]
+                ):
+                    if not candidate:
+                        continue
+                    for src in dict.fromkeys(
+                        [source, "china_tsunami_fanstudio", "fan_studio_tsunami"]
+                    ):
+                        if not src:
+                            continue
+                        existing = await finder(candidate, src)
+                        if existing:
+                            return existing
+        return None

--- a/core/storage/tsunami_history_cleanup_service.py
+++ b/core/storage/tsunami_history_cleanup_service.py
@@ -176,9 +176,7 @@ class TsunamiHistoryCleanupService:
                     f"保留 {kept}, 删除 {len(delete_ids)}, 多报折叠 {len(multi_groups)}"
                 )
             else:
-                logger.info(
-                    f"[灾害预警] 海啸历史清理：无重复组，已规范化 {kept} 行"
-                )
+                logger.info(f"[灾害预警] 海啸历史清理：无重复组，已规范化 {kept} 行")
             return result
         except Exception as exc:
             logger.error(f"[灾害预警] 海啸历史清理失败: {exc}")

--- a/core/storage/tsunami_history_cleanup_service.py
+++ b/core/storage/tsunami_history_cleanup_service.py
@@ -124,21 +124,12 @@ class TsunamiHistoryCleanupService:
                 groups.setdefault(self._group_key(row), []).append(row)
 
             multi_groups = [items for items in groups.values() if len(items) > 1]
-            if not multi_groups:
-                self._done = True
-                logger.debug("[灾害预警] 海啸历史清理：未发现重复组，跳过")
-                return {
-                    "kept": len(groups),
-                    "deleted": 0,
-                    "groups": 0,
-                    "skipped": 0,
-                }
 
             delete_ids: list[int] = []
             kept = 0
+            # 无论是否存在重复组，都规范化单行（补齐 source_id / unique_id）。
             for items in groups.values():
                 if len(items) == 1:
-                    # 单行也尽量补齐 real_event_id / source_id
                     only = items[0]
                     await self._normalize_keep_row(cursor, [only], keep=only)
                     kept += 1
@@ -170,8 +161,8 @@ class TsunamiHistoryCleanupService:
                 from ..network.admin.api.events_routes import invalidate_sources_cache
 
                 invalidate_sources_cache()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(f"[灾害预警] 无法失效源缓存: {exc}")
 
             result = {
                 "kept": kept,
@@ -179,10 +170,15 @@ class TsunamiHistoryCleanupService:
                 "groups": len(multi_groups),
                 "skipped": 0,
             }
-            logger.info(
-                "[灾害预警] 海啸历史重复清理完成: "
-                f"保留 {kept}, 删除 {len(delete_ids)}, 多报折叠 {len(multi_groups)}"
-            )
+            if multi_groups or delete_ids:
+                logger.info(
+                    "[灾害预警] 海啸历史重复清理完成: "
+                    f"保留 {kept}, 删除 {len(delete_ids)}, 多报折叠 {len(multi_groups)}"
+                )
+            else:
+                logger.info(
+                    f"[灾害预警] 海啸历史清理：无重复组，已规范化 {kept} 行"
+                )
             return result
         except Exception as exc:
             logger.error(f"[灾害预警] 海啸历史清理失败: {exc}")

--- a/core/storage/tsunami_history_cleanup_service.py
+++ b/core/storage/tsunami_history_cleanup_service.py
@@ -1,0 +1,283 @@
+"""
+海啸历史重复记录清理服务。
+
+将旧版「同事件多次 insert」产生的脏数据折叠为：
+- events 主表：每组稳定事件键仅保留最新一行
+- event_updates：同组历史行转为报次快照，便于前端多报时间线
+- 本文件将在后续版本中视情况移除
+
+不写入 DatabaseManager 本体，仅复用其连接生命周期。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from astrbot.api import logger
+
+from .source_compat import normalize_source_name
+
+
+class TsunamiHistoryCleanupService:
+    """海啸历史脏数据清理服务。"""
+
+    CN_SOURCE_ALIASES = ("fan_studio_tsunami", "china_tsunami_fanstudio")
+
+    def __init__(self, db):
+        """
+        Args:
+            db: DatabaseManager 实例（复用连接与 initialize 生命周期）。
+        """
+        self.db = db
+        self._done = False
+
+    @staticmethod
+    def _normalize_event_key(value: Any) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        if "|" in text:
+            return text.split("|", 1)[-1].strip()
+        return text
+
+    @classmethod
+    def _group_key(cls, row: dict[str, Any]) -> str:
+        unique_id = str(row.get("unique_id") or "").strip()
+        real_event_id = str(row.get("real_event_id") or "").strip()
+        bare_unique = cls._normalize_event_key(unique_id)
+        if bare_unique:
+            return f"uid:{bare_unique}"
+        if real_event_id:
+            return f"rid:{real_event_id}"
+        return f"id:{row.get('id')}"
+
+    @staticmethod
+    def _row_sort_key(row: dict[str, Any]) -> tuple:
+        return (
+            str(row.get("updated_at") or ""),
+            str(row.get("time") or ""),
+            str(row.get("created_at") or ""),
+            int(row.get("id") or 0),
+        )
+
+    @classmethod
+    def _preferred_source(cls, rows: list[dict[str, Any]]) -> str:
+        for row in reversed(rows):
+            source = str(row.get("source") or row.get("source_id") or "").strip()
+            if not source:
+                continue
+            normalized = normalize_source_name(source) or source
+            if normalized:
+                return normalized
+        return "china_tsunami_fanstudio"
+
+    @classmethod
+    def _preferred_real_event_id(cls, rows: list[dict[str, Any]]) -> str:
+        for row in reversed(rows):
+            real_event_id = str(row.get("real_event_id") or "").strip()
+            if real_event_id:
+                return real_event_id
+            bare = cls._normalize_event_key(row.get("unique_id"))
+            if bare:
+                return bare
+        return ""
+
+    @classmethod
+    def _preferred_unique_id(
+        cls, rows: list[dict[str, Any]], *, source: str, real_event_id: str
+    ) -> str:
+        # 优先保留已带 source| 前缀的规范 unique_id
+        for row in reversed(rows):
+            unique_id = str(row.get("unique_id") or "").strip()
+            if unique_id and "|" in unique_id:
+                return unique_id
+        bare = cls._normalize_event_key(real_event_id) or cls._normalize_event_key(
+            rows[-1].get("unique_id") if rows else ""
+        )
+        if bare and source:
+            return f"{source}|{bare}"
+        return bare
+
+    async def run_once(self, *, force: bool = False) -> dict[str, int]:
+        """执行一次清理；默认进程内只跑一次。"""
+        if self._done and not force:
+            return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 1}
+
+        connection = await self.db._ensure_connection()
+        cursor = await connection.cursor()
+        try:
+            await cursor.execute(
+                """
+                SELECT *
+                FROM events
+                WHERE type='tsunami'
+                ORDER BY id ASC
+                """
+            )
+            rows = [dict(item) for item in await cursor.fetchall()]
+            if not rows:
+                self._done = True
+                return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 0}
+
+            groups: dict[str, list[dict[str, Any]]] = {}
+            for row in rows:
+                groups.setdefault(self._group_key(row), []).append(row)
+
+            multi_groups = [items for items in groups.values() if len(items) > 1]
+            if not multi_groups:
+                self._done = True
+                logger.debug("[灾害预警] 海啸历史清理：未发现重复组，跳过")
+                return {
+                    "kept": len(groups),
+                    "deleted": 0,
+                    "groups": 0,
+                    "skipped": 0,
+                }
+
+            delete_ids: list[int] = []
+            kept = 0
+            for items in groups.values():
+                if len(items) == 1:
+                    # 单行也尽量补齐 real_event_id / source_id
+                    only = items[0]
+                    await self._normalize_keep_row(cursor, [only], keep=only)
+                    kept += 1
+                    continue
+
+                items_sorted = sorted(items, key=self._row_sort_key)
+                keep = items_sorted[-1]
+                await self._fold_group_to_keep(cursor, items_sorted, keep=keep)
+                kept += 1
+                for item in items_sorted[:-1]:
+                    delete_ids.append(int(item["id"]))
+
+            if delete_ids:
+                placeholders = ",".join("?" for _ in delete_ids)
+                # 重复主表行对应的 updates 一并删除；同组历史已转写到 keep 的 updates
+                await cursor.execute(
+                    f"DELETE FROM event_updates WHERE event_id IN ({placeholders})",
+                    tuple(delete_ids),
+                )
+                await cursor.execute(
+                    f"DELETE FROM events WHERE id IN ({placeholders})",
+                    tuple(delete_ids),
+                )
+
+            await connection.commit()
+            self._done = True
+
+            try:
+                from ..network.admin.api.events_routes import invalidate_sources_cache
+
+                invalidate_sources_cache()
+            except Exception:
+                pass
+
+            result = {
+                "kept": kept,
+                "deleted": len(delete_ids),
+                "groups": len(multi_groups),
+                "skipped": 0,
+            }
+            logger.info(
+                "[灾害预警] 海啸历史重复清理完成: "
+                f"保留 {kept}, 删除 {len(delete_ids)}, 多报折叠 {len(multi_groups)}"
+            )
+            return result
+        except Exception as exc:
+            logger.error(f"[灾害预警] 海啸历史清理失败: {exc}")
+            await connection.rollback()
+            raise
+
+    async def _normalize_keep_row(
+        self,
+        cursor,
+        rows: list[dict[str, Any]],
+        *,
+        keep: dict[str, Any],
+    ) -> None:
+        source = self._preferred_source(rows)
+        real_event_id = self._preferred_real_event_id(rows)
+        unique_id = self._preferred_unique_id(
+            rows, source=source, real_event_id=real_event_id
+        )
+        update_count = max(len(rows), int(keep.get("update_count", 1) or 1))
+        await cursor.execute(
+            """
+            UPDATE events
+            SET source = ?,
+                source_id = ?,
+                real_event_id = COALESCE(NULLIF(?, ''), real_event_id),
+                unique_id = COALESCE(NULLIF(?, ''), unique_id),
+                update_count = ?,
+                report_num = COALESCE(report_num, ?)
+            WHERE id = ?
+            """,
+            (
+                source,
+                source,
+                real_event_id or None,
+                unique_id or None,
+                update_count,
+                update_count,
+                keep["id"],
+            ),
+        )
+
+    async def _fold_group_to_keep(
+        self,
+        cursor,
+        items_sorted: list[dict[str, Any]],
+        *,
+        keep: dict[str, Any],
+    ) -> None:
+        """把同组历史行折叠到 keep，并写入 event_updates 报次快照。"""
+        await self._normalize_keep_row(cursor, items_sorted, keep=keep)
+
+        keep_id = int(keep["id"])
+        # 清掉 keep 原有 updates，按时间线重建
+        await cursor.execute(
+            "DELETE FROM event_updates WHERE event_id = ?",
+            (keep_id,),
+        )
+
+        for index, item in enumerate(items_sorted, start=1):
+            description = item.get("description")
+            level = item.get("level")
+            magnitude = item.get("magnitude")
+            depth = item.get("depth")
+            latitude = item.get("latitude")
+            longitude = item.get("longitude")
+            event_time = item.get("time")
+            source_event_id = (
+                str(item.get("real_event_id") or "").strip()
+                or self._normalize_event_key(item.get("unique_id"))
+                or str(item.get("id") or "")
+            )
+            recorded_at = (
+                item.get("updated_at") or item.get("created_at") or item.get("time")
+            )
+            await cursor.execute(
+                """
+                INSERT INTO event_updates
+                    (event_id, source_event_id, report_num, magnitude, depth,
+                     description, level, wind_speed, pressure, latitude, longitude,
+                     time, recorded_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    keep_id,
+                    source_event_id,
+                    index,
+                    magnitude,
+                    depth,
+                    description,
+                    level,
+                    item.get("max_wave_height") or item.get("wind_speed"),
+                    item.get("pressure"),
+                    latitude,
+                    longitude,
+                    event_time,
+                    recorded_at,
+                ),
+            )

--- a/plugin/commands/plugin_admin_command_service.py
+++ b/plugin/commands/plugin_admin_command_service.py
@@ -174,6 +174,8 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 },
                 "EQSC API": {
                     "china_typhoon": "中国气象局：实时活跃台风",
+                    # 与 P2P 子源名称一致，仅展示一个海啸
+                    "jma_tsunami": "日本气象厅: 海啸予报",
                 },
                 "NIED S-Net": {
                     "snet_msil": "日本海沟 S-Net 海底震度计",
@@ -326,16 +328,20 @@ class PluginAdminCommandService(CommandTelemetryMixin):
 
             sub_source_status = dict(status.get("sub_source_status", {}) or {})
             # 注入 EQSC 子源（不在 SOURCE_CATALOG 的 WebSocket 分组内）
-            # 子数据源展示只看 typhoon_enrichment 子开关本身
+            # 子数据源展示只看各自子开关本身
             eqsc_sub_sources = eqsc_health.get("sub_sources")
             eqsc_typhoon_enrichment = bool(
                 eqsc_health.get("typhoon_enrichment", eqsc_config_enabled)
             )
-            if not isinstance(eqsc_sub_sources, dict):
-                eqsc_sub_sources = {"china_typhoon": eqsc_typhoon_enrichment}
+            eqsc_jma_tsunami = bool(eqsc_health.get("jma_tsunami", eqsc_config_enabled))
+            # 固定顺序：台风 → 海啸（仅一个海啸入口，名称与 P2P 一致）
+            eqsc_sub_sources = {
+                "china_typhoon": eqsc_typhoon_enrichment,
+                "jma_tsunami": eqsc_jma_tsunami,
+            }
             sub_source_status["eqsc"] = dict(eqsc_sub_sources)
             if eqsc_config_enabled:
-                grouped_sources.setdefault("eqsc", ["china_typhoon"])
+                grouped_sources.setdefault("eqsc", ["china_typhoon", "jma_tsunami"])
 
             # 注入 S-Net：仅展示单一子源 snet_msil（与前端网格一致）
             sub_source_status["snet"] = {"snet_msil": snet_enabled}


### PR DESCRIPTION
## 📝 描述 / Description

feat #42 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

将基于 EQSC 的 JMA 海啸 HTTP 轮询集成到系统中，统一海啸解析/标准化和跨来源去重，丰富存储和界面中的海啸事件信息，并加固浏览器渲染以及 Global Quake 终报处理。

New Features:
- 添加统一的海啸领域辅助工具，用于在中国和日本数据源之间进行等级归一化、标题处理以及天气详情摘要。
- 引入 EQSC JMA 海啸 HTTP 轮询流水线，包括客户端、解析器、数据源目录条目，以及带有配置和连接状态展示的运行时接线。
- 在管理端事件卡片和时间线中提供更丰富的海啸元数据和结构化标签/分区，包括等级、区域、震源、浪高、海域和观测站等信息。

Bug Fixes:
- 确保 Global Quake 归档事件被视为终报，从而遵从终报推送策略。
- 通过检测已关闭的 Playwright 目标、校验/重建本地浏览器/页面池，并增强字体等待和截图逻辑，防止浏览器渲染失败。

Enhancements:
- 优化中国和 JMA 的海啸文本呈现器，使其在处理 emoji、标题、时区、坐标、预报以及取消/演练语义时更一致。
- 扩展对 JMA P2P 和新的 EQSC 快照的海啸解析，以生成更丰富的元数据、一致的事件 ID，以及用于去重的内容指纹。
- 升级事件存储模式和工厂，记录最大浪高、区域数量、取消/演练标记等海啸特定字段，并构建更好的列表标题与摘要。
- 改进海啸事件的合并、分组和分页逻辑，使多报文事件按稳定 ID 折叠并保留历史，同时计数基于去重后的事件。
- 增加 EQSC 感知的连接与健康状态上报，在状态界面和管理命令中包括为台风增强和海啸轮询提供的子来源标记。
- 使会话和配置校验支持海啸特定过滤器以及 EQSC 海啸轮询/缓存参数调优。

Documentation:
- 在 README 中说明 Global Quake 的推送频率配置现在已支持终报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate EQSC-based JMA tsunami HTTP polling into the system, unify tsunami parsing/normalization and cross-source de-duplication, enrich tsunami events in storage and UI, and harden browser rendering and Global Quake final-report handling.

New Features:
- Add unified tsunami domain helpers for level normalization, titles, and weather-detail summaries across China and Japan sources.
- Introduce an EQSC JMA tsunami HTTP polling pipeline, including client, parser, source catalog entry, and runtime wiring with configuration and connection status surfaces.
- Provide rich tsunami metadata and structured chips/sections in the admin event cards and timelines, including level, region, hypocenter, wave heights, areas, and stations.

Bug Fixes:
- Ensure Global Quake archived events are treated as final reports so they respect final-report push policies.
- Prevent browser rendering failures by detecting closed Playwright targets, validating/rebuilding the local browser/page pool, and making font waits/screenshotting more robust.

Enhancements:
- Refine tsunami text presenters for China and JMA to handle emojis, titles, time zones, coordinates, forecasts, and cancellation/training semantics more consistently.
- Extend tsunami parsing for JMA P2P and new EQSC snapshots to produce richer metadata, consistent event IDs, and content fingerprints for de-duplication.
- Upgrade event storage schema and factories to capture tsunami-specific fields like max wave height, area counts, cancellation/training flags, and to build better list titles and summaries.
- Improve tsunami event merging, grouping, and pagination so multi-report events are collapsed by stable IDs with history preserved, and counts operate on distinct events.
- Add EQSC-aware connection and health reporting, including sub-source flags for typhoon enrichment and tsunami polling in status UIs and admin commands.
- Make session and config validation support tsunami-specific filters and EQSC tsunami polling/cache tuning.

Documentation:
- Clarify in README that Global Quake now supports final reports in the push frequency configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增日本气象厅海啸数据接入、轮询与缓存支持。
  * 管理端新增海啸事件结构化详情面板、等级标签、预报区域及监测站信息展示。
  * 支持中国与日本海啸等级筛选、最低级别配置及训练报开关。

* **改进**
  * 优化海啸事件标题、时间轴、来源名称与历史记录展示。
  * 增强跨来源去重，减少重复推送。
  * Global Quake 支持最终报与归档报推送控制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->