### PR TITLE
fix: 修复并调整 S-Net 测站渐变上色逻辑。避免每次重载都触发海啸历史重复记录清理服务

### DIFF
--- a/admin/js/components/config/ConfigFieldLayout.jsx
+++ b/admin/js/components/config/ConfigFieldLayout.jsx
@@ -15,6 +15,7 @@ const CONFIG_ICONS = {
     push_frequency_control: '⏱️',
     message_format: '🎨',
     weather_config: '⛈️',
+    tsunami_config: '🌊',
     typhoon_config: '🌀',
     websocket_config: '🔌',
     web_admin: '💻',

--- a/core/message/render/snet_map_renderer.py
+++ b/core/message/render/snet_map_renderer.py
@@ -205,7 +205,8 @@ def _shindo_css_class(shindo: float) -> str:
 
 def _rgb_to_str(rgb: tuple[int, int, int] | list[int] | None) -> str:
     if not rgb or len(rgb) < 3:
-        return "31,228,96"
+        r, g, b = _SNET_BELOW_ZERO_RGB
+        return f"{r},{g},{b}"
     return f"{rgb[0]},{rgb[1]},{rgb[2]}"
 
 
@@ -432,6 +433,14 @@ class SnetMapRenderer:
                 sorted(station_list, key=lambda x: x["shindo"])
             ),
             "icon_svgs_json": icon_svgs_json,
+            # 渐变参数由 Python 常量注入 JSON payload，避免与模板 JS 双份维护漂移
+            "gradient_config_json": json.dumps(
+                {
+                    "color_neg3": list(_SNET_NEG3_RGB),
+                    "color_below_zero": list(_SNET_BELOW_ZERO_RGB),
+                    "gradient_end_shindo": _SNET_GRADIENT_END_SHINDO,
+                }
+            ),
             "display_time": display_time,
             "triggered_count": triggered_count,
             "total_stations": total_stations,

--- a/core/message/render/snet_map_renderer.py
+++ b/core/message/render/snet_map_renderer.py
@@ -38,9 +38,10 @@ SNET_LIST_LIMIT = 18
 # S-Net 卡片固定画布；渲染时临时放大浏览器视口，避免 800×800 池默认值裁切
 SNET_VIEWPORT = {"width": 1400, "height": 1000}
 
-# 計測震度 -3 → #0000CD，0 → #3FFA36（与地图 canvas 渐变一致）
+# 計測震度 -3 → #0000CD，-0.5 → #1FE460（震度0 起点；与地图 canvas 渐变一致）
 _SNET_NEG3_RGB = (0, 0, 205)
-_SNET_ZERO_RGB = (63, 250, 54)
+_SNET_BELOW_ZERO_RGB = (31, 228, 96)  # #1FE460
+_SNET_GRADIENT_END_SHINDO = -0.5  # 日本震度 0 的計測震度起点
 
 # 图标文件映射: (shindo下限, SVG文件名)
 _SNET_ICON_FILES = [
@@ -204,16 +205,24 @@ def _shindo_css_class(shindo: float) -> str:
 
 def _rgb_to_str(rgb: tuple[int, int, int] | list[int] | None) -> str:
     if not rgb or len(rgb) < 3:
-        return "63,250,54"
+        return "31,228,96"
     return f"{rgb[0]},{rgb[1]},{rgb[2]}"
 
 
 def _neg_to_zero_gradient_rgb(shindo: float) -> tuple[int, int, int]:
-    """計測震度 -3～0 线性插值到 (#0000CD → #3FFA36)。"""
-    t = max(0.0, min(1.0, (float(shindo) + 3.0) / 3.0))
-    r = int(round(_SNET_NEG3_RGB[0] + (_SNET_ZERO_RGB[0] - _SNET_NEG3_RGB[0]) * t))
-    g = int(round(_SNET_NEG3_RGB[1] + (_SNET_ZERO_RGB[1] - _SNET_NEG3_RGB[1]) * t))
-    b = int(round(_SNET_NEG3_RGB[2] + (_SNET_ZERO_RGB[2] - _SNET_NEG3_RGB[2]) * t))
+    """計測震度 -3～-0.5 线性插值到 (#0000CD → #1FE460)。"""
+    # 震度 0 起点为 -0.5；区间长度 2.5
+    span = 3.0 + _SNET_GRADIENT_END_SHINDO  # 2.5
+    t = max(0.0, min(1.0, (float(shindo) + 3.0) / span))
+    r = int(
+        round(_SNET_NEG3_RGB[0] + (_SNET_BELOW_ZERO_RGB[0] - _SNET_NEG3_RGB[0]) * t)
+    )
+    g = int(
+        round(_SNET_NEG3_RGB[1] + (_SNET_BELOW_ZERO_RGB[1] - _SNET_NEG3_RGB[1]) * t)
+    )
+    b = int(
+        round(_SNET_NEG3_RGB[2] + (_SNET_BELOW_ZERO_RGB[2] - _SNET_NEG3_RGB[2]) * t)
+    )
     return (r, g, b)
 
 
@@ -223,7 +232,8 @@ def _list_dot_bg(shindo: float) -> str:
         value = float(shindo)
     except (TypeError, ValueError):
         return ""
-    if value > 0:
+    # 仅震度 0 以下（計測震度 < -0.5）使用渐变色点
+    if value >= _SNET_GRADIENT_END_SHINDO:
         return ""
     r, g, b = _neg_to_zero_gradient_rgb(value)
     return f"rgb({r},{g},{b})"
@@ -357,8 +367,8 @@ class SnetMapRenderer:
             rgb = s.get("rgb")
             rgb_str = _rgb_to_str(rgb)
             sc = _shindo_css_class(shindo_f)
-            # <=0 列表圆点用 -3~0 渐变；>0 走 CSS 震度色 class
-            if shindo_f > 0:
+            # < -0.5 列表圆点用 -3~-0.5 渐变；>= -0.5 走 CSS 震度色 class（含震度0）
+            if shindo_f >= _SNET_GRADIENT_END_SHINDO:
                 dot_class = sc.replace("shindo-", "dot-") if sc else "dot-none"
                 dot_bg = ""
             else:
@@ -396,13 +406,13 @@ class SnetMapRenderer:
             max_shindo_text = f"{top['shindo']:.3f}"
             top_station_name = top["name"]
             top_shindo = float(top["shindo"])
-            if top_shindo > 0:
-                # 正震度：用与列表一致的 shindo-*（对齐 earthquake_list 色相）
+            if top_shindo >= _SNET_GRADIENT_END_SHINDO:
+                # 震度0及以上：用与列表一致的 shindo-*（对齐 earthquake_list 色相）
                 max_shindo_class = top.get("shindo_class") or _shindo_css_class(
                     top_shindo
                 )
             else:
-                # ≤0：与地图 -3~0 渐变同色（内联，避免 style=Jinja 在 class 上爆红）
+                # 震度0以下：与地图 -3~-0.5 渐变同色（内联，避免 style=Jinja 在 class 上爆红）
                 r, g, b = _neg_to_zero_gradient_rgb(top_shindo)
                 max_shindo_color = f"rgb({r},{g},{b})"
         else:

--- a/core/storage/tsunami_history_cleanup_service.py
+++ b/core/storage/tsunami_history_cleanup_service.py
@@ -37,6 +37,15 @@ class TsunamiHistoryCleanupService:
         self._done = False
 
     def _marker_path(self) -> Path | None:
+        """按数据库文件名区分标记，避免多库共享目录时互相覆盖。"""
+        db_path = getattr(self.db, "db_path", None)
+        if db_path is None:
+            return None
+        path = Path(db_path)
+        return path.parent / f".tsunami_history_cleanup_v1_{path.stem}.done"
+
+    def _legacy_marker_path(self) -> Path | None:
+        """兼容旧版固定文件名标记。"""
         db_path = getattr(self.db, "db_path", None)
         if db_path is None:
             return None
@@ -44,7 +53,10 @@ class TsunamiHistoryCleanupService:
 
     def _is_marked_done(self) -> bool:
         marker = self._marker_path()
-        return bool(marker and marker.is_file())
+        if marker and marker.is_file():
+            return True
+        legacy = self._legacy_marker_path()
+        return bool(legacy and legacy.is_file())
 
     def _write_marker(self) -> None:
         marker = self._marker_path()
@@ -54,7 +66,8 @@ class TsunamiHistoryCleanupService:
             marker.parent.mkdir(parents=True, exist_ok=True)
             marker.write_text("done\n", encoding="utf-8")
         except Exception as exc:
-            logger.debug(f"[灾害预警] 写入海啸清理标记失败: {exc}")
+            # 写失败会导致插件重载后反复扫描，需可观测
+            logger.warning(f"[灾害预警] 写入海啸清理标记失败: {exc}")
 
     @staticmethod
     def _normalize_event_key(value: Any) -> str:
@@ -151,7 +164,8 @@ class TsunamiHistoryCleanupService:
             return True
         if cur_update < update_count:
             return True
-        if cur_report in (None, "", 0) and update_count:
+        # 与下方 SQL 的 COALESCE(report_num, ?) 对齐：仅 NULL 会被替换
+        if cur_report is None and update_count:
             return True
         return False
 

--- a/core/storage/tsunami_history_cleanup_service.py
+++ b/core/storage/tsunami_history_cleanup_service.py
@@ -7,15 +7,20 @@
 - 本文件将在后续版本中视情况移除
 
 不写入 DatabaseManager 本体，仅复用其连接生命周期。
+完成后写入磁盘标记，避免插件重载反复扫描/刷日志。
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from astrbot.api import logger
 
 from .source_compat import normalize_source_name
+
+# 标记版本：清理逻辑变更时可递增，强制再跑一轮
+_MARKER_NAME = ".tsunami_history_cleanup_v1.done"
 
 
 class TsunamiHistoryCleanupService:
@@ -30,6 +35,26 @@ class TsunamiHistoryCleanupService:
         """
         self.db = db
         self._done = False
+
+    def _marker_path(self) -> Path | None:
+        db_path = getattr(self.db, "db_path", None)
+        if db_path is None:
+            return None
+        return Path(db_path).parent / _MARKER_NAME
+
+    def _is_marked_done(self) -> bool:
+        marker = self._marker_path()
+        return bool(marker and marker.is_file())
+
+    def _write_marker(self) -> None:
+        marker = self._marker_path()
+        if marker is None:
+            return
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text("done\n", encoding="utf-8")
+        except Exception as exc:
+            logger.debug(f"[灾害预警] 写入海啸清理标记失败: {exc}")
 
     @staticmethod
     def _normalize_event_key(value: Any) -> str:
@@ -98,10 +123,46 @@ class TsunamiHistoryCleanupService:
             return f"{source}|{bare}"
         return bare
 
+    @classmethod
+    def _needs_normalize(
+        cls,
+        keep: dict[str, Any],
+        *,
+        source: str,
+        real_event_id: str,
+        unique_id: str,
+        update_count: int,
+    ) -> bool:
+        """仅当字段确实需要修正时才 UPDATE。"""
+        cur_source = str(keep.get("source") or "").strip()
+        cur_source_id = str(keep.get("source_id") or "").strip()
+        cur_real = str(keep.get("real_event_id") or "").strip()
+        cur_unique = str(keep.get("unique_id") or "").strip()
+        cur_update = int(keep.get("update_count", 1) or 1)
+        cur_report = keep.get("report_num")
+
+        if cur_source != source:
+            return True
+        if cur_source_id != source:
+            return True
+        if real_event_id and cur_real != real_event_id:
+            return True
+        if unique_id and cur_unique != unique_id:
+            return True
+        if cur_update < update_count:
+            return True
+        if cur_report in (None, "", 0) and update_count:
+            return True
+        return False
+
     async def run_once(self, *, force: bool = False) -> dict[str, int]:
-        """执行一次清理；默认进程内只跑一次。"""
+        """执行一次清理；默认进程内 + 磁盘标记只跑一次。"""
         if self._done and not force:
-            return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 1}
+            return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 1, "updated": 0}
+        if not force and self._is_marked_done():
+            self._done = True
+            logger.debug("[灾害预警] 海啸历史清理：已有完成标记，跳过")
+            return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 1, "updated": 0}
 
         connection = await self.db._ensure_connection()
         cursor = await connection.cursor()
@@ -117,27 +178,36 @@ class TsunamiHistoryCleanupService:
             rows = [dict(item) for item in await cursor.fetchall()]
             if not rows:
                 self._done = True
-                return {"kept": 0, "deleted": 0, "groups": 0, "skipped": 0}
+                self._write_marker()
+                return {
+                    "kept": 0,
+                    "deleted": 0,
+                    "groups": 0,
+                    "skipped": 0,
+                    "updated": 0,
+                }
 
             groups: dict[str, list[dict[str, Any]]] = {}
             for row in rows:
                 groups.setdefault(self._group_key(row), []).append(row)
 
             multi_groups = [items for items in groups.values() if len(items) > 1]
-
             delete_ids: list[int] = []
             kept = 0
-            # 无论是否存在重复组，都规范化单行（补齐 source_id / unique_id）。
+            updated = 0
+
             for items in groups.values():
                 if len(items) == 1:
                     only = items[0]
-                    await self._normalize_keep_row(cursor, [only], keep=only)
+                    if await self._normalize_keep_row(cursor, [only], keep=only):
+                        updated += 1
                     kept += 1
                     continue
 
                 items_sorted = sorted(items, key=self._row_sort_key)
                 keep = items_sorted[-1]
-                await self._fold_group_to_keep(cursor, items_sorted, keep=keep)
+                if await self._fold_group_to_keep(cursor, items_sorted, keep=keep):
+                    updated += 1
                 kept += 1
                 for item in items_sorted[:-1]:
                     delete_ids.append(int(item["id"]))
@@ -156,6 +226,7 @@ class TsunamiHistoryCleanupService:
 
             await connection.commit()
             self._done = True
+            self._write_marker()
 
             try:
                 from ..network.admin.api.events_routes import invalidate_sources_cache
@@ -169,14 +240,19 @@ class TsunamiHistoryCleanupService:
                 "deleted": len(delete_ids),
                 "groups": len(multi_groups),
                 "skipped": 0,
+                "updated": updated,
             }
             if multi_groups or delete_ids:
                 logger.info(
                     "[灾害预警] 海啸历史重复清理完成: "
                     f"保留 {kept}, 删除 {len(delete_ids)}, 多报折叠 {len(multi_groups)}"
                 )
+            elif updated:
+                logger.info(f"[灾害预警] 海啸历史清理：无重复组，已规范化 {updated} 行")
             else:
-                logger.info(f"[灾害预警] 海啸历史清理：无重复组，已规范化 {kept} 行")
+                logger.debug(
+                    f"[灾害预警] 海啸历史清理：无重复组且无需规范化（共 {kept} 行）"
+                )
             return result
         except Exception as exc:
             logger.error(f"[灾害预警] 海啸历史清理失败: {exc}")
@@ -189,13 +265,23 @@ class TsunamiHistoryCleanupService:
         rows: list[dict[str, Any]],
         *,
         keep: dict[str, Any],
-    ) -> None:
+    ) -> bool:
+        """规范化保留行；有实际变更返回 True。"""
         source = self._preferred_source(rows)
         real_event_id = self._preferred_real_event_id(rows)
         unique_id = self._preferred_unique_id(
             rows, source=source, real_event_id=real_event_id
         )
         update_count = max(len(rows), int(keep.get("update_count", 1) or 1))
+        if not self._needs_normalize(
+            keep,
+            source=source,
+            real_event_id=real_event_id,
+            unique_id=unique_id,
+            update_count=update_count,
+        ):
+            return False
+
         await cursor.execute(
             """
             UPDATE events
@@ -217,6 +303,7 @@ class TsunamiHistoryCleanupService:
                 keep["id"],
             ),
         )
+        return True
 
     async def _fold_group_to_keep(
         self,
@@ -224,8 +311,9 @@ class TsunamiHistoryCleanupService:
         items_sorted: list[dict[str, Any]],
         *,
         keep: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         """把同组历史行折叠到 keep，并写入 event_updates 报次快照。"""
+        # 折叠组必然改写 updates；规范化结果无需单独使用
         await self._normalize_keep_row(cursor, items_sorted, keep=keep)
 
         keep_id = int(keep["id"])
@@ -275,3 +363,4 @@ class TsunamiHistoryCleanupService:
                     recorded_at,
                 ),
             )
+        return True

--- a/resources/card_templates/SNET/snet_station.html
+++ b/resources/card_templates/SNET/snet_station.html
@@ -401,9 +401,10 @@ var MAP_LON_MIN = 135.0, MAP_LON_MAX = 149.0;
 var MAP_LAT_MIN = 32.0,  MAP_LAT_MAX = 44.0;
 var MARGIN = 60;
 
-/* -3 → #0000CD, 0 → #3FFA36 线性渐变 */
+/* -3 → #0000CD, -0.5 → #1FE460 线性渐变（震度0 起点为計測震度 -0.5） */
 var COLOR_NEG3 = [0, 0, 205];
-var COLOR_ZERO = [63, 250, 54];
+var COLOR_BELOW_ZERO = [31, 228, 96];  // #1FE460
+var GRADIENT_END_SHINDO = -0.5;
 
 var ICON_KEYS = [
     [6.5, 52], [6.0, 48], [5.5, 44], [5.0, 40],
@@ -419,13 +420,14 @@ function lerpChannel(a, b, t) {
     return Math.round(a + (b - a) * t);
 }
 
-/** 計測震度 -3～0 → 蓝到绿渐变；低于 -3 钳制到 -3 色 */
+/** 計測震度 -3～-0.5 → 蓝到绿渐变；低于 -3 钳制到 -3 色 */
 function shindoToNegGradientRgb(sh) {
-    var t = clamp01((sh + 3.0) / 3.0);
+    var span = 3.0 + GRADIENT_END_SHINDO; // 2.5
+    var t = clamp01((sh + 3.0) / span);
     return [
-        lerpChannel(COLOR_NEG3[0], COLOR_ZERO[0], t),
-        lerpChannel(COLOR_NEG3[1], COLOR_ZERO[1], t),
-        lerpChannel(COLOR_NEG3[2], COLOR_ZERO[2], t)
+        lerpChannel(COLOR_NEG3[0], COLOR_BELOW_ZERO[0], t),
+        lerpChannel(COLOR_NEG3[1], COLOR_BELOW_ZERO[1], t),
+        lerpChannel(COLOR_NEG3[2], COLOR_BELOW_ZERO[2], t)
     ];
 }
 
@@ -437,13 +439,13 @@ function rgbCss(rgb, alpha) {
 }
 
 function shindoToIconSize(sh) {
-    // > 0 使用彩色震度图标；<= 0 用 -3~0 渐变色点
-    if (sh > 0) return 24;
+    // >= -0.5 使用彩色震度图标（含震度0）；< -0.5 用 -3~-0.5 渐变色点
+    if (sh >= GRADIENT_END_SHINDO) return 24;
     return 0;
 }
 
 function shindoToThreshold(sh) {
-    if (sh <= 0) return null;
+    if (sh < GRADIENT_END_SHINDO) return null;
     for (var i = 0; i < ICON_KEYS.length; i++) {
         if (sh >= ICON_KEYS[i][0]) return ICON_KEYS[i][0];
     }
@@ -502,7 +504,7 @@ function preloadIcons(callback) {
 }
 
 /* ════════════════════════════════════════════
-   绘制负震度 / 0 渐变色点
+   绘制震度0以下（計測震度 < -0.5）渐变色点
    ════════════════════════════════════════════ */
 function drawGradientDot(ctx, x, y, sh) {
     var rgb = shindoToNegGradientRgb(sh);
@@ -563,13 +565,13 @@ function renderMap() {
         ctx.stroke();
     }
 
-    // 测站：先画 <=0 渐变点，再画 >0 图标，保证触发站在上层
+    // 测站：先画 < -0.5 渐变点，再画 >= -0.5 图标，保证触发站在上层
     var positive = [];
     for (var si = 0; si < STATIONS.length; si++) {
         var s = STATIONS[si];
         var xy = lonlatToXY(s.lon, s.lat, mapW, mapH);
         var sh = s.shindo;
-        if (sh > 0) {
+        if (sh >= GRADIENT_END_SHINDO) {
             positive.push({ s: s, xy: xy, sh: sh });
         } else {
             drawGradientDot(ctx, xy[0], xy[1], sh);
@@ -586,8 +588,8 @@ function renderMap() {
             var hs = iconSize / 2;
             ctx.drawImage(icon, item.xy[0] - hs, item.xy[1] - hs, iconSize, iconSize);
         } else {
-            // 图标缺失时回退到 0 端点绿色，避免再次变灰
-            drawGradientDot(ctx, item.xy[0], item.xy[1], 0);
+            // 图标缺失时回退到渐变终点绿色（-0.5），避免再次变灰
+            drawGradientDot(ctx, item.xy[0], item.xy[1], GRADIENT_END_SHINDO);
         }
     }
 }

--- a/resources/card_templates/SNET/snet_station.html
+++ b/resources/card_templates/SNET/snet_station.html
@@ -389,6 +389,7 @@ html, body {
 <script type="application/json" id="snet-japan-rings">{{ rings_json }}</script>
 <script type="application/json" id="snet-stations">{{ stations_json }}</script>
 <script type="application/json" id="snet-icon-svgs">{{ icon_svgs_json }}</script>
+<script type="application/json" id="snet-gradient-config">{{ gradient_config_json }}</script>
 
 <script>
 (function() {
@@ -401,7 +402,7 @@ var MAP_LON_MIN = 135.0, MAP_LON_MAX = 149.0;
 var MAP_LAT_MIN = 32.0,  MAP_LAT_MAX = 44.0;
 var MARGIN = 60;
 
-/* -3 → #0000CD, -0.5 → #1FE460 线性渐变（震度0 起点为計測震度 -0.5） */
+/* 渐变参数默认值；实际值由下方 snet-gradient-config 覆盖（Python 单源） */
 var COLOR_NEG3 = [0, 0, 205];
 var COLOR_BELOW_ZERO = [31, 228, 96];  // #1FE460
 var GRADIENT_END_SHINDO = -0.5;
@@ -468,6 +469,24 @@ function _readJsonPayload(id) {
 var JAPAN_RINGS = _readJsonPayload('snet-japan-rings') || [];
 var STATIONS = _readJsonPayload('snet-stations') || [];
 var ICON_SVGS = _readJsonPayload('snet-icon-svgs') || {};
+/* 覆盖渐变参数：与 snet_map_renderer._SNET_* 保持单源一致 */
+(function applyGradientConfig() {
+    var cfg = _readJsonPayload('snet-gradient-config');
+    if (!cfg || typeof cfg !== 'object') return;
+    if (Array.isArray(cfg.color_neg3) && cfg.color_neg3.length >= 3) {
+        COLOR_NEG3 = cfg.color_neg3;
+    }
+    if (Array.isArray(cfg.color_below_zero) && cfg.color_below_zero.length >= 3) {
+        COLOR_BELOW_ZERO = cfg.color_below_zero;
+    }
+    if (typeof cfg.gradient_end_shindo === 'number') {
+        GRADIENT_END_SHINDO = cfg.gradient_end_shindo;
+        // 同步 ICON_KEYS 末项阈值（震度0 起点）
+        if (ICON_KEYS.length) {
+            ICON_KEYS[ICON_KEYS.length - 1][0] = GRADIENT_END_SHINDO;
+        }
+    }
+})();
 
 /* ════════════════════════════════════════════
    坐标转换


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

持久化海啸历史清理状态，以避免在插件重新加载时重复运行，并调整 S-Net 观测站渲染，使渐变色彩和阈值与测得震度定义保持一致。

Bug Fixes:
- 通过在磁盘上持久化一个完成标记，防止海啸历史清理在每次插件重新加载时重复运行。
- 仅在字段实际需要纠正时才规范化记录，避免不必要的海啸历史行更新。
- 修复 S-Net 观测站负震度渐变范围，将结束值改为测得震度 -0.5 而非 0，以匹配地图画布的行为。
- 确保 S-Net 观测站圆点和图标在正确的震度阈值（测得 -0.5）处在渐变着色和 CSS 震度类之间切换，避免视觉不一致。

Enhancements:
- 在清理过程中跟踪并报告被规范化/更新的海啸历史记录数量，以提升日志清晰度和可观测性。
- 优化 S-Net 观测站渐变色和回退行为，使缺失图标时能以正确的端点颜色渲染，而不是灰色。
- 更新管理配置界面 UI，为海啸相关设置展示专用图标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist tsunami history cleanup state to avoid repeated runs on plugin reload and adjust S-Net station rendering to align gradient coloring and thresholds with measured intensity definitions.

Bug Fixes:
- Prevent tsunami history cleanup from re-running on every plugin reload by persisting a completion marker on disk.
- Avoid unnecessary tsunami history row updates by only normalizing records when their fields actually need correction.
- Fix S-Net station negative-intensity gradient to use the correct range ending at measured intensity -0.5 instead of 0, matching the map canvas behavior.
- Ensure S-Net station dots and icons switch between gradient coloring and CSS shindo classes at the proper intensity threshold (measured -0.5) to avoid visual inconsistencies.

Enhancements:
- Track and report the number of normalized/updated tsunami history records during cleanup for clearer logging and observability.
- Refine S-Net station gradient colors and fallback behavior so missing icons render with the proper endpoint color instead of gray.
- Update admin configuration UI to show a dedicated icon for tsunami-related settings.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为海啸相关配置项新增 🌊 图标，提升配置页面可识别度。
- **优化**
  - 调整海底地震（S-Net）震度的负值渐变“0 起点”与分界阈值，更新测站点与最大震度的颜色/层级展示；并支持统一配置渐变参数。
- **维护**
  - 优化海啸历史数据清理：引入基于磁盘的完成标记以避免重复执行，并细化更新/跳过统计，提升处理准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->