### PR TITLE
feat: 支持渲染台风路径图

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,10 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 - **地图瓦片源 (`map_source`)**:
   - WebUI 中文选项：`高德地图`、`PetalMap矢量图亮`、`PetalMap矢量图暗`、`ArcGIS卫星影像`、`ArcGIS地形图`、`ArcGIS山影图`、`中科星图卫星影像`。
   - 同时兼容英文 ID：`amap`、`petallight`、`petaldark`、`arcwi`、`arcwob`、`arcwh`、`geovis`。
+  - 用于地震通用地图、Global Quake 卡片等。
+- **台风路径图瓦片源 (`typhoon_map_source`)**:
+  - 选项与 `map_source` 相同，但**仅作用于台风路径图**，与通用地图源独立。
+  - 默认 `PetalMap矢量图暗`（匹配台风卡片暗色主题）。
 - **地图缩放级别 (`map_zoom_level`)**: 范围 0-18 ，数值越大，固定视野中展现的区域范围就越小。(默认值 5)
   - z=0-2：全球视图
   - z=3-5：国家视图
@@ -733,7 +737,8 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 ```json
 "message_format": {
   "include_map": false,                         // 是否在消息中附带地图图片
-  "map_source": "PetalMap矢量图亮",             // 地图源（可填中文名或英文ID）
+  "map_source": "PetalMap矢量图亮",             // 通用地图源（可填中文名或英文ID）
+  "typhoon_map_source": "PetalMap矢量图暗",    // 台风路径图专用瓦片源
   "map_zoom_level": 5,                         // 地图缩放级别（0-18）
   "playwright_mode": "local",                  // 渲染模式：local/remote
   "playwright_server_url": "",                 // remote 模式下填写远程服务地址

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -720,7 +720,22 @@
           "中科星图卫星影像"
         ],
         "default": "PetalMap矢量图亮",
-        "hint": "选择地图渲染使用的瓦片源"
+        "hint": "选择地震通用地图 / Global Quake 卡片等渲染使用的瓦片源"
+      },
+      "typhoon_map_source": {
+        "description": "台风路径图瓦片源",
+        "type": "string",
+        "options": [
+          "高德地图",
+          "PetalMap矢量图亮",
+          "PetalMap矢量图暗",
+          "ArcGIS卫星影像",
+          "ArcGIS地形图",
+          "ArcGIS山影图",
+          "中科星图卫星影像"
+        ],
+        "default": "PetalMap矢量图暗",
+        "hint": "仅用于台风路径图渲染。与上方「地图瓦片源」独立；台风卡片默认暗色主题，建议使用暗色或卫星底图。"
       },
       "map_zoom_level": {
         "description": "地图缩放级别",

--- a/core/message/message_manager.py
+++ b/core/message/message_manager.py
@@ -185,6 +185,11 @@ class MessagePushManager:
         return self._bootstrap_service.snet_map_renderer
 
     @property
+    def typhoon_map_renderer(self):
+        """台风路径图渲染器。"""
+        return self._bootstrap_service.typhoon_map_renderer
+
+    @property
     def browser_manager(self):
         """浏览器管理器。"""
         return self.__dict__.get("_browser_manager")

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
 from typing import Any
@@ -530,9 +531,14 @@ class MessageBuildService:
 
             async def _render_typhoon() -> str | None:
                 safe_id = str(domain_event.typhoon_id or "unknown").replace("/", "_")
+                # 文件名纳入 map_source / playwright_mode 指纹，避免多会话差异化配置
+                # 并发渲染时写入同一路径导致串图或文件损坏。
+                cfg_token = hashlib.sha1(
+                    f"{map_source}|{playwright_mode}".encode()
+                ).hexdigest()[:10]
                 img_path = os.path.join(
                     str(self.manager.temp_dir),
-                    f"typhoon_map_{safe_id}.png",
+                    f"typhoon_map_{safe_id}_{cfg_token}.png",
                 )
                 return await renderer.render(
                     domain_event,

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -20,6 +20,7 @@ from ...domain.event_models import (
     EarthquakeEvent,
     EventEnvelope,
     TsunamiEvent,
+    TyphoonEvent,
     WeatherEvent,
 )
 from ...services.identity.event_identity import resolve_report_num
@@ -112,6 +113,66 @@ class MessageBuildService:
         # 全量排序指纹：同分钟同分布可跨推送/查询复用渲染结果
         fingerprint = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
         return f"snet_map|{timestamp}|{fingerprint}"
+
+    @staticmethod
+    def _build_typhoon_map_cache_key(
+        data: dict[str, Any] | TyphoonEvent,
+        *,
+        map_source: str,
+        playwright_mode: str,
+    ) -> str:
+        """构建台风路径图缓存键（编号 + 轨迹指纹 + 地图源）。"""
+        if isinstance(data, TyphoonEvent):
+            typhoon_id = str(data.typhoon_id or "")
+            history = list(data.history_track or [])
+            future = list(data.future_track or [])
+            updated_at = str(data.updated_at or "")
+        else:
+            typhoon_id = str(data.get("typhoon_id") or data.get("eqsc_id") or "")
+            history = list(data.get("history_track") or [])
+            future = list(data.get("future_track") or [])
+            updated_at = str(
+                data.get("updated_at") or data.get("updated_at_text") or ""
+            )
+
+        def _track_fingerprint(nodes: list[Any]) -> list[tuple[Any, ...]]:
+            rows: list[tuple[Any, ...]] = []
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                rows.append(
+                    (
+                        str(node.get("time") or ""),
+                        node.get("latitude")
+                        if node.get("latitude") is not None
+                        else node.get("lat"),
+                        node.get("longitude")
+                        if node.get("longitude") is not None
+                        else node.get("lon"),
+                        node.get("windSpeed")
+                        if node.get("windSpeed") is not None
+                        else node.get("wind_speed"),
+                        node.get("pressure"),
+                        str(
+                            node.get("typeNameCN")
+                            or node.get("type")
+                            or node.get("level")
+                            or ""
+                        ),
+                    )
+                )
+            return rows
+
+        key_obj = {
+            "type": "typhoon_map",
+            "typhoon_id": typhoon_id,
+            "updated_at": updated_at,
+            "history": _track_fingerprint(history),
+            "future": _track_fingerprint(future),
+            "map_source": map_source or "PetalMap矢量图暗",
+            "playwright_mode": playwright_mode or "local",
+        }
+        return json.dumps(key_obj, sort_keys=True, ensure_ascii=False, default=str)
 
     @staticmethod
     def _build_map_cache_key(lat: float, lon: float, config: dict[str, Any]) -> str:
@@ -279,6 +340,12 @@ class MessageBuildService:
 
         # S-Net 测站分布图（替代通用地图）
         await self._append_snet_map_if_needed(chain, event, source_id=source_id)
+        # 台风路径图（EQSC 富化轨迹）
+        await self._append_typhoon_map_if_needed(
+            chain,
+            event,
+            message_format_config=message_format_config,
+        )
         # 地图渲染与插入（S-Net 跳过，避免重复）
         if source_id != "snet_msil":
             await self._append_map_if_needed(
@@ -425,6 +492,64 @@ class MessageBuildService:
             # 不删除 out：交给 RenderImageCache / 临时目录清理服务回收
         except Exception as e:
             logger.error(f"[灾害预警] S-Net 测站图渲染失败: {e}")
+
+    async def _append_typhoon_map_if_needed(
+        self,
+        chain: MessageChain,
+        event: EventEnvelope,
+        *,
+        message_format_config: dict[str, Any],
+    ) -> None:
+        """为台风事件附加路径图（需 history_track，走 RenderImageCache）。"""
+        domain_event = self._get_domain_event(event)
+        if not isinstance(domain_event, TyphoonEvent):
+            return
+
+        renderer = getattr(self.manager, "typhoon_map_renderer", None)
+        if renderer is None:
+            return
+        can_render = getattr(renderer, "can_render", None)
+        if callable(can_render) and not can_render(domain_event):
+            return
+
+        # 台风路径图使用独立瓦片配置，不与地震通用地图 map_source 混用。
+        map_source = (
+            message_format_config.get("typhoon_map_source") or "PetalMap矢量图暗"
+        )
+        if not str(map_source).strip():
+            map_source = "PetalMap矢量图暗"
+        playwright_mode = message_format_config.get("playwright_mode") or (
+            self.manager.config.get("message_format", {}) or {}
+        ).get("playwright_mode", "local")
+        cache_key = self._build_typhoon_map_cache_key(
+            domain_event,
+            map_source=str(map_source),
+            playwright_mode=str(playwright_mode),
+        )
+        try:
+
+            async def _render_typhoon() -> str | None:
+                safe_id = str(domain_event.typhoon_id or "unknown").replace("/", "_")
+                img_path = os.path.join(
+                    str(self.manager.temp_dir),
+                    f"typhoon_map_{safe_id}.png",
+                )
+                return await renderer.render(
+                    domain_event,
+                    img_path,
+                    map_source=str(map_source),
+                    playwright_mode=str(playwright_mode),
+                )
+
+            out = await self.manager._render_with_cache(cache_key, _render_typhoon)
+            if not out or not os.path.exists(out):
+                return
+            with open(out, "rb") as f:
+                b64_data = base64.b64encode(f.read()).decode()
+            chain.chain.append(Comp.Image.fromBase64(b64_data))
+            logger.debug("[灾害预警] 已附加台风路径图")
+        except Exception as e:
+            logger.error(f"[灾害预警] 台风路径图渲染失败: {e}")
 
     async def _append_map_if_needed(
         self,

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -168,6 +168,9 @@ class PushExecutionService:
                         "map_source": message_format_config.get(
                             "map_source", "PetalMap矢量图亮"
                         ),
+                        "typhoon_map_source": message_format_config.get(
+                            "typhoon_map_source", "PetalMap矢量图暗"
+                        ),
                         "map_zoom_level": message_format_config.get(
                             "map_zoom_level", 5
                         ),

--- a/core/message/render/typhoon_map_renderer.py
+++ b/core/message/render/typhoon_map_renderer.py
@@ -27,8 +27,9 @@ from ...domain.typhoon.typhoon_levels import level_weight
 from ...domain.typhoon.typhoon_values import clean_text, to_float
 from ...domain.typhoon.typhoon_winds import clean_wind_circle
 
-# 台风卡片固定画布；渲染时临时放大浏览器视口，避免 800×800 池默认值裁切。
-TYPHOON_VIEWPORT = {"width": 1600, "height": 1200}
+# 台风卡片固定画布（与 typhoon_track.html 的 1400×1000 对齐）；
+# 渲染时临时放大浏览器视口，避免 800×800 池默认值裁切。
+TYPHOON_VIEWPORT = {"width": 1400, "height": 1000}
 
 # 默认视野（西北太平洋常见台风活动区），轨迹过短时兜底。
 DEFAULT_LON_MIN = 100.0
@@ -159,8 +160,8 @@ def _format_panel_time(value: Any) -> str:
     return TimeConverter._safe_strftime(local, "%Y年%m月%d日%H:%M:%S")
 
 
-def _format_table_time(value: Any) -> str:
-    """表格时间：MM/DD HH:MM。"""
+def _format_compact_time(value: Any) -> str:
+    """紧凑时间：MM/DD HH:MM（表格行与迷你图刻度共用）。"""
     parsed = _parse_node_time(value)
     if parsed is None:
         text = clean_text(value)
@@ -208,7 +209,7 @@ def _build_table_rows(
         pr = to_float(node.get("pressure"))
         rows.append(
             {
-                "time": _format_table_time(node.get("time")),
+                "time": _format_compact_time(node.get("time")),
                 "pos": _format_pos(lat, lon),
                 "ws": f"{ws:g}" if ws is not None else "",
                 "pr": f"{pr:g}" if pr is not None else "",
@@ -307,16 +308,6 @@ def _compute_view_bounds(
         mid = (DEFAULT_LAT_MIN + DEFAULT_LAT_MAX) / 2.0
         la, ha = mid - 1.0, mid + 1.0
     return lo, hi, la, ha
-
-
-def _format_chart_time(value: Any) -> str:
-    """迷你图时间刻度：MM/DD HH:MM。"""
-    parsed = _parse_node_time(value)
-    if parsed is None:
-        text = clean_text(value)
-        return text[:11] if text else ""
-    local = parsed.astimezone(TimeConverter._get_timezone("UTC+8"))
-    return TimeConverter._safe_strftime(local, "%m/%d %H:%M")
 
 
 def _format_signed_delta(delta: float | None, unit: str, *, digits: int = 0) -> str:
@@ -423,6 +414,8 @@ class TyphoonMapRenderer:
         self.plugin_root = plugin_root
         self._template_cache: str | None = None
         self._template_mtime: float | None = None
+        self._helper_js_cache: str | None = None
+        self._helper_js_mtime: float | None = None
 
     def _get_template(self) -> str:
         """读取 HTML 模板原文（含占位符）。
@@ -449,6 +442,28 @@ class TyphoonMapRenderer:
             self._template_cache = f.read()
         self._template_mtime = mtime
         return self._template_cache
+
+    def _get_helper_js(self) -> str:
+        """读取 map_render_helper.js（按 mtime 缓存，避免每次渲染重复读盘）。"""
+        helper_path = os.path.join(
+            self.plugin_root,
+            "resources",
+            "card_templates",
+            "map_render_helper.js",
+        )
+        if not os.path.exists(helper_path):
+            raise FileNotFoundError(f"地图渲染辅助脚本未找到: {helper_path}")
+        mtime = os.path.getmtime(helper_path)
+        if (
+            self._helper_js_cache is not None
+            and self._helper_js_mtime is not None
+            and mtime == self._helper_js_mtime
+        ):
+            return self._helper_js_cache
+        with open(helper_path, encoding="utf-8") as f:
+            self._helper_js_cache = f.read()
+        self._helper_js_mtime = mtime
+        return self._helper_js_cache
 
     def can_render(self, data: TyphoonEvent | dict[str, Any] | None) -> bool:
         """是否具备可渲染轨迹（至少一个有效历史点）。"""
@@ -537,11 +552,7 @@ class TyphoonMapRenderer:
         leaflet_css_path = Path(
             os.path.abspath(os.path.join(resources_dir, "leaflet.css"))
         )
-        helper_path = os.path.abspath(
-            os.path.join(resources_dir, "map_render_helper.js")
-        )
-        with open(helper_path, encoding="utf-8") as f:
-            helper_js = f.read()
+        helper_js = self._get_helper_js()
 
         # remote Playwright 无法读本地 file:// 时，回退 CDN。
         if playwright_mode == "remote":
@@ -653,7 +664,7 @@ class TyphoonMapRenderer:
             for n in chart_nodes
         ]
         chart_press = [float(to_float(n.get("pressure")) or 0.0) for n in chart_nodes]
-        chart_times = [_format_chart_time(n.get("time")) for n in chart_nodes]
+        chart_times = [_format_compact_time(n.get("time")) for n in chart_nodes]
 
         lo, hi, la, ha = _compute_view_bounds(history, future)
         event_name = (

--- a/core/message/render/typhoon_map_renderer.py
+++ b/core/message/render/typhoon_map_renderer.py
@@ -1,0 +1,735 @@
+"""
+message/render/typhoon_map_renderer.py — 台风路径图渲染器（Playwright 版）。
+
+设计原则（改模板为主，薄渲染器）：
+1. 模板直接消费 EQSC 原生 history_track / future_track / windCircle 字段。
+2. 本文件只做：轨迹排序清洗、面板摘要、bootstrap JSON 注入、Playwright 截图。
+3. 不引入 TyphoonTrackPoint 中间模型，也不单独拆完整 adapter 模块。
+4. HTML 模板刻意避免 Jinja 语法，改用占位符替换，避免 IDE 对模板误报爆红。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from astrbot.api import logger
+
+from ....utils.map_tile_sources import get_tile_url_js
+from ....utils.time_converter import TimeConverter
+from ....utils.version import get_plugin_version
+from ...domain.event_models import TyphoonEvent
+from ...domain.typhoon.typhoon_display_format import format_coordinates
+from ...domain.typhoon.typhoon_levels import level_weight
+from ...domain.typhoon.typhoon_values import clean_text, to_float
+from ...domain.typhoon.typhoon_winds import clean_wind_circle
+
+# 台风卡片固定画布；渲染时临时放大浏览器视口，避免 800×800 池默认值裁切。
+TYPHOON_VIEWPORT = {"width": 1600, "height": 1200}
+
+# 默认视野（西北太平洋常见台风活动区），轨迹过短时兜底。
+DEFAULT_LON_MIN = 100.0
+DEFAULT_LON_MAX = 170.0
+DEFAULT_LAT_MIN = 5.0
+DEFAULT_LAT_MAX = 45.0
+
+# 强度等级 0-6 对应配色（与模板 CAT_COLORS 保持一致）。
+CAT_COLORS: dict[int, tuple[int, int, int]] = {
+    0: (120, 120, 130),
+    1: (50, 175, 255),
+    2: (50, 215, 115),
+    3: (255, 215, 40),
+    4: (255, 160, 10),
+    5: (245, 95, 10),
+    6: (225, 40, 40),
+}
+
+# 面板风圈展示：标签 / EQSC 键 / RGB。
+RADII_META: list[tuple[str, str, tuple[int, int, int]]] = [
+    ("7级", "30KTS", (100, 180, 255)),
+    ("10级", "50KTS", (255, 200, 50)),
+    ("12级", "64KTS", (255, 80, 0)),
+]
+
+QUADRANT_CN = {"NE": "东", "SE": "南", "SW": "西", "NW": "北"}
+DEFAULT_MAP_SOURCE = "PetalMap矢量图暗"
+
+# 模板占位符：渲染时整体替换，模板文件本身保持合法 HTML/JS。
+_PLACEHOLDER_BOOTSTRAP = "__TYPHOON_BOOTSTRAP_JSON__"
+_PLACEHOLDER_LEAFLET_JS = "__LEAFLET_JS_URL__"
+_PLACEHOLDER_LEAFLET_CSS = "__LEAFLET_CSS_URL__"
+_PLACEHOLDER_HELPER_JS = "__MAP_RENDER_HELPER_JS__"
+
+
+def _parse_node_time(value: Any) -> datetime | None:
+    """解析轨迹节点时间；无时区时按 UTC+8 解释（与 EQSC/FAN 业务习惯一致）。"""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = TimeConverter.parse_datetime(str(value).strip())
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=TimeConverter._get_timezone("UTC+8"))
+    return parsed
+
+
+def _node_time_key(node: dict[str, Any]) -> float:
+    """排序键：无效时间沉底为 0。"""
+    parsed = _parse_node_time(node.get("time"))
+    return parsed.timestamp() if parsed is not None else 0.0
+
+
+def _node_lat_lon(node: dict[str, Any]) -> tuple[float | None, float | None]:
+    """兼容 latitude/lat、longitude/lon 两套键名。"""
+    lat = to_float(
+        node.get("latitude") if node.get("latitude") is not None else node.get("lat")
+    )
+    lon = to_float(
+        node.get("longitude") if node.get("longitude") is not None else node.get("lon")
+    )
+    return lat, lon
+
+
+def _node_level_text(node: dict[str, Any]) -> str:
+    """提取节点强度文案（优先中文 typeNameCN）。"""
+    return clean_text(
+        node.get("typeNameCN")
+        or node.get("type")
+        or node.get("level")
+        or node.get("typhoon_type")
+    )
+
+
+def _node_wind_circle(node: dict[str, Any]) -> dict[str, Any]:
+    """清洗节点四象限风圈，剔除 NULL/空象限。"""
+    raw = (
+        node.get("windCircle")
+        if node.get("windCircle") is not None
+        else node.get("wind_circle")
+    )
+    return clean_wind_circle(raw)
+
+
+def _normalize_track_nodes(nodes: Any) -> list[dict[str, Any]]:
+    """保留 EQSC 原生字段，仅做排序、坐标校验与风圈清洗。
+
+    注意：这里不做“适配成 TyphoonTrackPoint”的完整转换，
+    只保证模板 JS 能稳定读到 latitude/longitude/windSpeed/typeNameCN/windCircle。
+    """
+    if not isinstance(nodes, list):
+        return []
+    cleaned: list[dict[str, Any]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        lat, lon = _node_lat_lon(node)
+        if lat is None or lon is None:
+            continue
+        item = dict(node)
+        item["latitude"] = lat
+        item["longitude"] = lon
+        # 统一风速别名，模板侧优先读 windSpeed。
+        if item.get("windSpeed") is None and item.get("wind_speed") is not None:
+            item["windSpeed"] = item.get("wind_speed")
+        level = _node_level_text(item)
+        if level and not item.get("typeNameCN"):
+            item["typeNameCN"] = level
+        circle = _node_wind_circle(item)
+        if circle:
+            item["windCircle"] = circle
+        cleaned.append(item)
+    # EQSC historyTrack 顺序不保证，统一按时间升序。
+    cleaned.sort(key=_node_time_key)
+    return cleaned
+
+
+def _format_panel_time(value: Any) -> str:
+    """面板更新时间：YYYY年MM月DD日HH:MM:SS（北京时间）。"""
+    parsed = _parse_node_time(value)
+    if parsed is None:
+        text = clean_text(value)
+        return text or ""
+    local = parsed.astimezone(TimeConverter._get_timezone("UTC+8"))
+    return TimeConverter._safe_strftime(local, "%Y年%m月%d日%H:%M:%S")
+
+
+def _format_table_time(value: Any) -> str:
+    """表格时间：MM/DD HH:MM。"""
+    parsed = _parse_node_time(value)
+    if parsed is None:
+        text = clean_text(value)
+        return text[:11] if text else ""
+    local = parsed.astimezone(TimeConverter._get_timezone("UTC+8"))
+    return TimeConverter._safe_strftime(local, "%m/%d %H:%M")
+
+
+def _format_pos(lat: float | None, lon: float | None) -> str:
+    """表格坐标：压缩 format_coordinates 结果，节省列宽。
+
+    例：14.2°N, 118.5°E → 14.2N 118.5E（空格分隔，避免与风速列粘连）。
+    """
+    text = format_coordinates(lat, lon)
+    if not text:
+        return ""
+    return text.replace("°", "").replace(",", " ").replace("  ", " ").strip()
+
+
+def _cat_color_css(cat: int) -> str:
+    rgb = CAT_COLORS.get(int(cat or 0), CAT_COLORS[0])
+    return f"rgb({rgb[0]},{rgb[1]},{rgb[2]})"
+
+
+def _build_table_rows(
+    nodes: list[dict[str, Any]],
+    *,
+    reverse: bool = False,
+    limit: int | None = None,
+) -> list[dict[str, str]]:
+    """构建左右栏表格行（预报/历史共用）。"""
+    seq = list(reversed(nodes)) if reverse else list(nodes)
+    if isinstance(limit, int) and limit > 0:
+        seq = seq[:limit]
+    rows: list[dict[str, str]] = []
+    for node in seq:
+        lat, lon = _node_lat_lon(node)
+        level = _node_level_text(node)
+        cat = level_weight(level)
+        ws = to_float(
+            node.get("windSpeed")
+            if node.get("windSpeed") is not None
+            else node.get("wind_speed")
+        )
+        pr = to_float(node.get("pressure"))
+        rows.append(
+            {
+                "time": _format_table_time(node.get("time")),
+                "pos": _format_pos(lat, lon),
+                "ws": f"{ws:g}" if ws is not None else "",
+                "pr": f"{pr:g}" if pr is not None else "",
+                "cat": level or "",
+                "cat_color": _cat_color_css(cat),
+            }
+        )
+    return rows
+
+
+def _build_wind_radii_panel(wind_circle: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """把四象限风圈整理成面板可读行。"""
+    cleaned = clean_wind_circle(wind_circle or {})
+    rows: list[dict[str, Any]] = []
+    for label, key, color in RADII_META:
+        circle = cleaned.get(key)
+        if not isinstance(circle, dict):
+            continue
+        parts: list[str] = []
+        for qk in ("NE", "SE", "SW", "NW"):
+            val = to_float(circle.get(qk))
+            if val is None or val <= 0:
+                continue
+            parts.append(f"{QUADRANT_CN.get(qk, qk)}{int(val)}km")
+        if not parts:
+            continue
+        # 两两一行，避免面板过宽。
+        lines = [" ".join(parts[i : i + 2]) for i in range(0, len(parts), 2)]
+        rows.append(
+            {
+                "label": label,
+                "lines": lines,
+                "color_rgb": f"{color[0]},{color[1]},{color[2]}",
+            }
+        )
+    return rows
+
+
+def _compute_view_bounds(
+    history: list[dict[str, Any]],
+    future: list[dict[str, Any]],
+) -> tuple[float, float, float, float]:
+    """按路径点四至（最西/最东/最南/最北）计算地图视野。
+
+    规则：
+    1. 取 history + future 全部有效点的 lon/lat 极值；
+    2. 按跨度加少量 padding（约 8%，夹在 0.3°~1.2°）；
+    3. 跨度过小时给最小框，避免 zoom 过大；
+    4. 结果限制在默认大区内兜底。
+    """
+    lons: list[float] = []
+    lats: list[float] = []
+    for node in history + future:
+        lat, lon = _node_lat_lon(node)
+        if lat is None or lon is None:
+            continue
+        lats.append(lat)
+        lons.append(lon)
+    if not lons or not lats:
+        return DEFAULT_LON_MIN, DEFAULT_LON_MAX, DEFAULT_LAT_MIN, DEFAULT_LAT_MAX
+
+    # 四至：最西/最东/最南/最北
+    lon_min, lon_max = min(lons), max(lons)
+    lat_min, lat_max = min(lats), max(lats)
+
+    lon_span = max(lon_max - lon_min, 0.05)
+    lat_span = max(lat_max - lat_min, 0.05)
+
+    # 按跨度自适应 padding：短路径多留一点，长路径少留
+    pad_lon = min(max(lon_span * 0.08, 0.3), 1.2)
+    pad_lat = min(max(lat_span * 0.08, 0.3), 1.2)
+
+    lo = lon_min - pad_lon
+    hi = lon_max + pad_lon
+    la = lat_min - pad_lat
+    ha = lat_max + pad_lat
+
+    # 短轨迹最小跨度（度）
+    min_span = 2.0
+    if hi - lo < min_span:
+        c = (lo + hi) / 2.0
+        lo, hi = c - min_span / 2.0, c + min_span / 2.0
+    if ha - la < min_span:
+        c = (la + ha) / 2.0
+        la, ha = c - min_span / 2.0, c + min_span / 2.0
+
+    # 兜底夹在默认大区
+    lo = max(lo, DEFAULT_LON_MIN)
+    hi = min(hi, DEFAULT_LON_MAX)
+    la = max(la, DEFAULT_LAT_MIN)
+    ha = min(ha, DEFAULT_LAT_MAX)
+    if hi <= lo:
+        mid = (DEFAULT_LON_MIN + DEFAULT_LON_MAX) / 2.0
+        lo, hi = mid - 1.0, mid + 1.0
+    if ha <= la:
+        mid = (DEFAULT_LAT_MIN + DEFAULT_LAT_MAX) / 2.0
+        la, ha = mid - 1.0, mid + 1.0
+    return lo, hi, la, ha
+
+
+def _format_chart_time(value: Any) -> str:
+    """迷你图时间刻度：MM/DD HH:MM。"""
+    parsed = _parse_node_time(value)
+    if parsed is None:
+        text = clean_text(value)
+        return text[:11] if text else ""
+    local = parsed.astimezone(TimeConverter._get_timezone("UTC+8"))
+    return TimeConverter._safe_strftime(local, "%m/%d %H:%M")
+
+
+def _format_signed_delta(delta: float | None, unit: str, *, digits: int = 0) -> str:
+    """格式化带符号变化量，如 +2m/s / -3hPa。"""
+    if delta is None:
+        return ""
+    if abs(delta) < 0.05:
+        return f"0{unit}"
+    q = round(delta, digits) if digits > 0 else int(round(delta))
+    if digits > 0:
+        text = f"{q:+.{digits}f}".rstrip("0").rstrip(".")
+    else:
+        text = f"{q:+d}"
+    return f"{text}{unit}"
+
+
+def _build_intensity_trend(
+    *,
+    wind_speed: float | None,
+    pressure: float | None,
+    prev_ws: float | None,
+    prev_pr: float | None,
+    category_name: str,
+    prev_level: str,
+) -> tuple[str, str]:
+    """综合风速/气压/等级给出强度趋势文案与样式类。"""
+    score = 0
+    if wind_speed is not None and prev_ws is not None:
+        d = wind_speed - prev_ws
+        if d > 0.5:
+            score += 1
+        elif d < -0.5:
+            score -= 1
+    if pressure is not None and prev_pr is not None:
+        d = pressure - prev_pr
+        # 气压下降通常意味着增强
+        if d < -0.5:
+            score += 1
+        elif d > 0.5:
+            score -= 1
+    cat_now = level_weight(category_name)
+    cat_prev = level_weight(prev_level)
+    if cat_now > cat_prev:
+        score += 1
+    elif cat_now < cat_prev:
+        score -= 1
+
+    if score >= 1:
+        return "强度增强", "intensity-up"
+    if score <= -1:
+        return "强度减弱", "intensity-down"
+    return "强度稳定", "intensity-flat"
+
+
+def _resolve_source_label(
+    data_source: str | None, source_label: str | None = None
+) -> str:
+    """统一来源角标文案（EQSC / FAN / LOCAL）。"""
+    text = clean_text(source_label) or clean_text(data_source)
+    low = text.lower()
+    if "eqsc" in low:
+        return "EQSC"
+    if "fan" in low:
+        return "FAN"
+    if "local" in low or "本地" in text:
+        return "LOCAL"
+    if text:
+        return text.upper()
+    return "EQSC"
+
+
+def _extract_payload(data: TyphoonEvent | dict[str, Any]) -> dict[str, Any]:
+    """统一 TyphoonEvent / TyphoonQueryItem 为渲染输入字典。"""
+    if isinstance(data, TyphoonEvent):
+        return {
+            "typhoon_id": data.typhoon_id,
+            "name": data.name,
+            "name_en": data.name_en,
+            "display_name": data.name or data.name_en or data.typhoon_id,
+            "typhoon_type": data.typhoon_type,
+            "latitude": data.latitude,
+            "longitude": data.longitude,
+            "pressure": data.pressure,
+            "wind_speed": data.wind_speed,
+            "move_direction": data.move_direction,
+            "move_speed": data.move_speed,
+            "updated_at": data.updated_at,
+            "history_track": list(data.history_track or []),
+            "future_track": list(data.future_track or []),
+            "wind_circle": dict(data.wind_circle or {}),
+            "data_source": "eqsc",
+            "source_label": "EQSC",
+        }
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+class TyphoonMapRenderer:
+    """台风路径图渲染器（Playwright，EQSC 原生字段契约）。"""
+
+    def __init__(self, browser_manager=None, plugin_root: str = ""):
+        self.browser_manager = browser_manager
+        self.plugin_root = plugin_root
+        self._template_cache: str | None = None
+        self._template_mtime: float | None = None
+
+    def _get_template(self) -> str:
+        """读取 HTML 模板原文（含占位符）。
+
+        按文件 mtime 失效缓存，避免热更新后仍用旧模板导致视野/样式不生效。
+        """
+        template_path = os.path.join(
+            self.plugin_root,
+            "resources",
+            "card_templates",
+            "Typhoon",
+            "typhoon_track.html",
+        )
+        if not os.path.exists(template_path):
+            raise FileNotFoundError(f"台风模板未找到: {template_path}")
+        mtime = os.path.getmtime(template_path)
+        if (
+            self._template_cache is not None
+            and self._template_mtime is not None
+            and mtime == self._template_mtime
+        ):
+            return self._template_cache
+        with open(template_path, encoding="utf-8") as f:
+            self._template_cache = f.read()
+        self._template_mtime = mtime
+        return self._template_cache
+
+    def can_render(self, data: TyphoonEvent | dict[str, Any] | None) -> bool:
+        """是否具备可渲染轨迹（至少一个有效历史点）。"""
+        if data is None:
+            return False
+        payload = _extract_payload(data)
+        history = _normalize_track_nodes(payload.get("history_track"))
+        return len(history) >= 1
+
+    async def render(
+        self,
+        data: TyphoonEvent | dict[str, Any],
+        output_path: str,
+        *,
+        map_source: str | None = None,
+        playwright_mode: str = "local",
+    ) -> str | None:
+        """渲染台风路径图到 output_path，成功返回路径，失败返回 None。"""
+        payload = _extract_payload(data)
+        history = _normalize_track_nodes(payload.get("history_track"))
+        future = _normalize_track_nodes(payload.get("future_track"))
+        if not history:
+            logger.warning("[灾害预警] 台风路径图跳过：无有效 history_track")
+            return None
+
+        try:
+            html_content = self._render_html(
+                payload,
+                history=history,
+                future=future,
+                map_source=map_source or DEFAULT_MAP_SOURCE,
+                playwright_mode=playwright_mode,
+            )
+        except Exception as e:
+            logger.error(f"[灾害预警] 台风模板渲染失败: {e}", exc_info=True)
+            return None
+
+        if not self.browser_manager:
+            logger.warning("[灾害预警] 无浏览器管理器，跳过台风路径图渲染")
+            return None
+
+        try:
+            # 与 S-Net 一致：临时放大视口后截 #card-wrapper。
+            result = await self.browser_manager.render_card(
+                html_content,
+                output_path,
+                selector="#card-wrapper",
+                wait_until="domcontentloaded",
+                viewport=TYPHOON_VIEWPORT,
+            )
+            if result and os.path.exists(output_path):
+                logger.info(
+                    f"[灾害预警] 台风路径图已生成 "
+                    f"({os.path.getsize(output_path)} bytes): {output_path}"
+                )
+                return output_path
+            logger.warning("[灾害预警] 台风路径图渲染未生成文件")
+            return None
+        except Exception as e:
+            logger.error(
+                f"[灾害预警] 台风路径图 Playwright 渲染失败: {e}",
+                exc_info=True,
+            )
+            return None
+
+    def _render_html(
+        self,
+        payload: dict[str, Any],
+        *,
+        history: list[dict[str, Any]],
+        future: list[dict[str, Any]],
+        map_source: str,
+        playwright_mode: str,
+    ) -> str:
+        """把 bootstrap / 静态资源 URL 注入模板占位符。"""
+        bootstrap = self._build_bootstrap(
+            payload,
+            history=history,
+            future=future,
+            map_source=map_source,
+        )
+        resources_dir = os.path.join(self.plugin_root, "resources", "card_templates")
+        leaflet_js_path = Path(
+            os.path.abspath(os.path.join(resources_dir, "leaflet.js"))
+        )
+        leaflet_css_path = Path(
+            os.path.abspath(os.path.join(resources_dir, "leaflet.css"))
+        )
+        helper_path = os.path.abspath(
+            os.path.join(resources_dir, "map_render_helper.js")
+        )
+        with open(helper_path, encoding="utf-8") as f:
+            helper_js = f.read()
+
+        # remote Playwright 无法读本地 file:// 时，回退 CDN。
+        if playwright_mode == "remote":
+            leaflet_js_url = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            leaflet_css_url = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        else:
+            leaflet_js_url = leaflet_js_path.as_uri()
+            leaflet_css_url = leaflet_css_path.as_uri()
+
+        html = self._get_template()
+        html = html.replace(
+            _PLACEHOLDER_BOOTSTRAP,
+            json.dumps(bootstrap, ensure_ascii=False, default=str),
+        )
+        html = html.replace(_PLACEHOLDER_LEAFLET_JS, leaflet_js_url)
+        html = html.replace(_PLACEHOLDER_LEAFLET_CSS, leaflet_css_url)
+        html = html.replace(_PLACEHOLDER_HELPER_JS, helper_js)
+        return html
+
+    def _build_bootstrap(
+        self,
+        payload: dict[str, Any],
+        *,
+        history: list[dict[str, Any]],
+        future: list[dict[str, Any]],
+        map_source: str,
+    ) -> dict[str, Any]:
+        """组装模板 bootstrap JSON（面板 + 轨迹 + 视野 + 瓦片）。"""
+        latest = history[-1]
+        prev = history[-2] if len(history) >= 2 else None
+
+        # 面板优先用顶层字段，缺失时回退最新历史点。
+        lat = to_float(payload.get("latitude"))
+        lon = to_float(payload.get("longitude"))
+        if lat is None or lon is None:
+            lat, lon = _node_lat_lon(latest)
+
+        wind_speed = to_float(payload.get("wind_speed"))
+        if wind_speed is None:
+            wind_speed = to_float(
+                latest.get("windSpeed")
+                if latest.get("windSpeed") is not None
+                else latest.get("wind_speed")
+            )
+        pressure = to_float(payload.get("pressure"))
+        if pressure is None:
+            pressure = to_float(latest.get("pressure"))
+
+        category_name = clean_text(payload.get("typhoon_type")) or _node_level_text(
+            latest
+        )
+        cat = level_weight(category_name)
+        cat_rgb = CAT_COLORS.get(cat, CAT_COLORS[0])
+
+        # 相对上一历史点的风速/气压变化量（数值中性色 + 小标签，避免箭头语义歧义）。
+        ws_delta_text = ""
+        pr_delta_text = ""
+        ws_delta_class = "delta-flat"
+        pr_delta_class = "delta-flat"
+        intensity_trend_text = "强度稳定"
+        intensity_trend_class = "intensity-flat"
+        prev_ws = None
+        prev_pr = None
+        prev_level = ""
+        if prev is not None:
+            prev_ws = to_float(
+                prev.get("windSpeed")
+                if prev.get("windSpeed") is not None
+                else prev.get("wind_speed")
+            )
+            prev_pr = to_float(prev.get("pressure"))
+            prev_level = _node_level_text(prev)
+            if prev_ws is not None and wind_speed is not None:
+                d_ws = wind_speed - prev_ws
+                if abs(d_ws) >= 0.5:
+                    ws_delta_text = _format_signed_delta(d_ws, "m/s")
+                    ws_delta_class = "delta-up" if d_ws > 0 else "delta-down"
+            if prev_pr is not None and pressure is not None:
+                d_pr = pressure - prev_pr
+                if abs(d_pr) >= 0.5:
+                    pr_delta_text = _format_signed_delta(d_pr, "hPa")
+                    # 气压标签只表达数值升降，用中性蓝灰，避免红色误导
+                    pr_delta_class = "delta-pr-up" if d_pr > 0 else "delta-pr-down"
+            intensity_trend_text, intensity_trend_class = _build_intensity_trend(
+                wind_speed=wind_speed,
+                pressure=pressure,
+                prev_ws=prev_ws,
+                prev_pr=prev_pr,
+                category_name=category_name,
+                prev_level=prev_level,
+            )
+
+        wind_circle = payload.get("wind_circle")
+        if not isinstance(wind_circle, dict) or not wind_circle:
+            wind_circle = _node_wind_circle(latest)
+        wind_radii = _build_wind_radii_panel(wind_circle)
+
+        # 迷你折线图：最近 24 个历史点 + 时间刻度。
+        chart_nodes = history[-24:] if len(history) >= 2 else history
+        chart_winds = [
+            float(
+                to_float(
+                    n.get("windSpeed")
+                    if n.get("windSpeed") is not None
+                    else n.get("wind_speed")
+                )
+                or 0.0
+            )
+            for n in chart_nodes
+        ]
+        chart_press = [float(to_float(n.get("pressure")) or 0.0) for n in chart_nodes]
+        chart_times = [_format_chart_time(n.get("time")) for n in chart_nodes]
+
+        lo, hi, la, ha = _compute_view_bounds(history, future)
+        event_name = (
+            clean_text(
+                payload.get("display_name")
+                or payload.get("name")
+                or payload.get("name_en")
+                or payload.get("typhoon_id")
+            )
+            or "未知台风"
+        )
+        event_code = (
+            clean_text(payload.get("typhoon_id") or payload.get("eqsc_id")) or "--"
+        )
+        source = _resolve_source_label(
+            str(payload.get("data_source") or ""),
+            str(payload.get("source_label") or ""),
+        )
+        move_dir = clean_text(
+            payload.get("move_direction")
+            or latest.get("directionCN")
+            or latest.get("direction")
+        )
+        move_speed_val = to_float(payload.get("move_speed"))
+        if move_speed_val is None:
+            move_speed_val = to_float(latest.get("speed") or latest.get("moveSpeed"))
+
+        version = get_plugin_version()
+        watermark_text = (
+            f"@DBJD-CR/astrbot_plugin_disaster_warning (灾害预警) {version} · 台风路径"
+        )
+
+        return {
+            # 轨迹：模板 JS 直接 normalize EQSC 节点
+            "history": history,
+            "forecast": future,
+            "view": {"lo": lo, "hi": hi, "la": la, "ha": ha},
+            "chart_winds": chart_winds,
+            "chart_pressures": chart_press,
+            "chart_times": chart_times,
+            "tile_url": get_tile_url_js(map_source or DEFAULT_MAP_SOURCE),
+            "wind_radii": wind_radii,
+            "forecast_rows": _build_table_rows(future, limit=12),
+            "history_rows": _build_table_rows(history, reverse=True),
+            "panel": {
+                "event_name": event_name,
+                "event_code": event_code,
+                "source": source,
+                "category_name": category_name,
+                "cat_color_rgb": f"{cat_rgb[0]},{cat_rgb[1]},{cat_rgb[2]}",
+                "wind_speed": (
+                    f"{wind_speed:.0f}m/s" if wind_speed is not None else "--"
+                ),
+                "pressure": f"{pressure:.0f}hPa" if pressure is not None else "--",
+                # 兼容旧字段（模板已不再依赖箭头染色）
+                "ws_trend": "",
+                "pr_trend": "",
+                "ws_delta_text": ws_delta_text,
+                "pr_delta_text": pr_delta_text,
+                "ws_delta_class": ws_delta_class,
+                "pr_delta_class": pr_delta_class,
+                "intensity_trend_text": intensity_trend_text,
+                "intensity_trend_class": intensity_trend_class,
+                "position": format_coordinates(lat, lon) or "--",
+                "move_dir": move_dir,
+                "move_speed": (
+                    f"{move_speed_val:.0f}km/h" if move_speed_val is not None else ""
+                ),
+                "update_time": _format_panel_time(
+                    payload.get("updated_at")
+                    or payload.get("updated_at_text")
+                    or latest.get("time")
+                ),
+                "watermark_text": watermark_text,
+            },
+        }
+
+
+__all__ = ["TyphoonMapRenderer", "TYPHOON_VIEWPORT"]

--- a/core/message/runtime/bootstrap_service.py
+++ b/core/message/runtime/bootstrap_service.py
@@ -20,6 +20,7 @@ from ..builders.map_attachment_builder import MapAttachmentBuilder
 from ..builders.text_message_builder import TextMessageBuilder
 from ..render.remote_media_fetcher import RemoteMediaFetcher
 from ..render.snet_map_renderer import SnetMapRenderer
+from ..render.typhoon_map_renderer import TyphoonMapRenderer
 from .browser_manager import BrowserManager
 
 
@@ -35,6 +36,7 @@ class MessageManagerBootstrapService:
         self.card_message_builder = None
         self.global_quake_card_builder = None
         self.snet_map_renderer = None
+        self.typhoon_map_renderer = None
         self.remote_media_fetcher = None
 
     def setup_filters(self, config: dict[str, Any]) -> None:
@@ -81,7 +83,7 @@ class MessageManagerBootstrapService:
 
         # 只有本地浏览器模式且确实需要图形渲染时才后台预热，
         # 这样既能缩短首次渲染等待，也能避免无地图场景白白消耗资源。
-        # include_map / GQ 卡 / S-Net 任一启用都预热。
+        # include_map / GQ 卡 / S-Net / 台风路径图任一启用都预热。
         data_sources = (
             self.manager.config.get("data_sources", {})
             if isinstance(self.manager.config, dict)
@@ -90,10 +92,15 @@ class MessageManagerBootstrapService:
         snet_cfg = (
             data_sources.get("snet", {}) if isinstance(data_sources, dict) else {}
         )
+        typhoon_cfg = (
+            data_sources.get("typhoon", {}) if isinstance(data_sources, dict) else {}
+        )
         need_browser = (
             msg_config.get("include_map", False)
             or msg_config.get("use_global_quake_card", False)
             or bool(isinstance(snet_cfg, dict) and snet_cfg.get("enabled", False))
+            # 台风路径图查询/推送也依赖 Playwright，启用台风源时一并预热。
+            or bool(isinstance(typhoon_cfg, dict) and typhoon_cfg.get("enabled", False))
         )
         if playwright_mode == "local" and need_browser:
             logger.debug("[灾害预警] 检测到已启用卡片渲染功能，正在后台预热浏览器...")
@@ -123,6 +130,10 @@ class MessageManagerBootstrapService:
             browser_manager=self.manager.browser_manager,
         )
         self.snet_map_renderer = SnetMapRenderer(
+            browser_manager=self.manager.browser_manager,
+            plugin_root=self.manager.plugin_root,
+        )
+        self.typhoon_map_renderer = TyphoonMapRenderer(
             browser_manager=self.manager.browser_manager,
             plugin_root=self.manager.plugin_root,
         )

--- a/core/message/runtime/bootstrap_service.py
+++ b/core/message/runtime/bootstrap_service.py
@@ -92,15 +92,19 @@ class MessageManagerBootstrapService:
         snet_cfg = (
             data_sources.get("snet", {}) if isinstance(data_sources, dict) else {}
         )
-        typhoon_cfg = (
-            data_sources.get("typhoon", {}) if isinstance(data_sources, dict) else {}
+        # 台风源实际配置路径：data_sources.fan_studio.china_typhoon（bool）
+        fan_studio_cfg = (
+            data_sources.get("fan_studio", {}) if isinstance(data_sources, dict) else {}
         )
         need_browser = (
             msg_config.get("include_map", False)
             or msg_config.get("use_global_quake_card", False)
             or bool(isinstance(snet_cfg, dict) and snet_cfg.get("enabled", False))
             # 台风路径图查询/推送也依赖 Playwright，启用台风源时一并预热。
-            or bool(isinstance(typhoon_cfg, dict) and typhoon_cfg.get("enabled", False))
+            or bool(
+                isinstance(fan_studio_cfg, dict)
+                and fan_studio_cfg.get("china_typhoon", False)
+            )
         )
         if playwright_mode == "local" and need_browser:
             logger.debug("[灾害预警] 检测到已启用卡片渲染功能，正在后台预热浏览器...")

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -996,26 +996,52 @@ class ConfigValidator:
                 logger.warning("[灾害预警] 配置警告: 浏览器池大小过大，已限制为 10。")
                 cfg["browser_pool_size"] = 10
 
-        # 地图源校验
-        map_source = cfg.get("map_source")
+        # 地图源校验（通用地图 / 台风路径图共用选项表）
         valid_source_ids = set(MAP_TILE_SOURCES.keys())
         valid_source_names = set(MAP_SOURCE_NAME_TO_ID.keys())
-        if map_source is not None:
-            if not isinstance(map_source, str):
+
+        def _validate_map_source_field(
+            field_name: str,
+            *,
+            default_value: str,
+            label: str,
+        ) -> None:
+            value = cfg.get(field_name)
+            if value is None:
+                return
+            if not isinstance(value, str):
                 logger.warning(
-                    f"[灾害预警] 配置警告: 地图源类型错误 ({type(map_source).__name__})，已重置为 PetalMap矢量图亮。"
+                    f"[灾害预警] 配置警告: {label}类型错误 "
+                    f"({type(value).__name__})，已重置为 {default_value}。"
                 )
-                cfg["map_source"] = "PetalMap矢量图亮"
+                cfg[field_name] = default_value
+                return
+            text = value.strip()
+            if not text:
+                cfg[field_name] = default_value
+                return
+            normalized_source = normalize_map_source(text)
+            if (
+                text not in valid_source_names
+                and normalized_source not in valid_source_ids
+            ):
+                # 仅警告，不强制重置，以支持未来扩展或自定义源
+                logger.warning(
+                    f"[灾害预警] 配置警告: {label} {text} 不在标准列表中，请确认是否为自定义源。"
+                )
             else:
-                normalized_source = normalize_map_source(map_source)
-                if (
-                    map_source not in valid_source_names
-                    and normalized_source not in valid_source_ids
-                ):
-                    # 仅警告，不强制重置，以支持未来扩展或自定义源
-                    logger.warning(
-                        f"[灾害预警] 配置警告: 地图源 {map_source} 不在标准列表中，请确认是否为自定义源。"
-                    )
+                cfg[field_name] = text
+
+        _validate_map_source_field(
+            "map_source",
+            default_value="PetalMap矢量图亮",
+            label="地图源",
+        )
+        _validate_map_source_field(
+            "typhoon_map_source",
+            default_value="PetalMap矢量图暗",
+            label="台风路径图瓦片源",
+        )
 
         # Global Quake 模板校验
         gq_template = cfg.get("global_quake_template")

--- a/core/services/query/typhoon_query_presenter.py
+++ b/core/services/query/typhoon_query_presenter.py
@@ -119,7 +119,7 @@ def attach_summary_text(item: dict[str, Any], *, detail: str) -> dict[str, Any]:
 def build_typhoon_query_text(result: dict[str, Any]) -> str:
     """把查询结果格式化为命令侧可读文本。
 
-    - 单条（id）：输出完整摘要。
+    - 单条（id）：直接输出摘要正文。
     - 多条（list/search）：
       - current：紧凑列表
       - full：每条输出完整摘要，条目之间用分隔线区分
@@ -144,6 +144,11 @@ def build_typhoon_query_text(result: dict[str, Any]) -> str:
             lines.extend(f"• {line}" for line in usage)
         return "\n".join(lines)
 
+    # 单条详情不再附加“来源/模式”标题行，直接输出摘要正文。
+    if result.get("query_mode") == "id":
+        data = result.get("data") or {}
+        return str(data.get("summary_text") or "暂无详情")
+
     source = result.get("source") or "unknown"
     detail = result.get("detail") or DETAIL_CURRENT
     source_label = {
@@ -153,15 +158,6 @@ def build_typhoon_query_text(result: dict[str, Any]) -> str:
     fallback_hint = ""
     if result.get("fallback_from") == "eqsc":
         fallback_hint = "，EQSC不可用已回退"
-
-    if result.get("query_mode") == "id":
-        data = result.get("data") or {}
-        header = (
-            f"🌀 台风信息详情（来源：{source_label}{fallback_hint}，"
-            f"模式：{'完整路径' if detail == DETAIL_FULL else '当前信息'}）"
-        )
-        body = data.get("summary_text") or "暂无详情"
-        return f"{header}\n\n{body}"
 
     items = result.get("items") or []
     total = result.get("total", len(items))

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -21,6 +21,8 @@ from ...core.app.services import format_earthquake_list_text, quoted_plain_resul
 from ...core.domain.event_context import EarthquakeDisplayContext
 from ...core.message.presenters.earthquake_presenter import SnetPresenter
 from ...core.message.push.message_build_service import MessageBuildService
+from ...core.services.query.typhoon_query_parser import DETAIL_CURRENT, DETAIL_FULL
+from ...core.services.query.typhoon_query_presenter import attach_summary_text
 from ...core.services.query.typhoon_query_service import (
     build_typhoon_query_text,
     parse_typhoon_query_args,
@@ -29,6 +31,7 @@ from ...core.services.query.typhoon_query_service import (
 from ...core.services.query.weather_query_service import query_weather_alarm_data
 from ...core.services.simulation.simulation_service import build_earthquake_simulation
 from .telemetry_mixin import CommandTelemetryMixin
+from .typhoon_query_image_helper import append_typhoon_track_image
 
 
 class PluginQueryCommandService(CommandTelemetryMixin):
@@ -312,6 +315,8 @@ class PluginQueryCommandService(CommandTelemetryMixin):
 
         优先复用 EQSC 查询逻辑；配置无效或查询失败时回退本地数据库（Fan/EQSC重建）。
         支持指定 ID、名称、数量、活跃过滤与详细程度（当前信息/完整路径）。
+        单台风查询为渲染路径图可内部提升为完整轨迹，但返回文本仍按用户 detail。
+        当结果含 history_track 时，尝试附加台风路径图（列表仅渲首张）。
         """
 
         def _quoted_plain_result(text: str):
@@ -327,15 +332,33 @@ class PluginQueryCommandService(CommandTelemetryMixin):
             enrichment = getattr(
                 self.plugin.disaster_service, "typhoon_enrichment_service", None
             )
+            # 单台风（ID/名称）为出路径图，查询侧将 current 提升为 full 以拿到 history_track；
+            # 文本展示仍尊重用户原始 detail。列表查询（无 ID/名称）不提升，避免批量拉轨迹。
+            user_detail = parsed.get("detail") or DETAIL_CURRENT
+            query_detail = user_detail
+            if user_detail == DETAIL_CURRENT and (
+                parsed.get("typhoon_id") or parsed.get("keyword")
+            ):
+                query_detail = DETAIL_FULL
             result = await query_typhoon_data(
                 db,
                 enrichment,
                 typhoon_id=parsed.get("typhoon_id"),
                 keyword=parsed.get("keyword"),
                 count=parsed.get("count"),
-                detail=parsed.get("detail"),
+                detail=query_detail,
                 active_only=bool(parsed.get("active_only")),
             )
+
+            # 轨迹字段保留给路径图；summary_text / detail 按用户参数重写，避免文本被提升成完整路径。
+            if result.get("success") and query_detail != user_detail:
+                data_item = result.get("data")
+                if isinstance(data_item, dict):
+                    attach_summary_text(data_item, detail=user_detail)
+                for item in result.get("items") or []:
+                    if isinstance(item, dict):
+                        attach_summary_text(item, detail=user_detail)
+                result["detail"] = user_detail
 
             await self._track_command_feature(
                 "command_typhoon_query",
@@ -350,7 +373,33 @@ class PluginQueryCommandService(CommandTelemetryMixin):
                     "result_count": int(result.get("total") or 0),
                 },
             )
-            yield _quoted_plain_result(build_typhoon_query_text(result))
+            text = build_typhoon_query_text(result)
+            chain_parts: list = [Comp.Plain(text)]
+            chain_parts = await append_typhoon_track_image(
+                plugin=self.plugin,
+                result=result,
+                chain_parts=chain_parts,
+            )
+            if len(chain_parts) > 1:
+                try:
+                    if hasattr(self.plugin, "_with_quote_reply"):
+                        yield event.chain_result(
+                            self.plugin._with_quote_reply(event, chain_parts)
+                        )
+                    else:
+                        yield event.chain_result(chain_parts)
+                    return
+                except Exception:
+                    yield _quoted_plain_result(text)
+                    try:
+                        await self.plugin.context.send_message(
+                            event.unified_msg_origin,
+                            MessageChain([chain_parts[1]]),
+                        )
+                    except Exception:
+                        pass
+                    return
+            yield _quoted_plain_result(text)
         except Exception as e:
             logger.error(f"[灾害预警] 查询台风信息失败: {e}")
             yield _quoted_plain_result(f"❌ 查询失败: {e}")

--- a/plugin/commands/typhoon_query_image_helper.py
+++ b/plugin/commands/typhoon_query_image_helper.py
@@ -26,8 +26,9 @@ async def append_typhoon_track_image(
     """若查询结果含可渲染轨迹，则向 chain_parts 追加路径图。
 
     策略：
-    - 优先 result["data"]，否则取 items 中首个含 history_track 的项
-    - 列表多条时只渲第一张，避免一次查询打爆浏览器池
+    - 候选顺序：优先 result["data"]，再按 items 顺序
+    - 遍历候选，渲染首个含有效 history_track 且可以渲染的项
+    - 列表多条时只渲一张，避免一次查询打爆浏览器池
     - 渲染失败不抛出，仅打 warning 并返回原 chain_parts
     """
     if not result.get("success"):
@@ -68,7 +69,7 @@ async def append_typhoon_track_image(
         map_source = "PetalMap矢量图暗"
     playwright_mode = msg_cfg.get("playwright_mode", "local")
 
-    for item in candidates[:1]:
+    for item in candidates:
         history = item.get("history_track") or []
         if not isinstance(history, list) or not history:
             continue
@@ -109,6 +110,8 @@ async def append_typhoon_track_image(
                 with open(out, "rb") as f:
                     b64 = base64.b64encode(f.read()).decode()
                 chain_parts.append(Comp.Image.fromBase64(b64))
+                # 只渲首张可渲染路径图，避免列表查询打爆浏览器池。
+                break
         except Exception as render_err:
             logger.warning(f"[灾害预警] 台风查询路径图渲染失败: {render_err}")
     return chain_parts

--- a/plugin/commands/typhoon_query_image_helper.py
+++ b/plugin/commands/typhoon_query_image_helper.py
@@ -1,0 +1,117 @@
+"""台风查询路径图辅助。
+
+把 /台风信息查询 的附图逻辑从命令服务中拆出，
+避免在 plugin_query_command_service 里堆叠大段渲染代码。
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import Any
+
+import astrbot.api.message_components as Comp
+from astrbot.api import logger
+
+from ...core.message.push.message_build_service import MessageBuildService
+
+
+async def append_typhoon_track_image(
+    *,
+    plugin: Any,
+    result: dict[str, Any],
+    chain_parts: list,
+) -> list:
+    """若查询结果含可渲染轨迹，则向 chain_parts 追加路径图。
+
+    策略：
+    - 优先 result["data"]，否则取 items 中首个含 history_track 的项
+    - 列表多条时只渲第一张，避免一次查询打爆浏览器池
+    - 渲染失败不抛出，仅打 warning 并返回原 chain_parts
+    """
+    if not result.get("success"):
+        return chain_parts
+
+    candidates: list[dict[str, Any]] = []
+    data_item = result.get("data")
+    if isinstance(data_item, dict):
+        candidates.append(data_item)
+    for item in result.get("items") or []:
+        if isinstance(item, dict) and item not in candidates:
+            candidates.append(item)
+    if not candidates:
+        return chain_parts
+
+    service = getattr(plugin, "disaster_service", None)
+    message_manager = getattr(service, "message_manager", None) if service else None
+    renderer = (
+        getattr(message_manager, "typhoon_map_renderer", None)
+        if message_manager
+        else None
+    )
+    if renderer is None:
+        return chain_parts
+
+    msg_cfg: dict[str, Any] = {}
+    try:
+        cfg = getattr(message_manager, "config", None) or {}
+        if isinstance(cfg, dict):
+            raw_msg_cfg = cfg.get("message_format", {})
+            if isinstance(raw_msg_cfg, dict):
+                msg_cfg = raw_msg_cfg
+    except Exception:
+        msg_cfg = {}
+    # 台风路径图专用瓦片源；未配置时回退暗色底图（与台风卡片主题一致）。
+    map_source = msg_cfg.get("typhoon_map_source") or "PetalMap矢量图暗"
+    if not str(map_source).strip():
+        map_source = "PetalMap矢量图暗"
+    playwright_mode = msg_cfg.get("playwright_mode", "local")
+
+    for item in candidates[:1]:
+        history = item.get("history_track") or []
+        if not isinstance(history, list) or not history:
+            continue
+        can_render = getattr(renderer, "can_render", None)
+        if callable(can_render) and not can_render(item):
+            continue
+        try:
+            temp_dir = getattr(message_manager, "temp_dir", None)
+            safe_id = str(item.get("typhoon_id") or item.get("eqsc_id") or "q").replace(
+                "/", "_"
+            )
+            img_path = os.path.join(
+                str(temp_dir or "."),
+                f"typhoon_map_query_{safe_id}_{int(time.time())}.png",
+            )
+            cache_key = MessageBuildService._build_typhoon_map_cache_key(
+                item,
+                map_source=str(map_source),
+                playwright_mode=str(playwright_mode),
+            )
+
+            async def _render_typhoon(
+                _item: dict[str, Any] = item, _path: str = img_path
+            ) -> str | None:
+                return await renderer.render(
+                    _item,
+                    _path,
+                    map_source=str(map_source),
+                    playwright_mode=str(playwright_mode),
+                )
+
+            render_with_cache = getattr(message_manager, "_render_with_cache", None)
+            if callable(render_with_cache):
+                out = await render_with_cache(cache_key, _render_typhoon)
+            else:
+                out = await _render_typhoon()
+            if out and os.path.exists(out):
+                with open(out, "rb") as f:
+                    b64 = base64.b64encode(f.read()).decode()
+                chain_parts.append(Comp.Image.fromBase64(b64))
+        except Exception as render_err:
+            logger.warning(f"[灾害预警] 台风查询路径图渲染失败: {render_err}")
+    return chain_parts
+
+
+__all__ = ["append_typhoon_track_image"]

--- a/resources/card_templates/Typhoon/typhoon_track.html
+++ b/resources/card_templates/Typhoon/typhoon_track.html
@@ -729,32 +729,6 @@ function formatHourLabel(timeText) {
 }
 
 /**
- * 中文移向 → 方位角（度，0=北，顺时针）。
- * 无法识别时返回 null。
- */
-function directionToBearing(text) {
-    var s = String(text || '').trim();
-    if (!s) return null;
-    var table = [
-        ['北北西', 337.5], ['西北北', 337.5],
-        ['北北东', 22.5], ['东北北', 22.5],
-        ['东东北', 67.5], ['东北东', 67.5],
-        ['东东南', 112.5], ['东南东', 112.5],
-        ['南东南', 157.5], ['东南南', 157.5],
-        ['南西南', 202.5], ['西南南', 202.5],
-        ['西西南', 247.5], ['西南西', 247.5],
-        ['西西北', 292.5], ['西北西', 292.5],
-        ['东北', 45], ['东南', 135], ['西南', 225], ['西北', 315],
-        ['正北', 0], ['正东', 90], ['正南', 180], ['正西', 270],
-        ['北', 0], ['东', 90], ['南', 180], ['西', 270]
-    ];
-    for (var i = 0; i < table.length; i++) {
-        if (s.indexOf(table[i][0]) >= 0) return table[i][1];
-    }
-    return null;
-}
-
-/**
  * 把 EQSC 原生轨迹节点规范化为画布点。
  * 保留 lat/lon/cat/ws/pr/ts 与 r7/r10/r12（来自 30/50/64KTS）。
  */
@@ -1273,71 +1247,6 @@ function drawRadiiPoly(cx, cy, lat, lon, radii, fillColor, edgeColor, dashed, li
     ctx.lineJoin = 'round';
     ctx.stroke();
     if (dashed) ctx.setLineDash([]);
-}
-
-function drawMoveArrow(cx, cy, bearing, color) {
-    if (bearing === null || bearing === undefined) return;
-    var rad = (bearing - 90) * Math.PI / 180; // canvas: 0°=东，转成北为 0
-    // 上面公式：地理 0=北 → canvas 角
-    rad = (bearing) * Math.PI / 180;
-    // 北=0：x = sin(b), y = -cos(b)
-    var len = 28;
-    var ex = cx + Math.sin(rad) * len;
-    var ey = cy - Math.cos(rad) * len;
-    ctx.save();
-    ctx.strokeStyle = color;
-    ctx.fillStyle = color;
-    ctx.lineWidth = 2.5;
-    ctx.lineCap = 'round';
-    ctx.beginPath();
-    ctx.moveTo(cx, cy);
-    ctx.lineTo(ex, ey);
-    ctx.stroke();
-    // 箭头头部
-    var ah = 8;
-    var left = bearing - 150;
-    var right = bearing + 150;
-    var lr = left * Math.PI / 180;
-    var rr = right * Math.PI / 180;
-    ctx.beginPath();
-    ctx.moveTo(ex, ey);
-    ctx.lineTo(ex + Math.sin(lr) * ah, ey - Math.cos(lr) * ah);
-    ctx.lineTo(ex + Math.sin(rr) * ah, ey - Math.cos(rr) * ah);
-    ctx.closePath();
-    ctx.fill();
-    ctx.restore();
-}
-
-function drawTyphoonSymbol(cx, cy, color) {
-    // 简化双臂螺旋 + 中心眼
-    ctx.save();
-    ctx.translate(cx, cy);
-    ctx.strokeStyle = color;
-    ctx.fillStyle = color;
-    ctx.lineWidth = 1.8;
-    ctx.lineCap = 'round';
-    for (var arm = 0; arm < 2; arm++) {
-        ctx.beginPath();
-        for (var t = 0; t <= 28; t++) {
-            var ang = (t / 28) * Math.PI * 1.15 + arm * Math.PI;
-            var rad = 3 + t * 0.35;
-            var x = Math.cos(ang) * rad;
-            var y = Math.sin(ang) * rad;
-            if (t === 0) ctx.moveTo(x, y);
-            else ctx.lineTo(x, y);
-        }
-        ctx.stroke();
-    }
-    ctx.beginPath();
-    ctx.arc(0, 0, 2.2, 0, Math.PI * 2);
-    ctx.fillStyle = 'rgba(255,255,255,0.9)';
-    ctx.fill();
-    ctx.beginPath();
-    ctx.arc(0, 0, 3.4, 0, Math.PI * 2);
-    ctx.strokeStyle = color;
-    ctx.lineWidth = 1.4;
-    ctx.stroke();
-    ctx.restore();
 }
 
 /**

--- a/resources/card_templates/Typhoon/typhoon_track.html
+++ b/resources/card_templates/Typhoon/typhoon_track.html
@@ -1,0 +1,2133 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>台风路径图</title>
+<!-- leaflet_css / leaflet_js / helper 由渲染器在注入阶段替换占位符 -->
+<link rel="stylesheet" href="__LEAFLET_CSS_URL__" />
+<script src="__LEAFLET_JS_URL__"></script>
+<script>__MAP_RENDER_HELPER_JS__</script>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+    width: 1400px; height: 1000px;
+    background: #060606;
+    font-family: "Microsoft YaHei", "Segoe UI", sans-serif;
+    overflow: hidden;
+}
+#card-wrapper {
+    width: 1400px; height: 1000px;
+    display: flex;
+    background: #0e0e12;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+/* ── 左侧：路径历史 + 路径预报 ── */
+#panel-left {
+    width: 386px;
+    flex-shrink: 0;
+    background: #0e0e12;
+    /* 上/左/底 6px 与舞台对齐；右侧 6px 作为与地图的分隔 */
+    padding: 6px 6px 6px 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 0;
+    box-sizing: border-box;
+}
+#card-history,
+#card-forecast {
+    padding: 8px 6px 8px 8px;
+    border-radius: 12px;
+}
+#card-history {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+#card-forecast {
+    flex: 0 0 188px;
+    /* 与底部信息坞同高，贴齐底部 */
+    height: 188px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    margin-bottom: 0;
+}
+#history-scroll,
+#forecast-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/* ── 右侧舞台：地图全高，信息坞/图例叠在地图上 ── */
+#right-stage {
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    /* 左侧贴齐路径卡片（0），仅保留上/右/下 6px */
+    padding: 6px 6px 6px 0;
+}
+#map-area {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    border-radius: 12px;
+    overflow: hidden;
+}
+#map { width: 100%; height: 100%; background: #060606; }
+#overlay-canvas {
+    position: absolute; top: 0; left: 0;
+    width: 100%; height: 100%;
+    pointer-events: none;
+    z-index: 1000;
+}
+.watermark {
+    position: absolute; top: 10px; right: 14px;
+    color: rgba(180,185,195,0.45);
+    font-size: 12px; font-weight: bold;
+    pointer-events: none;
+    z-index: 1001;
+    text-shadow: 0 0 6px rgba(0,0,0,0.6);
+}
+
+/* 地图图例：右上角，避开水印（水印 top:10 right:14） */
+#map-legend {
+    position: absolute;
+    right: 12px;
+    top: 34px;
+    bottom: auto;
+    z-index: 1003;
+    background: rgba(14, 14, 20, 0.90);
+    border: 1px solid rgba(80, 90, 110, 0.55);
+    border-radius: 10px;
+    padding: 8px 10px;
+    min-width: 148px;
+    backdrop-filter: blur(4px);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+    pointer-events: none;
+}
+#map-legend .lg-title {
+    font-size: 11px;
+    font-weight: bold;
+    color: #9aa3b5;
+    margin-bottom: 6px;
+    letter-spacing: 0.5px;
+}
+#map-legend .lg-row {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin: 3px 0;
+    font-size: 11px;
+    color: #d5dae6;
+    font-weight: bold;
+}
+/* 强度图例：与地图圆点一致 */
+#map-legend .lg-swatch {
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 0 1px rgba(0,0,0,0.35);
+}
+#map-legend .lg-line {
+    width: 18px; height: 0;
+    flex-shrink: 0;
+}
+#map-legend .lg-line.solid {
+    border-top: 2.5px solid #64b9ff;
+}
+#map-legend .lg-line.dashed {
+    border-top: 2px dashed #c8cdd8;
+}
+#map-legend .lg-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+#map-legend .lg-dot.hollow {
+    background: transparent;
+    border: 2px solid #c8cdd8;
+    box-sizing: border-box;
+}
+#map-legend .lg-sep {
+    height: 1px;
+    background: rgba(80,90,110,0.45);
+    margin: 6px 0;
+}
+#map-legend .lg-wind {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    color: #b8c0d0;
+    margin-top: 2px;
+}
+#map-legend .lg-ring {
+    width: 12px; height: 12px;
+    border-radius: 50%;
+    border: 2px solid;
+    flex-shrink: 0;
+    opacity: 0.85;
+}
+
+/* 底部信息坞：贴底铺满，卡片间距紧凑 */
+#bottom-dock {
+    position: absolute;
+    left: 6px;
+    right: 6px;
+    bottom: 6px;
+    height: 188px;
+    display: grid;
+    grid-template-columns: 1.05fr 1.15fr 0.95fr 1.25fr;
+    gap: 4px;
+    z-index: 1002;
+    pointer-events: none;
+    min-height: 0;
+}
+.dock-card {
+    background: rgba(18, 18, 28, 0.94);
+    border: 1px solid rgba(55, 60, 78, 0.85);
+    border-radius: 10px;
+    padding: 6px 8px;
+    overflow: hidden;
+    position: relative;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    backdrop-filter: blur(6px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.22);
+    pointer-events: none;
+}
+.dock-card::before {
+    content: '';
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 14px;
+    background: linear-gradient(to bottom, rgba(34,34,48,0.85), transparent);
+    border-radius: 10px 10px 0 0;
+    pointer-events: none;
+}
+.card {
+    background: #181822;
+    border: 1px solid #2a2a37;
+    border-radius: 16px;
+    padding: 10px 12px;
+    overflow: hidden;
+    position: relative;
+}
+.card::before {
+    content: '';
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 24px;
+    background: linear-gradient(to bottom, rgba(34,34,48,0.9), transparent);
+    border-radius: 16px 16px 0 0;
+    pointer-events: none;
+}
+.card-header {
+    font-size: 12px; font-weight: bold;
+    color: #3787e1;
+    margin-bottom: 4px;
+    position: relative; z-index: 1;
+    flex-shrink: 0;
+}
+.dock-card .card-header {
+    font-size: 11.5px;
+    margin-bottom: 3px;
+}
+.dock-card .metric-row {
+    min-height: 16px;
+    margin: 1px 0;
+}
+.dock-card .metric-label { font-size: 11px; }
+.dock-card .metric-main { font-size: 12px; }
+.dock-card .muted { font-size: 11px; }
+.row-title {
+    font-size: 12px; color: #697080;
+    display: inline;
+}
+.row-value {
+    font-size: 13px; font-weight: bold; color: #e1e4eb;
+    float: right;
+}
+.metric-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 6px;
+    margin: 2px 0;
+    min-height: 18px;
+}
+.metric-label {
+    font-size: 12px;
+    color: #697080;
+    flex-shrink: 0;
+}
+.metric-main {
+    font-size: 13px;
+    font-weight: bold;
+    color: #e1e4eb;
+    text-align: right;
+    min-width: 0;
+}
+.metric-delta {
+    display: inline-block;
+    margin-left: 4px;
+    padding: 0 5px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: bold;
+    vertical-align: middle;
+    line-height: 16px;
+}
+/* 风速变化：升=增强倾向(暖色)，降=减弱倾向(冷绿) */
+.delta-up {
+    color: #ff8e8e;
+    background: rgba(240, 70, 70, 0.14);
+}
+.delta-down {
+    color: #6ddea0;
+    background: rgba(70, 195, 110, 0.14);
+}
+/* 气压变化：仅表示数值升降，统一中性蓝灰，避免被误读为“危险红色” */
+.delta-pr-up,
+.delta-pr-down {
+    color: #8ec5ff;
+    background: rgba(100, 160, 230, 0.14);
+}
+.delta-flat {
+    color: #9aa3b5;
+    background: rgba(120, 130, 150, 0.12);
+}
+.intensity-badge {
+    display: inline-block;
+    margin-top: 4px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: bold;
+}
+.intensity-up {
+    color: #ffb4b4;
+    background: rgba(240, 70, 70, 0.16);
+    border: 1px solid rgba(240, 70, 70, 0.28);
+}
+.intensity-down {
+    color: #8ee0b0;
+    background: rgba(70, 195, 110, 0.14);
+    border: 1px solid rgba(70, 195, 110, 0.25);
+}
+.intensity-flat {
+    color: #a8b0c0;
+    background: rgba(120, 130, 150, 0.12);
+    border: 1px solid rgba(120, 130, 150, 0.22);
+}
+
+/* 类别标签 */
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 12px; font-weight: bold;
+    color: #fff;
+    margin-right: 5px;
+}
+.badge-src {
+    display: inline-block;
+    padding: 2px 7px;
+    border-radius: 6px;
+    font-size: 12px; font-weight: bold;
+    color: #fff;
+}
+.badge-src-eqsc { background: #3787d7; }
+.badge-src-fan { background: #5a7fd7; }
+.badge-src-local { background: #6a6a7a; }
+.badge-src-cma { background: #3787d7; }
+.badge-src-jma { background: #d75037; }
+.badge-row { margin-top: 4px; }
+
+/* 风圈 */
+.radii-label { font-size: 11px; font-weight: bold; }
+.radii-line {
+    font-size: 11px;
+    font-weight: bold;
+    margin-left: 4px;
+    line-height: 1.4;
+}
+.muted { font-size: 12px; color: #697080; }
+.pos-value { font-size: 12px; }
+.clearfix { clear: both; }
+.clearfix-sm { clear: both; height: 2px; }
+
+/* 表格：固定列宽，列内容居中，间距更均匀 */
+.table-wrap {
+    font-size: 11.5px;
+    font-weight: bold;
+    width: 100%;
+}
+.table-header {
+    color: #697080;
+    font-size: 10.5px;
+    margin-bottom: 3px;
+    padding: 0 2px;
+    flex-shrink: 0;
+}
+.table-row {
+    line-height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 2px;
+    gap: 2px;
+}
+.table-row-alt { background: rgba(30,30,42,0.6); border-radius: 4px; }
+.table-row-latest {
+    /* 仅底色高亮，不加左边色条，避免与居中列错位 */
+    background: rgba(55, 135, 225, 0.16);
+    border-radius: 4px;
+}
+.table-cell {
+    flex: 0 0 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    text-align: center;
+    padding: 0 1px;
+}
+.col-time { width: 76px; }
+.col-pos { width: 96px; }
+.col-ws { width: 38px; }
+.col-pr { width: 40px; }
+.col-cat { flex: 1 1 auto; min-width: 70px; max-width: 96px; }
+.table-compact { font-size: 11px; }
+.table-compact .table-row { line-height: 16px; }
+.table-compact .col-time { width: 74px; }
+.table-compact .col-pos { width: 94px; }
+.table-compact .col-ws { width: 36px; }
+.table-compact .col-pr { width: 38px; }
+
+/* 迷你曲线图 */
+.chart-wrap { position: relative; flex: 1; min-height: 0; overflow: hidden; }
+#mini-chart { width: 100%; height: 100%; display: block; }
+.chart-legend {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    font-size: 9.5px;
+    color: #8b93a5;
+    margin-top: 2px;
+    flex-shrink: 0;
+    line-height: 1.2;
+    min-width: 0;
+    overflow: hidden;
+}
+.chart-legend-items {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+.chart-legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    white-space: nowrap;
+}
+.chart-legend span::before {
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 2.5px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+.chart-legend .lw::before { background: #ff9614; }
+.chart-legend .lp::before { background: #64b9ff; }
+.chart-meta {
+    font-size: 9px;
+    color: #7a8498;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+</style>
+</head>
+<body>
+<div id="card-wrapper">
+    <!-- 左侧：路径历史（上）+ 路径预报（下，高度对齐信息坞） -->
+    <div id="panel-left">
+        <div class="card" id="card-history"></div>
+        <div class="card" id="card-forecast"></div>
+    </div>
+
+    <!-- 右侧：地图全高；信息坞/图例叠在地图上，不挤压地图 -->
+    <div id="right-stage">
+        <div id="map-area">
+            <div id="map"></div>
+            <canvas id="overlay-canvas"></canvas>
+            <div class="watermark" id="watermark"></div>
+            <div id="map-legend"></div>
+            <div id="bottom-dock">
+                <div class="dock-card" id="card-identity"></div>
+                <div class="dock-card" id="card-live"></div>
+                <div class="dock-card" id="card-radii"></div>
+                <div class="dock-card" id="card-chart-wrap">
+                    <div class="card-header">风速/气压变化</div>
+                    <div class="chart-wrap">
+                        <canvas id="mini-chart"></canvas>
+                    </div>
+                    <div class="chart-legend">
+                        <div class="chart-legend-items">
+                            <span class="lw">风速</span>
+                            <span class="lp">气压</span>
+                        </div>
+                        <div class="chart-meta" id="chart-meta"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!--
+  渲染器会把下方占位符替换为完整 bootstrap JSON。
+  模板本身保持合法 JS/CSS，避免 VSCode 对 Jinja 语法爆红。
+-->
+<script type="application/json" id="typhoon-bootstrap">__TYPHOON_BOOTSTRAP_JSON__</script>
+
+<script>
+(function() {
+'use strict';
+
+/**
+ * 读取 Python 注入的 bootstrap 数据。
+ * 字段约定见 TyphoonMapRenderer._build_bootstrap()。
+ */
+function loadBootstrap() {
+    var el = document.getElementById('typhoon-bootstrap');
+    if (!el) return {};
+    try {
+        return JSON.parse(el.textContent || '{}');
+    } catch (e) {
+        console.error('[台风] bootstrap JSON 解析失败:', e);
+        return {};
+    }
+}
+
+var BOOT = loadBootstrap();
+var HISTORY_RAW = Array.isArray(BOOT.history) ? BOOT.history : [];
+var FORECAST_RAW = Array.isArray(BOOT.forecast) ? BOOT.forecast : [];
+var VIEW = BOOT.view || { lo: 100, hi: 170, la: 5, ha: 45 };
+var CHART_WINDS = Array.isArray(BOOT.chart_winds) ? BOOT.chart_winds : [];
+var CHART_PRESS = Array.isArray(BOOT.chart_pressures) ? BOOT.chart_pressures : [];
+var CHART_TIMES = Array.isArray(BOOT.chart_times) ? BOOT.chart_times : [];
+var TILE_URL = BOOT.tile_url || '';
+var PANEL = BOOT.panel || {};
+var FORECAST_ROWS = Array.isArray(BOOT.forecast_rows) ? BOOT.forecast_rows : [];
+var HISTORY_ROWS = Array.isArray(BOOT.history_rows) ? BOOT.history_rows : [];
+var WIND_RADII = Array.isArray(BOOT.wind_radii) ? BOOT.wind_radii : [];
+
+var CAT_COLORS = {
+    0: '#787882',
+    1: '#32afff',
+    2: '#32d773',
+    3: '#ffd728',
+    4: '#ffa00a',
+    5: '#f55f0a',
+    6: '#e12828'
+};
+var CAT_NAMES = {
+    0: '未知',
+    1: '热带低压',
+    2: '热带风暴',
+    3: '强热带风暴',
+    4: '台风',
+    5: '强台风',
+    6: '超强台风'
+};
+var CAT_SHORT = {
+    0: '—',
+    1: 'TD',
+    2: 'TS',
+    3: 'STS',
+    4: 'TY',
+    5: 'STY',
+    6: 'SuperTY'
+};
+
+// 等级中文 → 0-6（长词优先，避免“强台风”命中“台风”）
+var LEVEL_WEIGHTS = [
+    ['超强台风', 6],
+    ['强台风', 5],
+    ['强热带风暴', 3],
+    ['热带风暴', 2],
+    ['热带低压', 1],
+    ['台风', 4]
+];
+
+function levelWeight(text) {
+    var s = String(text || '').trim();
+    if (!s) return 0;
+    for (var i = 0; i < LEVEL_WEIGHTS.length; i++) {
+        if (s === LEVEL_WEIGHTS[i][0] || s.indexOf(LEVEL_WEIGHTS[i][0]) >= 0) {
+            return LEVEL_WEIGHTS[i][1];
+        }
+    }
+    return 0;
+}
+
+function toNum(v) {
+    if (v === null || v === undefined || v === '') return null;
+    var n = Number(v);
+    return isFinite(n) ? n : null;
+}
+
+function escapeHtml(text) {
+    // 用 fromCharCode 拼 HTML 实体，避免源文件里的 &...; 被二次解码弄坏
+    return String(text == null ? '' : text).replace(/[&<>"']/g, function (ch) {
+        if (ch === '&') return String.fromCharCode(38) + 'amp;';
+        if (ch === '<') return String.fromCharCode(38) + 'lt;';
+        if (ch === '>') return String.fromCharCode(38) + 'gt;';
+        if (ch === '"') return String.fromCharCode(38) + 'quot;';
+        return String.fromCharCode(38) + '#39;';
+    });
+}
+
+function cleanCircle(circle) {
+    if (!circle || typeof circle !== 'object') return null;
+    var out = {};
+    var has = false;
+    ['NE', 'SE', 'SW', 'NW'].forEach(function(k) {
+        var n = toNum(circle[k]);
+        if (n !== null && n > 0) {
+            out[k] = n;
+            has = true;
+        }
+    });
+    return has ? out : null;
+}
+
+function extractWindCircle(node) {
+    var raw = (node && (node.windCircle || node.wind_circle)) || null;
+    if (!raw || typeof raw !== 'object') {
+        return { r7: null, r10: null, r12: null };
+    }
+    return {
+        r7: cleanCircle(raw['30KTS'] || raw['30kts']),
+        r10: cleanCircle(raw['50KTS'] || raw['50kts']),
+        r12: cleanCircle(raw['64KTS'] || raw['64kts'])
+    };
+}
+
+function formatTs(timeText) {
+    var s = String(timeText || '').trim();
+    if (!s) return '';
+    var m = s.match(/(\d{1,2}):(\d{2})/);
+    if (m) return (m[1].length === 1 ? '0' + m[1] : m[1]) + ':' + m[2];
+    return '';
+}
+
+/**
+ * 解析轨迹时间字符串，返回 {year, month, day, hour, minute} 或 null。
+ * 优先完整 ISO / 四位年，避免把年份前两位误当成“日”。
+ *
+ * 例：
+ * - "2020-09-06 17:00:00" → day=6, hour=17
+ * - "2026/07/06 17:00"     → day=6, hour=17
+ * - "07/06 17:00"          → day=6, hour=17
+ * - "7月6日17时"           → day=6, hour=17
+ */
+function parseTrackDateParts(timeText) {
+    var s = String(timeText || '').trim();
+    if (!s) return null;
+
+    // 1) 完整四位年：YYYY-MM-DD[ T]HH:mm[:ss]
+    var m = s.match(
+        /(\d{4})[\/\-年](\d{1,2})[\/\-月](\d{1,2})[日T\s]+(\d{1,2}):(\d{2})/
+    );
+    if (m) {
+        return {
+            year: parseInt(m[1], 10),
+            month: parseInt(m[2], 10),
+            day: parseInt(m[3], 10),
+            hour: parseInt(m[4], 10),
+            minute: parseInt(m[5], 10)
+        };
+    }
+
+    // 2) 仅日期四位年：YYYY-MM-DD
+    m = s.match(/(\d{4})[\/\-年](\d{1,2})[\/\-月](\d{1,2})/);
+    if (m) {
+        var hm = s.match(/(\d{1,2}):(\d{2})/);
+        return {
+            year: parseInt(m[1], 10),
+            month: parseInt(m[2], 10),
+            day: parseInt(m[3], 10),
+            hour: hm ? parseInt(hm[1], 10) : 0,
+            minute: hm ? parseInt(hm[2], 10) : 0
+        };
+    }
+
+    // 3) 中文：M月D日H时
+    m = s.match(/(\d{1,2})月(\d{1,2})日\s*(\d{1,2})时/);
+    if (m) {
+        return {
+            year: null,
+            month: parseInt(m[1], 10),
+            day: parseInt(m[2], 10),
+            hour: parseInt(m[3], 10),
+            minute: 0
+        };
+    }
+
+    // 4) 短格式 MM/DD HH:mm 或 MM-DD HH:mm（月必须 1-12，日 1-31）
+    m = s.match(/(^|[^\d])(\d{1,2})[\/\-](\d{1,2})(?:[^\d]+(\d{1,2}):(\d{2}))?/);
+    if (m) {
+        var month = parseInt(m[2], 10);
+        var day = parseInt(m[3], 10);
+        if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+            return {
+                year: null,
+                month: month,
+                day: day,
+                hour: m[4] != null ? parseInt(m[4], 10) : 0,
+                minute: m[5] != null ? parseInt(m[5], 10) : 0
+            };
+        }
+    }
+
+    // 5) 原生 Date 兜底（注意：部分环境对 "YYYY-MM-DD HH:mm" 解析不稳，已优先正则）
+    var d = new Date(s.replace(/-/g, '/'));
+    if (!isNaN(d.getTime())) {
+        return {
+            year: d.getFullYear(),
+            month: d.getMonth() + 1,
+            day: d.getDate(),
+            hour: d.getHours(),
+            minute: d.getMinutes()
+        };
+    }
+    return null;
+}
+
+function formatHourLabel(timeText) {
+    var parts = parseTrackDateParts(timeText);
+    if (!parts) return formatTs(timeText);
+    var mm = parts.month < 10 ? '0' + parts.month : String(parts.month);
+    var dd = parts.day < 10 ? '0' + parts.day : String(parts.day);
+    var hh = parts.hour < 10 ? '0' + parts.hour : String(parts.hour);
+    return mm + '/' + dd + ' ' + hh + '时';
+}
+
+/**
+ * 中文移向 → 方位角（度，0=北，顺时针）。
+ * 无法识别时返回 null。
+ */
+function directionToBearing(text) {
+    var s = String(text || '').trim();
+    if (!s) return null;
+    var table = [
+        ['北北西', 337.5], ['西北北', 337.5],
+        ['北北东', 22.5], ['东北北', 22.5],
+        ['东东北', 67.5], ['东北东', 67.5],
+        ['东东南', 112.5], ['东南东', 112.5],
+        ['南东南', 157.5], ['东南南', 157.5],
+        ['南西南', 202.5], ['西南南', 202.5],
+        ['西西南', 247.5], ['西南西', 247.5],
+        ['西西北', 292.5], ['西北西', 292.5],
+        ['东北', 45], ['东南', 135], ['西南', 225], ['西北', 315],
+        ['正北', 0], ['正东', 90], ['正南', 180], ['正西', 270],
+        ['北', 0], ['东', 90], ['南', 180], ['西', 270]
+    ];
+    for (var i = 0; i < table.length; i++) {
+        if (s.indexOf(table[i][0]) >= 0) return table[i][1];
+    }
+    return null;
+}
+
+/**
+ * 把 EQSC 原生轨迹节点规范化为画布点。
+ * 保留 lat/lon/cat/ws/pr/ts 与 r7/r10/r12（来自 30/50/64KTS）。
+ */
+function normalizeNode(node) {
+    if (!node || typeof node !== 'object') return null;
+    var lat = toNum(node.latitude != null ? node.latitude : node.lat);
+    var lon = toNum(node.longitude != null ? node.longitude : node.lon);
+    if (lat === null || lon === null) return null;
+    var levelText = String(
+        node.typeNameCN || node.type || node.level || node.typhoon_type || ''
+    ).trim();
+    var cat = levelWeight(levelText);
+    var winds = extractWindCircle(node);
+    var hour = null;
+    var rawTime = String(node.time || '').trim();
+    var hm = rawTime.match(/(\d{1,2}):(\d{2})/);
+    if (hm) hour = parseInt(hm[1], 10);
+    return {
+        lat: lat,
+        lon: lon,
+        cat: cat,
+        level: levelText || CAT_NAMES[cat] || '',
+        ws: toNum(node.windSpeed != null ? node.windSpeed : node.wind_speed),
+        pr: toNum(node.pressure),
+        ts: formatTs(node.time),
+        hour: hour,
+        timeRaw: rawTime,
+        r7: winds.r7,
+        r10: winds.r10,
+        r12: winds.r12
+    };
+}
+
+var PAST = HISTORY_RAW.map(normalizeNode).filter(Boolean);
+var FCST = FORECAST_RAW.map(normalizeNode).filter(Boolean);
+
+function hexWithAlpha(hex, alpha) {
+    var h = String(hex || '#969696').replace('#', '');
+    if (h.length === 3) {
+        h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    }
+    var a = Math.max(0, Math.min(1, alpha));
+    var ah = Math.round(a * 255).toString(16).padStart(2, '0');
+    return '#' + h + ah;
+}
+
+function formatDelta(value, unit, digits) {
+    if (value === null || value === undefined || !isFinite(value)) return '';
+    var d = typeof digits === 'number' ? digits : 0;
+    var abs = Math.abs(value).toFixed(d).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+    var sign = value > 0 ? '+' : (value < 0 ? '−' : '');
+    // 使用 Unicode minus，避免 HTML 实体问题；显示层再 escape
+    if (value < 0) sign = '-';
+    if (value > 0) sign = '+';
+    return sign + abs + (unit || '');
+}
+
+/** 渲染左侧历史表 + 底部信息坞 + 图例 */
+function renderPanel() {
+    var catName = PANEL.category_name || '';
+    var catColor = PANEL.cat_color_rgb || '150,150,150';
+
+    var identity = document.getElementById('card-identity');
+    if (identity) {
+        identity.innerHTML =
+            '<div class="card-header">&#9733; 台风</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">名称</span>' +
+                '<span class="metric-main">' + escapeHtml(PANEL.event_name || '--') + '</span>' +
+            '</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">编号</span>' +
+                '<span class="metric-main">' + escapeHtml(PANEL.event_code || '--') + '</span>' +
+            '</div>' +
+            '<div class="badge-row">' +
+                (catName
+                    ? '<span class="badge" style="background:rgba(' + catColor + ',1)">' +
+                      escapeHtml(catName) + '</span>'
+                    : '') +
+            '</div>' +
+            (PANEL.update_time
+                ? '<div class="muted" style="margin-top:6px">更新 ' +
+                  escapeHtml(PANEL.update_time) + '</div>'
+                : '');
+    }
+
+    var live = document.getElementById('card-live');
+    if (live) {
+        // 趋势：数值保持中性色；变化量用小标签；综合强度单独说明
+        var wsDelta = PANEL.ws_delta_text || '';
+        var prDelta = PANEL.pr_delta_text || '';
+        var wsDeltaCls = PANEL.ws_delta_class || 'delta-flat';
+        var prDeltaCls = PANEL.pr_delta_class || 'delta-flat';
+        var intensityText = PANEL.intensity_trend_text || '强度稳定';
+        var intensityCls = PANEL.intensity_trend_class || 'intensity-flat';
+        var moveText = ((PANEL.move_dir || '') + ' ' + (PANEL.move_speed || '')).trim() || '--';
+
+        live.innerHTML =
+            '<div class="card-header">实况</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">风速</span>' +
+                '<span class="metric-main">' +
+                    escapeHtml(PANEL.wind_speed || '--') +
+                    (wsDelta
+                        ? '<span class="metric-delta ' + wsDeltaCls + '">' +
+                          escapeHtml(wsDelta) + '</span>'
+                        : '') +
+                '</span>' +
+            '</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">气压</span>' +
+                '<span class="metric-main">' +
+                    escapeHtml(PANEL.pressure || '--') +
+                    (prDelta
+                        ? '<span class="metric-delta ' + prDeltaCls + '">' +
+                          escapeHtml(prDelta) + '</span>'
+                        : '') +
+                '</span>' +
+            '</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">移动</span>' +
+                '<span class="metric-main">' + escapeHtml(moveText) + '</span>' +
+            '</div>' +
+            '<div class="metric-row">' +
+                '<span class="metric-label">位置</span>' +
+                '<span class="metric-main pos-value">' +
+                    escapeHtml(PANEL.position || '--') +
+                '</span>' +
+            '</div>' +
+            '<div><span class="intensity-badge ' + intensityCls + '">' +
+                escapeHtml(intensityText) +
+            '</span></div>';
+    }
+
+    var radii = document.getElementById('card-radii');
+    if (radii) {
+        var html = '<div class="card-header">风圈半径</div>';
+        if (!WIND_RADII.length) {
+            html +=
+                '<div class="muted" style="margin-top:8px;line-height:1.5">' +
+                '当前报文未提供风圈数据' +
+                '</div>';
+        } else {
+            WIND_RADII.forEach(function(r) {
+                var color = r.color_rgb || '150,150,150';
+                html += '<div class="radii-label" style="color:rgba(' + color + ',1)">' +
+                    escapeHtml(r.label || '') + '</div>';
+                (r.lines || []).forEach(function(line) {
+                    html += '<div class="radii-line" style="color:rgba(' + color + ',0.95)">' +
+                        escapeHtml(line) + '</div>';
+                });
+            });
+        }
+        radii.innerHTML = html;
+    }
+
+    function tableHeaderHtml() {
+        return '<div class="table-header table-row">' +
+            '<span class="table-cell col-time">时间</span>' +
+            '<span class="table-cell col-pos">位置</span>' +
+            '<span class="table-cell col-ws">风速</span>' +
+            '<span class="table-cell col-pr">气压</span>' +
+            '<span class="table-cell col-cat">等级</span>' +
+            '</div>';
+    }
+
+    function tableRowHtml(r, rowCls) {
+        var color = r.cat_color || '#969696';
+        return '<div class="' + rowCls + '">' +
+            '<span class="table-cell col-time" style="color:#e1e4eb">' +
+                escapeHtml(r.time || '') + '</span>' +
+            '<span class="table-cell col-pos" style="color:#e1e4eb">' +
+                escapeHtml(r.pos || '') + '</span>' +
+            '<span class="table-cell col-ws" style="color:' + color + '">' +
+                escapeHtml(r.ws || '') + '</span>' +
+            '<span class="table-cell col-pr" style="color:' + color + '">' +
+                escapeHtml(r.pr || '') + '</span>' +
+            '<span class="table-cell col-cat" style="color:' + color + '">' +
+                escapeHtml(r.cat || '') + '</span>' +
+            '</div>';
+    }
+
+    // 左侧路径历史（上）
+    var historyEl = document.getElementById('card-history');
+    if (historyEl) {
+        var hhtml = '<div class="card-header">路径历史</div>';
+        if (!HISTORY_ROWS.length) {
+            hhtml += '<div class="muted">暂无历史数据</div>';
+        } else {
+            hhtml += '<div id="history-scroll"><div class="table-wrap">';
+            hhtml += tableHeaderHtml();
+            HISTORY_ROWS.forEach(function(r, idx) {
+                var rowCls = 'table-row';
+                if (idx === 0) rowCls += ' table-row-latest';
+                else if (idx % 2 === 1) rowCls += ' table-row-alt';
+                hhtml += tableRowHtml(r, rowCls);
+            });
+            hhtml += '</div></div>';
+        }
+        historyEl.innerHTML = hhtml;
+    }
+
+    // 左侧路径预报（下，高度对齐信息坞）
+    var forecastEl = document.getElementById('card-forecast');
+    if (forecastEl) {
+        var fhtml = '<div class="card-header">路径预报</div>';
+        if (!FORECAST_ROWS.length) {
+            fhtml += '<div class="muted">暂无预报数据</div>';
+        } else {
+            fhtml += '<div id="forecast-scroll"><div class="table-wrap table-compact">';
+            fhtml += tableHeaderHtml();
+            FORECAST_ROWS.forEach(function(r, idx) {
+                var alt = (idx % 2 === 1) ? ' table-row-alt' : '';
+                fhtml += tableRowHtml(r, 'table-row' + alt);
+            });
+            fhtml += '</div></div>';
+        }
+        forecastEl.innerHTML = fhtml;
+    }
+
+    // 地图图例（强度用圆点，与路径点一致）
+    var legend = document.getElementById('map-legend');
+    if (legend) {
+        var lhtml = '<div class="lg-title">图例</div>';
+        [1, 2, 3, 4, 5, 6].forEach(function(cat) {
+            lhtml +=
+                '<div class="lg-row">' +
+                    '<span class="lg-swatch" style="background:' + CAT_COLORS[cat] + '"></span>' +
+                    '<span>' + escapeHtml(CAT_NAMES[cat]) + '</span>' +
+                '</div>';
+        });
+        lhtml += '<div class="lg-sep"></div>';
+        lhtml +=
+            '<div class="lg-row">' +
+                '<span class="lg-line solid"></span><span>历史路径</span>' +
+            '</div>' +
+            '<div class="lg-row">' +
+                '<span class="lg-line dashed"></span><span>预报路径</span>' +
+            '</div>' +
+            '<div class="lg-row">' +
+                '<span class="lg-dot" style="background:#32afff"></span><span>历史定位</span>' +
+            '</div>' +
+            '<div class="lg-row">' +
+                '<span class="lg-dot hollow"></span><span>预报定位</span>' +
+            '</div>';
+        lhtml += '<div class="lg-sep"></div>';
+        lhtml +=
+            '<div class="lg-wind">' +
+                '<span class="lg-ring" style="border-color:#64b4ff"></span>7级风圈' +
+            '</div>' +
+            '<div class="lg-wind">' +
+                '<span class="lg-ring" style="border-color:#ffc832"></span>10级风圈' +
+            '</div>' +
+            '<div class="lg-wind">' +
+                '<span class="lg-ring" style="border-color:#ff5000"></span>12级风圈' +
+            '</div>';
+        legend.innerHTML = lhtml;
+    }
+
+    var wm = document.getElementById('watermark');
+    if (wm) wm.textContent = PANEL.watermark_text || '';
+
+    var chartMeta = document.getElementById('chart-meta');
+    if (chartMeta) {
+        if (CHART_TIMES.length >= 2) {
+            chartMeta.textContent =
+                (CHART_TIMES[0] || '') + ' → ' + (CHART_TIMES[CHART_TIMES.length - 1] || '');
+        } else {
+            chartMeta.textContent = '';
+        }
+    }
+}
+
+// ── 地图 ──
+var map = null;
+try {
+    // 先给一个临时中心，确保 Leaflet 完成 _loaded，后续 getSize/setView 才可靠
+    map = L.map('map', {
+        zoomControl: false,
+        attributionControl: false,
+        zoomAnimation: false,
+        fadeAnimation: false,
+        markerZoomAnimation: false,
+        zoomSnap: 0.25,
+        zoomDelta: 0.5,
+        center: [22, 112],
+        zoom: 6
+    });
+} catch (e) {
+    console.error('[台风] L.map 初始化失败:', e, e.stack);
+}
+
+var tileLayer = null;
+try {
+    if (map && TILE_URL) {
+        tileLayer = L.tileLayer(TILE_URL, {
+            maxZoom: 18,
+            minZoom: 0,
+            keepBuffer: 2,
+            updateWhenIdle: true,
+            updateWhenZooming: false
+        }).addTo(map);
+    }
+} catch (e) {
+    console.error('[台风] tileLayer 创建失败:', e, e.stack);
+}
+
+if (tileLayer) {
+    tileLayer.on('tileerror', function(e) {
+        var img = e.tile;
+        if (!img || !img.src) return;
+        var retries = parseInt(img.dataset.retryCount || '0', 10);
+        if (retries >= 3) return;
+        img.dataset.retryCount = String(retries + 1);
+        var delay = (retries + 1) * 1000;
+        var coords = img._coords || {};
+        this.fire('tileloadstart', { tile: img, coords: coords, url: img.src });
+        setTimeout(function() {
+            var sep = img.src.indexOf('?') > -1 ? '&' : '?';
+            img.src = img.src.split('?')[0] + sep + '_retry=' + Date.now() + '_' + retries;
+        }, delay);
+    });
+}
+
+var canvas = document.getElementById('overlay-canvas');
+var ctx = canvas.getContext('2d');
+
+function resizeCanvas() {
+    if (!map) return false;
+    var rect = map.getContainer().getBoundingClientRect();
+    if (rect.width < 1 || rect.height < 1) return false;
+    canvas.width = rect.width;
+    canvas.height = rect.height;
+    return true;
+}
+
+function toPt(lat, lon) {
+    if (!map) return null;
+    var p = map.latLngToContainerPoint([lat, lon]);
+    return (isFinite(p.x) && isFinite(p.y)) ? p : null;
+}
+
+function kmToPx(lat, lon, km) {
+    var center = toPt(lat, lon);
+    if (!center) return 0;
+    var dLon = km / (111.32 * Math.cos(lat * Math.PI / 180));
+    var east = toPt(lat, lon + dLon);
+    if (!east) return 0;
+    return Math.abs(east.x - center.x);
+}
+
+function strokeSegment(x0, y0, x1, y1, color, width, glowColor, glowWidth) {
+    if (glowColor && glowWidth) {
+        ctx.beginPath();
+        ctx.moveTo(x0, y0);
+        ctx.lineTo(x1, y1);
+        ctx.strokeStyle = glowColor;
+        ctx.lineWidth = glowWidth;
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+        ctx.stroke();
+    }
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(x1, y1);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    ctx.stroke();
+}
+
+function drawLabel(text, x, y, options) {
+    if (!text) return;
+    var opt = options || {};
+    var font = opt.font || 'bold 10px "Microsoft YaHei"';
+    var color = opt.color || '#e8ecf4';
+    var align = opt.align || 'center';
+    var baseline = opt.baseline || 'bottom';
+    var bg = opt.bg || 'rgba(8,10,16,0.78)';
+    var border = opt.border || 'rgba(255,255,255,0.12)';
+    var padX = opt.padX != null ? opt.padX : 5;
+    var padY = opt.padY != null ? opt.padY : 3;
+    var radius = opt.radius != null ? opt.radius : 3;
+    ctx.save();
+    ctx.font = font;
+    ctx.textAlign = align;
+    ctx.textBaseline = baseline;
+    var metrics = ctx.measureText(text);
+    var tw = metrics.width;
+    var th = opt.th || 13;
+    var bx = x - (align === 'center' ? tw / 2 : (align === 'right' ? tw : 0)) - padX;
+    var by = y - th - padY;
+    if (baseline === 'top') by = y - padY;
+    if (baseline === 'middle') by = y - th / 2 - padY;
+    ctx.fillStyle = bg;
+    ctx.strokeStyle = border;
+    ctx.lineWidth = 1;
+    roundRect(ctx, bx, by, tw + padX * 2, th + padY * 2, radius);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = color;
+    var ty = y;
+    if (baseline === 'bottom') ty = y - 3;
+    if (baseline === 'middle') ty = y + 0.5;
+    ctx.fillText(text, x, ty);
+    ctx.restore();
+}
+
+/**
+ * 参考专业台风图：等级色块 + 名称/时间白底黑字，贴在当前点右侧。
+ * 例： [强台风] 巴威 11日6时
+ */
+function drawCurrentPointBadge(cx, cy, parts) {
+    if (!parts || !parts.length) return;
+    var gap = 6;
+    var x = cx + 12;
+    var y = cy;
+    var h = 18;
+    var padX = 6;
+    var totalW = 0;
+    var measured = [];
+    ctx.save();
+    ctx.font = 'bold 11px "Microsoft YaHei"';
+    for (var i = 0; i < parts.length; i++) {
+        var p = parts[i];
+        var tw = ctx.measureText(p.text || '').width;
+        var w = tw + padX * 2;
+        measured.push({ text: p.text || '', color: p.color || '#111', bg: p.bg || '#fff', w: w });
+        totalW += w;
+    }
+    // 整体描边底，保证清晰
+    ctx.fillStyle = 'rgba(0,0,0,0.18)';
+    roundRect(ctx, x - 1, y - h / 2 - 1, totalW + 2, h + 2, 4);
+    ctx.fill();
+
+    var ox = x;
+    for (i = 0; i < measured.length; i++) {
+        var m = measured[i];
+        var isFirst = i === 0;
+        var isLast = i === measured.length - 1;
+        ctx.beginPath();
+        if (isFirst && isLast) {
+            roundRect(ctx, ox, y - h / 2, m.w, h, 4);
+        } else if (isFirst) {
+            // 左圆角
+            var r = 4;
+            ctx.moveTo(ox + r, y - h / 2);
+            ctx.lineTo(ox + m.w, y - h / 2);
+            ctx.lineTo(ox + m.w, y + h / 2);
+            ctx.lineTo(ox + r, y + h / 2);
+            ctx.quadraticCurveTo(ox, y + h / 2, ox, y + h / 2 - r);
+            ctx.lineTo(ox, y - h / 2 + r);
+            ctx.quadraticCurveTo(ox, y - h / 2, ox + r, y - h / 2);
+            ctx.closePath();
+        } else if (isLast) {
+            r = 4;
+            ctx.moveTo(ox, y - h / 2);
+            ctx.lineTo(ox + m.w - r, y - h / 2);
+            ctx.quadraticCurveTo(ox + m.w, y - h / 2, ox + m.w, y - h / 2 + r);
+            ctx.lineTo(ox + m.w, y + h / 2 - r);
+            ctx.quadraticCurveTo(ox + m.w, y + h / 2, ox + m.w - r, y + h / 2);
+            ctx.lineTo(ox, y + h / 2);
+            ctx.closePath();
+        } else {
+            ctx.rect(ox, y - h / 2, m.w, h);
+        }
+        ctx.fillStyle = m.bg;
+        ctx.fill();
+        ctx.fillStyle = m.color;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(m.text, ox + m.w / 2, y + 0.5);
+        ox += m.w;
+    }
+    ctx.restore();
+}
+
+function roundRect(c, x, y, w, h, r) {
+    var rr = Math.min(r, w / 2, h / 2);
+    c.beginPath();
+    c.moveTo(x + rr, y);
+    c.arcTo(x + w, y, x + w, y + h, rr);
+    c.arcTo(x + w, y + h, x, y + h, rr);
+    c.arcTo(x, y + h, x, y, rr);
+    c.arcTo(x, y, x + w, y, rr);
+    c.closePath();
+}
+
+function drawRadiiPoly(cx, cy, lat, lon, radii, fillColor, edgeColor, dashed, lineWidth) {
+    if (!radii) return;
+    var quads = [[0, 90, 'NE'], [90, 180, 'SE'], [180, 270, 'SW'], [270, 360, 'NW']];
+    var hasAny = quads.some(function(q) { return radii[q[2]] > 0; });
+    if (!hasAny) return;
+    var polyPts = [];
+    quads.forEach(function(q) {
+        var rk = radii[q[2]];
+        if (!rk || rk <= 0) return;
+        var rp = kmToPx(lat, lon, rk);
+        if (rp < 3) return;
+        for (var deg = q[0]; deg <= q[1]; deg += 6) {
+            var rad = deg * Math.PI / 180;
+            polyPts.push([cx + rp * Math.cos(rad), cy - rp * Math.sin(rad)]);
+        }
+    });
+    if (polyPts.length < 3) return;
+    ctx.beginPath();
+    ctx.moveTo(polyPts[0][0], polyPts[0][1]);
+    for (var i = 1; i < polyPts.length; i++) ctx.lineTo(polyPts[i][0], polyPts[i][1]);
+    ctx.closePath();
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    if (dashed) ctx.setLineDash([6, 4]);
+    ctx.strokeStyle = edgeColor;
+    ctx.lineWidth = lineWidth != null ? lineWidth : 1.5;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+    if (dashed) ctx.setLineDash([]);
+}
+
+function drawMoveArrow(cx, cy, bearing, color) {
+    if (bearing === null || bearing === undefined) return;
+    var rad = (bearing - 90) * Math.PI / 180; // canvas: 0°=东，转成北为 0
+    // 上面公式：地理 0=北 → canvas 角
+    rad = (bearing) * Math.PI / 180;
+    // 北=0：x = sin(b), y = -cos(b)
+    var len = 28;
+    var ex = cx + Math.sin(rad) * len;
+    var ey = cy - Math.cos(rad) * len;
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.fillStyle = color;
+    ctx.lineWidth = 2.5;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(ex, ey);
+    ctx.stroke();
+    // 箭头头部
+    var ah = 8;
+    var left = bearing - 150;
+    var right = bearing + 150;
+    var lr = left * Math.PI / 180;
+    var rr = right * Math.PI / 180;
+    ctx.beginPath();
+    ctx.moveTo(ex, ey);
+    ctx.lineTo(ex + Math.sin(lr) * ah, ey - Math.cos(lr) * ah);
+    ctx.lineTo(ex + Math.sin(rr) * ah, ey - Math.cos(rr) * ah);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+}
+
+function drawTyphoonSymbol(cx, cy, color) {
+    // 简化双臂螺旋 + 中心眼
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.strokeStyle = color;
+    ctx.fillStyle = color;
+    ctx.lineWidth = 1.8;
+    ctx.lineCap = 'round';
+    for (var arm = 0; arm < 2; arm++) {
+        ctx.beginPath();
+        for (var t = 0; t <= 28; t++) {
+            var ang = (t / 28) * Math.PI * 1.15 + arm * Math.PI;
+            var rad = 3 + t * 0.35;
+            var x = Math.cos(ang) * rad;
+            var y = Math.sin(ang) * rad;
+            if (t === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+    }
+    ctx.beginPath();
+    ctx.arc(0, 0, 2.2, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.9)';
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(0, 0, 3.4, 0, Math.PI * 2);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.4;
+    ctx.stroke();
+    ctx.restore();
+}
+
+/**
+ * 解析节点时间戳（秒）。无法解析返回 null。
+ * 支持 ISO / "YYYY-MM-DD HH:mm" / "MM/DD HH:mm" 等常见格式。
+ */
+function parseNodeEpoch(node) {
+    if (!node) return null;
+    var raw = String(node.timeRaw || '').trim();
+    if (!raw) return null;
+    var d = new Date(raw.replace(/-/g, '/'));
+    if (!isNaN(d.getTime())) return d.getTime() / 1000;
+    var m = raw.match(/(?:(\d{4})[\/\-年])?(\d{1,2})[\/\-月](\d{1,2}).*?(\d{1,2}):(\d{2})/);
+    if (m) {
+        var y = m[1] ? parseInt(m[1], 10) : (new Date()).getFullYear();
+        var mo = parseInt(m[2], 10) - 1;
+        var da = parseInt(m[3], 10);
+        var hh = parseInt(m[4], 10);
+        var mi = parseInt(m[5], 10);
+        var dd = new Date(y, mo, da, hh, mi, 0);
+        if (!isNaN(dd.getTime())) return dd.getTime() / 1000;
+    }
+    return null;
+}
+
+function nodeHasRadii(node) {
+    return !!(node && (node.r7 || node.r10 || node.r12));
+}
+
+/**
+ * 历史风圈采样：约每 24h 一个，含当前点。
+ * 缺数据时在 ±18h 窗口内向前/向后回退找最近有风圈的点；
+ * 仍无则跳过该槽位，保证不乱画。
+ */
+function selectHistoryRadiiIndices(nodes) {
+    if (!nodes || !nodes.length) return [];
+    var n = nodes.length;
+    var last = n - 1;
+    var epochs = nodes.map(parseNodeEpoch);
+    var selected = [];
+    var used = {};
+
+    function pushIdx(idx) {
+        if (idx == null || idx < 0 || idx >= n) return;
+        if (used[idx]) return;
+        if (!nodeHasRadii(nodes[idx])) return;
+        used[idx] = true;
+        selected.push(idx);
+    }
+
+    if (nodeHasRadii(nodes[last])) {
+        pushIdx(last);
+    } else {
+        for (var back = 1; back <= 6; back++) {
+            if (last - back >= 0 && nodeHasRadii(nodes[last - back])) {
+                pushIdx(last - back);
+                break;
+            }
+        }
+    }
+
+    var lastEpoch = epochs[last];
+    if (lastEpoch == null) {
+        var step = 8;
+        for (var i = last - step; i >= 0; i -= step) {
+            var found = -1;
+            if (nodeHasRadii(nodes[i])) found = i;
+            else {
+                for (var d = 1; d <= 3; d++) {
+                    if (i - d >= 0 && nodeHasRadii(nodes[i - d])) { found = i - d; break; }
+                    if (i + d < n && nodeHasRadii(nodes[i + d])) { found = i + d; break; }
+                }
+            }
+            if (found >= 0) pushIdx(found);
+        }
+        return selected.sort(function(a, b) { return a - b; });
+    }
+
+    var DAY = 24 * 3600;
+    var WINDOW = 18 * 3600;
+    var target = lastEpoch - DAY;
+    var minEpoch = null;
+    for (i = 0; i < n; i++) {
+        if (epochs[i] != null) {
+            minEpoch = (minEpoch == null) ? epochs[i] : Math.min(minEpoch, epochs[i]);
+        }
+    }
+    if (minEpoch == null) minEpoch = lastEpoch - DAY * 10;
+
+    while (target >= minEpoch - WINDOW) {
+        var best = -1;
+        var bestDist = Infinity;
+        for (i = 0; i < n; i++) {
+            if (epochs[i] == null) continue;
+            var dist = Math.abs(epochs[i] - target);
+            if (dist <= WINDOW && dist < bestDist && nodeHasRadii(nodes[i])) {
+                var tooClose = false;
+                for (var s = 0; s < selected.length; s++) {
+                    var se = epochs[selected[s]];
+                    if (se != null && Math.abs(se - epochs[i]) < 12 * 3600) {
+                        tooClose = true;
+                        break;
+                    }
+                }
+                if (tooClose) continue;
+                bestDist = dist;
+                best = i;
+            }
+        }
+        if (best >= 0) pushIdx(best);
+        target -= DAY;
+    }
+    return selected.sort(function(a, b) { return a - b; });
+}
+
+function drawRadiiAt(node, pt, isCurrent) {
+    if (!node || !pt || !nodeHasRadii(node)) return;
+    // 历史风圈提高对比度，避免“看不见”；当前点更实
+    var a7 = isCurrent ? 0.18 : 0.12;
+    var a10 = isCurrent ? 0.20 : 0.14;
+    var a12 = isCurrent ? 0.20 : 0.14;
+    var e7 = isCurrent ? 0.82 : 0.68;
+    var e10 = isCurrent ? 0.88 : 0.74;
+    var e12 = isCurrent ? 0.92 : 0.78;
+    var lw = isCurrent ? 1.8 : 1.6;
+    drawRadiiPoly(
+        pt.x, pt.y, node.lat, node.lon, node.r7,
+        'rgba(100,180,255,' + a7 + ')', 'rgba(100,180,255,' + e7 + ')', !isCurrent, lw
+    );
+    drawRadiiPoly(
+        pt.x, pt.y, node.lat, node.lon, node.r10,
+        'rgba(255,200,50,' + a10 + ')', 'rgba(255,200,50,' + e10 + ')', !isCurrent, lw
+    );
+    drawRadiiPoly(
+        pt.x, pt.y, node.lat, node.lon, node.r12,
+        'rgba(255,80,0,' + a12 + ')', 'rgba(255,80,0,' + e12 + ')', !isCurrent, lw
+    );
+}
+
+function formatBadgeTime(node) {
+    if (!node) return '';
+    // 优先 timeRaw（EQSC 原始时间），避免把年份前两位误读成“日”
+    // 例：2020-09-06 17:00 → 6日17时（旧正则会错成 20日17时）
+    var parts = parseTrackDateParts(node.timeRaw || '');
+    if (parts && parts.day >= 1) {
+        return parts.day + '日' + parts.hour + '时';
+    }
+    // 回退：仅有 HH:mm
+    if (node.ts) {
+        var hm = String(node.ts).split(':');
+        if (hm.length >= 1) return parseInt(hm[0], 10) + '时';
+    }
+    return '';
+}
+
+function drawTrack() {
+    if (map) map.invalidateSize({ pan: false, debounceMoveend: true });
+    if (!map) return;
+    var dpr = Math.max(window.devicePixelRatio || 1, 1.5);
+    var rect = map.getContainer().getBoundingClientRect();
+    if (rect.width < 1 || rect.height < 1) return;
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+    canvas.style.width = rect.width + 'px';
+    canvas.style.height = rect.height + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, rect.width, rect.height);
+    ctx.imageSmoothingEnabled = true;
+    if (ctx.imageSmoothingQuality) ctx.imageSmoothingQuality = 'high';
+
+    var DOT_R = 3.6;
+    var LINE_W = 2.4;
+    var FCST_LINE_W = 2.1;
+    var pts = [];
+
+    if (PAST.length > 0) {
+        pts = PAST.map(function(p) { return toPt(p.lat, p.lon); }).filter(Boolean);
+        if (pts.length < 1) return;
+
+        var lastIdx = pts.length - 1;
+
+        // 1) 历史风圈：约每 24h 一个（含当前），先画以免盖住路径
+        var radiiIdx = selectHistoryRadiiIndices(PAST);
+        for (var ri = 0; ri < radiiIdx.length; ri++) {
+            var rIdx = radiiIdx[ri];
+            if (rIdx < 0 || rIdx >= pts.length) continue;
+            drawRadiiAt(PAST[rIdx], pts[rIdx], rIdx === lastIdx);
+        }
+
+        // 2) 历史路径：分段强度色，实线 + 轻描边
+        if (pts.length >= 2) {
+            for (var i = 1; i < pts.length; i++) {
+                var segCat = PAST[i].cat || PAST[i - 1].cat || 0;
+                var segColor = CAT_COLORS[segCat] || '#969696';
+                strokeSegment(
+                    pts[i - 1].x, pts[i - 1].y,
+                    pts[i].x, pts[i].y,
+                    segColor,
+                    LINE_W,
+                    'rgba(0,0,0,0.18)',
+                    LINE_W + 1.6
+                );
+            }
+        }
+
+        // 3) 历史定位点：统一小圆点 + 深色描边
+        for (i = 0; i < pts.length; i++) {
+            if (i === lastIdx) continue;
+            var p = PAST[i];
+            var cp = pts[i];
+            var c = CAT_COLORS[p.cat] || '#969696';
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R + 0.9, 0, Math.PI * 2);
+            ctx.fillStyle = 'rgba(0,0,0,0.35)';
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R, 0, Math.PI * 2);
+            ctx.fillStyle = c;
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R, 0, Math.PI * 2);
+            ctx.strokeStyle = 'rgba(0,0,0,0.35)';
+            ctx.lineWidth = 0.8;
+            ctx.stroke();
+        }
+    }
+
+    // 4) 预报路径：虚线 + 小圆点
+    if (FCST.length > 0 && map) {
+        var fpts = FCST.map(function(p) {
+            return map.latLngToContainerPoint([p.lat, p.lon]);
+        }).filter(Boolean);
+
+        if (PAST.length > 0 && fpts.length > 0) {
+            var joinPt = map.latLngToContainerPoint([
+                PAST[PAST.length - 1].lat,
+                PAST[PAST.length - 1].lon
+            ]);
+            var joinColor = CAT_COLORS[FCST[0].cat || PAST[PAST.length - 1].cat] || '#969696';
+            ctx.setLineDash([5, 4]);
+            strokeSegment(
+                joinPt.x, joinPt.y,
+                fpts[0].x, fpts[0].y,
+                joinColor,
+                FCST_LINE_W,
+                'rgba(0,0,0,0.14)',
+                FCST_LINE_W + 1.4
+            );
+            ctx.setLineDash([]);
+        }
+
+        if (fpts.length >= 2) {
+            for (i = 1; i < fpts.length; i++) {
+                var fc = CAT_COLORS[FCST[i].cat || FCST[i - 1].cat] || '#969696';
+                ctx.setLineDash([5, 4]);
+                strokeSegment(
+                    fpts[i - 1].x, fpts[i - 1].y,
+                    fpts[i].x, fpts[i].y,
+                    fc,
+                    FCST_LINE_W,
+                    'rgba(0,0,0,0.14)',
+                    FCST_LINE_W + 1.4
+                );
+                ctx.setLineDash([]);
+            }
+        }
+
+        for (i = 0; i < fpts.length; i++) {
+            p = FCST[i];
+            cp = fpts[i];
+            c = CAT_COLORS[p.cat] || '#969696';
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R - 0.1, 0, Math.PI * 2);
+            ctx.fillStyle = c;
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R + 0.7, 0, Math.PI * 2);
+            ctx.strokeStyle = 'rgba(255,255,255,0.55)';
+            ctx.lineWidth = 1.1;
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(cp.x, cp.y, DOT_R + 0.7, 0, Math.PI * 2);
+            ctx.strokeStyle = 'rgba(0,0,0,0.28)';
+            ctx.lineWidth = 0.7;
+            ctx.stroke();
+        }
+    }
+
+    // 5) 当前中心：白环 + 色芯（无中心白点）+ 轻光晕 + 参考图风格标签
+    if (PAST.length > 0 && pts.length > 0) {
+        var last = PAST[pts.length - 1];
+        var lp = pts[pts.length - 1];
+        var mc = CAT_COLORS[last.cat] || '#969696';
+
+        for (var gr = 12; gr > 7; gr--) {
+            var alpha = Math.max(0, 0.12 - (12 - gr) * 0.02);
+            ctx.beginPath();
+            ctx.arc(lp.x, lp.y, gr, 0, Math.PI * 2);
+            ctx.fillStyle = hexWithAlpha(mc, alpha);
+            ctx.fill();
+        }
+
+        // 外白环
+        ctx.beginPath();
+        ctx.arc(lp.x, lp.y, 7.2, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(255,255,255,0.98)';
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(lp.x, lp.y, 7.2, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(0,0,0,0.28)';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        // 色芯（实心，不再叠中心白点）
+        ctx.beginPath();
+        ctx.arc(lp.x, lp.y, 5.0, 0, Math.PI * 2);
+        ctx.fillStyle = mc;
+        ctx.fill();
+
+        var levelText = last.level || PANEL.category_name || '';
+        var nameText = String(PANEL.event_name || '').trim();
+        nameText = nameText.replace(/\s*[（(][^）)]*[）)]\s*/g, '').trim();
+        var timeText = formatBadgeTime(last);
+        var badgeParts = [];
+        if (levelText) {
+            badgeParts.push({ text: levelText, color: '#ffffff', bg: mc });
+        }
+        var rightBits = [];
+        if (nameText) rightBits.push(nameText);
+        if (timeText) rightBits.push(timeText);
+        if (rightBits.length) {
+            badgeParts.push({ text: rightBits.join(' '), color: '#111111', bg: '#ffffff' });
+        }
+        if (badgeParts.length) {
+            drawCurrentPointBadge(lp.x, lp.y, badgeParts);
+        }
+    }
+}
+
+/**
+ * 迷你曲线图：风速/气压双轴独立缩放 + 单调三次 Hermite 平滑曲线。
+ * 避免折线生硬与标签重叠，便于观察相对变化。
+ */
+function drawMiniChart() {
+    var cvs = document.getElementById('mini-chart');
+    if (!cvs || !cvs.parentElement) return;
+    var rect = cvs.parentElement.getBoundingClientRect();
+    var W = Math.max(rect.width - 2, 40);
+    var H = Math.max(rect.height - 2, 40);
+    var dpr = Math.max(window.devicePixelRatio || 1, 2);
+    cvs.width = Math.round(W * dpr);
+    cvs.height = Math.round(H * dpr);
+    cvs.style.width = W + 'px';
+    cvs.style.height = H + 'px';
+    var cx = cvs.getContext('2d');
+    cx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    cx.clearRect(0, 0, W, H);
+    cx.imageSmoothingEnabled = true;
+    if (cx.imageSmoothingQuality) cx.imageSmoothingQuality = 'high';
+
+    if (!CHART_WINDS.length && !CHART_PRESS.length) return;
+
+    // 左右内边距：右侧给端点数值标签，避免溢出卡片
+    var padL = 4;
+    var padR = 44;
+    var padT = 12;
+    var padB = 15;
+    var plotW = Math.max(W - padL - padR, 10);
+    var plotH = Math.max(H - padT - padB, 10);
+
+    function validValues(values) {
+        if (!values || !values.length) return [];
+        return values.filter(function(v) {
+            return v !== null && v !== undefined && isFinite(v) && v > 0;
+        });
+    }
+
+    function rangeOf(values, padRatio) {
+        var vals = validValues(values);
+        if (!vals.length) return { mn: 0, mx: 1 };
+        var mn = Math.min.apply(null, vals);
+        var mx = Math.max.apply(null, vals);
+        if (mx - mn < 1e-6) {
+            var mid = mn || 1;
+            return { mn: mid * 0.92, mx: mid * 1.08 };
+        }
+        var pad = (mx - mn) * (padRatio != null ? padRatio : 0.12);
+        return { mn: mn - pad, mx: mx + pad };
+    }
+
+    function pointsOf(values, rng, invertY) {
+        if (!values || values.length < 1) return [];
+        var step = plotW / Math.max(values.length - 1, 1);
+        var span = (rng.mx - rng.mn) || 1;
+        return values.map(function(v, idx) {
+            var vv = (v !== null && v !== undefined && isFinite(v)) ? v : rng.mn;
+            var norm = (vv - rng.mn) / span;
+            norm = Math.max(0, Math.min(1, norm));
+            return {
+                x: padL + idx * step,
+                y: invertY
+                    ? padT + norm * plotH
+                    : padT + (1 - norm) * plotH,
+                v: vv
+            };
+        });
+    }
+
+    // 单调三次 Hermite（Fritsch–Carlson）控制点，避免过冲。
+    // 假定当前路径点已在 pts[0]，不再 moveTo，避免打断面积填充。
+    function smoothPath(pts) {
+        if (!pts || pts.length < 2) return;
+        if (pts.length === 2) {
+            cx.lineTo(pts[1].x, pts[1].y);
+            return;
+        }
+        var nPts = pts.length;
+        var dx = [];
+        var dy = [];
+        var m = [];
+        var i;
+        for (i = 0; i < nPts - 1; i++) {
+            dx[i] = pts[i + 1].x - pts[i].x;
+            dy[i] = pts[i + 1].y - pts[i].y;
+            m[i] = dx[i] !== 0 ? dy[i] / dx[i] : 0;
+        }
+        var tang = [];
+        tang[0] = m[0];
+        tang[nPts - 1] = m[nPts - 2];
+        for (i = 1; i < nPts - 1; i++) {
+            if (m[i - 1] * m[i] <= 0) tang[i] = 0;
+            else tang[i] = (m[i - 1] + m[i]) / 2;
+        }
+        // 限制过冲
+        for (i = 0; i < nPts - 1; i++) {
+            if (Math.abs(m[i]) < 1e-8) {
+                tang[i] = 0;
+                tang[i + 1] = 0;
+            } else {
+                var a = tang[i] / m[i];
+                var b = tang[i + 1] / m[i];
+                var s = a * a + b * b;
+                if (s > 9) {
+                    var t = 3 / Math.sqrt(s);
+                    tang[i] = t * a * m[i];
+                    tang[i + 1] = t * b * m[i];
+                }
+            }
+        }
+        for (i = 0; i < nPts - 1; i++) {
+            var p0 = pts[i];
+            var p1 = pts[i + 1];
+            var h = dx[i];
+            var c1x = p0.x + h / 3;
+            var c1y = p0.y + tang[i] * h / 3;
+            var c2x = p1.x - h / 3;
+            var c2y = p1.y - tang[i + 1] * h / 3;
+            cx.bezierCurveTo(c1x, c1y, c2x, c2y, p1.x, p1.y);
+        }
+    }
+
+    function drawSmoothSeries(values, color, invertY, unit, labelSide) {
+        var rng = rangeOf(values, 0.14);
+        var pts = pointsOf(values, rng, invertY);
+        if (pts.length < 2) return pts;
+
+        // 面积填充（淡）
+        cx.beginPath();
+        cx.moveTo(pts[0].x, padT + plotH);
+        cx.lineTo(pts[0].x, pts[0].y);
+        smoothPath(pts);
+        cx.lineTo(pts[pts.length - 1].x, padT + plotH);
+        cx.closePath();
+        cx.fillStyle = color.replace('0.95)', '0.10)').replace('0.9)', '0.10)');
+        cx.fill();
+
+        // 平滑曲线
+        cx.beginPath();
+        cx.moveTo(pts[0].x, pts[0].y);
+        smoothPath(pts);
+        cx.strokeStyle = color;
+        cx.lineWidth = 2.0;
+        cx.lineJoin = 'round';
+        cx.lineCap = 'round';
+        cx.stroke();
+
+        // 端点
+        [pts[0], pts[pts.length - 1]].forEach(function(pt, idx) {
+            cx.beginPath();
+            cx.arc(pt.x, pt.y, idx === 1 ? 2.6 : 2.0, 0, Math.PI * 2);
+            cx.fillStyle = color;
+            cx.fill();
+            cx.beginPath();
+            cx.arc(pt.x, pt.y, idx === 1 ? 2.6 : 2.0, 0, Math.PI * 2);
+            cx.strokeStyle = 'rgba(0,0,0,0.25)';
+            cx.lineWidth = 0.7;
+            cx.stroke();
+        });
+
+        // 最新值标签：画在曲线末端右侧留白区内，带底避免溢出裁切
+        var last = pts[pts.length - 1];
+        var label = Math.round(last.v) + unit;
+        cx.font = 'bold 9px "Microsoft YaHei"';
+        var tw = cx.measureText(label).width;
+        var lx = Math.min(last.x + 5, W - tw - 3);
+        // 若贴右边，改画在点左侧
+        if (lx + tw > W - 2) lx = Math.max(2, last.x - tw - 5);
+        var ly = last.y;
+        if (labelSide === 'top') {
+            ly = Math.max(padT + 8, last.y - 6);
+        } else {
+            ly = Math.min(padT + plotH - 4, last.y + 8);
+        }
+        // 半透明底
+        var bh = 12;
+        var bw = tw + 6;
+        cx.fillStyle = 'rgba(8,10,16,0.62)';
+        roundRect(cx, lx - 3, ly - bh / 2, bw, bh, 3);
+        cx.fill();
+        cx.fillStyle = color;
+        cx.textAlign = 'left';
+        cx.textBaseline = 'middle';
+        cx.fillText(label, lx, ly + 0.5);
+        return pts;
+    }
+
+    // 风速：上高下低；气压：上低下高（invertY），双轴独立
+    drawSmoothSeries(CHART_WINDS, 'rgba(255,150,20,0.95)', false, 'm/s', 'top');
+    drawSmoothSeries(CHART_PRESS, 'rgba(100,185,255,0.95)', true, 'hPa', 'bottom');
+
+    // 时间刻度（仅首/中/尾，避免拥挤）
+    if (CHART_TIMES.length >= 2) {
+        cx.fillStyle = '#6f788a';
+        cx.font = '9px "Microsoft YaHei"';
+        cx.textBaseline = 'top';
+        var labels = [
+            { idx: 0, align: 'left' },
+            { idx: Math.floor((CHART_TIMES.length - 1) / 2), align: 'center' },
+            { idx: CHART_TIMES.length - 1, align: 'right' }
+        ];
+        labels.forEach(function(item) {
+            var t = CHART_TIMES[item.idx] || '';
+            if (!t) return;
+            var x = padL + (plotW * item.idx) / Math.max(CHART_TIMES.length - 1, 1);
+            cx.textAlign = item.align;
+            cx.fillText(t, x, padT + plotH + 3);
+        });
+    }
+}
+
+/**
+ * 从路径点取四至（最西/最东/最南/最北）。
+ * 只吃 PAST/FCST 实际点，不吃 bootstrap 默认大区。
+ */
+function computeTrackBoundsRaw() {
+    var lats = [];
+    var lons = [];
+    function collect(nodes) {
+        if (!nodes) return;
+        for (var i = 0; i < nodes.length; i++) {
+            var n = nodes[i];
+            if (!n) continue;
+            var lat = Number(n.lat);
+            var lon = Number(n.lon);
+            if (!isFinite(lat) || !isFinite(lon)) continue;
+            if (lat < -80 || lat > 80 || lon < -180 || lon > 180) continue;
+            lats.push(lat);
+            lons.push(lon);
+        }
+    }
+    collect(PAST);
+    collect(FCST);
+
+    if (!lats.length || !lons.length) {
+        return {
+            la: Number(VIEW.la) || 5,
+            ha: Number(VIEW.ha) || 45,
+            lo: Number(VIEW.lo) || 100,
+            hi: Number(VIEW.hi) || 170,
+            fromTrack: false
+        };
+    }
+    return {
+        la: Math.min.apply(null, lats),
+        ha: Math.max.apply(null, lats),
+        lo: Math.min.apply(null, lons),
+        hi: Math.max.apply(null, lons),
+        fromTrack: true
+    };
+}
+
+/** Web Mercator Y（0~1，北小南大的补：这里用标准 0 北→南 递增） */
+function mercatorY(lat) {
+    var rad = lat * Math.PI / 180;
+    var s = Math.sin(rad);
+    // 限制避免极区 inf
+    s = Math.max(-0.9999, Math.min(0.9999, s));
+    return 0.5 - Math.log((1 + s) / (1 - s)) / (4 * Math.PI);
+}
+
+/**
+ * 按路径四至 + 可用像素，手动计算 zoom，再按像素位置精确对齐。
+ *
+ * 对齐策略（适配新 zoom 算法）：
+ * 1) 先用世界像素公式算 zoom，使路径落入“坞上方可视区”；
+ * 2) setView 到路径中心；
+ * 3) 用 latLngToContainerPoint 实测路径四至像素，
+ *    把路径块居中到可视区，并保证南端不低于坞顶、北端不低于顶边。
+ *
+ * 注意 Leaflet panBy：正 y 让内容上移（中心南移），负 y 让内容下移。
+ */
+function applyMapView() {
+    if (!map) return;
+
+    // 强制用 DOM 实测尺寸，避免 Leaflet 内部 size 未更新
+    var rect = map.getContainer().getBoundingClientRect();
+    var mapW = rect.width || 1000;
+    var mapH = rect.height || 980;
+    if (mapW < 80 || mapH < 80) return;
+
+    try {
+        map.invalidateSize({ pan: false, debounceMoveend: false });
+    } catch (_e) {}
+
+    var raw = computeTrackBoundsRaw();
+    // 没有真实轨迹时不要用默认大区硬 fit，给一个温和中心
+    if (!raw.fromTrack) {
+        map.setView([(raw.la + raw.ha) / 2, (raw.lo + raw.hi) / 2], 5, { animate: false });
+        return;
+    }
+
+    var la = raw.la;
+    var ha = raw.ha;
+    var lo = raw.lo;
+    var hi = raw.hi;
+
+    var lonSpan0 = Math.max(hi - lo, 0.05);
+    var latSpan0 = Math.max(ha - la, 0.05);
+
+    // 紧凑 padding：只留少量呼吸边
+    var padLon = Math.min(Math.max(lonSpan0 * 0.04, 0.15), 0.5);
+    var padLat = Math.min(Math.max(latSpan0 * 0.04, 0.15), 0.5);
+    lo -= padLon; hi += padLon;
+    la -= padLat; ha += padLat;
+    var lonSpan = hi - lo;
+    var latSpan = ha - la;
+
+    // 信息坞：路径只放在坞上方可视区
+    var dockEl = document.getElementById('bottom-dock');
+    var dockH = 188;
+    if (dockEl) {
+        var dr = dockEl.getBoundingClientRect();
+        if (dr.height > 0) dockH = Math.ceil(dr.height + 4);
+    }
+    var padTop = 14;
+    var padSide = Math.max(12, Math.round(mapW * 0.012));
+    var padGap = 10; // 路径南端与信息坞顶的空隙
+    var usableW = Math.max(mapW - padSide * 2, 160);
+    var usableH = Math.max(mapH - dockH - padTop - padGap, 200);
+
+    // 世界边长 = 256 * 2^z
+    var zLon = Math.log(usableW * 360 / (lonSpan * 256)) / Math.LN2;
+    var mercSpan = Math.abs(mercatorY(ha) - mercatorY(la));
+    if (!(mercSpan > 1e-8)) mercSpan = Math.max(latSpan / 360, 1e-6);
+    var zLat = Math.log(usableH / (mercSpan * 256)) / Math.LN2;
+
+    var zoom = Math.min(zLon, zLat);
+    if (!isFinite(zoom)) zoom = 7;
+    // 不再额外 +0.15：避免路径高度超过 usableH 导致南端被坞挡住
+    zoom = Math.max(5, Math.min(zoom, 11));
+    zoom = Math.round(zoom * 4) / 4;
+
+    var centerLat = (la + ha) / 2;
+    var centerLon = (lo + hi) / 2;
+    map.setView([centerLat, centerLon], zoom, { animate: false });
+
+    // ── 像素级精确对齐 ──
+    // 目标可视区：[topY, bottomY] × [leftX, rightX]
+    var topY = padTop;
+    var bottomY = mapH - dockH - padGap;
+    var leftX = padSide;
+    var rightX = mapW - padSide;
+    var usableMidY = (topY + bottomY) / 2;
+    var usableMidX = (leftX + rightX) / 2;
+
+    function trackPixelBox() {
+        // 用四角取包围盒，比只取中线更稳
+        var pts = [
+            map.latLngToContainerPoint([ha, lo]),
+            map.latLngToContainerPoint([ha, hi]),
+            map.latLngToContainerPoint([la, lo]),
+            map.latLngToContainerPoint([la, hi])
+        ];
+        var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+        for (var i = 0; i < pts.length; i++) {
+            if (!pts[i]) continue;
+            if (pts[i].x < minX) minX = pts[i].x;
+            if (pts[i].x > maxX) maxX = pts[i].x;
+            if (pts[i].y < minY) minY = pts[i].y;
+            if (pts[i].y > maxY) maxY = pts[i].y;
+        }
+        return { minX: minX, maxX: maxX, minY: minY, maxY: maxY };
+    }
+
+    try {
+        var box = trackPixelBox();
+        if (!isFinite(box.minY) || !isFinite(box.maxY)) return;
+
+        // 1) 先把路径块中心对齐到可视区中心
+        var trackMidY = (box.minY + box.maxY) / 2;
+        var trackMidX = (box.minX + box.maxX) / 2;
+        // panBy 正 y = 内容上移；路径中心偏下时 dy>0，需要上移
+        var dy = trackMidY - usableMidY;
+        var dx = trackMidX - usableMidX;
+        if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
+            map.panBy([dx, dy], { animate: false });
+        }
+
+        // 2) 硬约束：南端不得进入信息坞，北端不得超出顶边
+        box = trackPixelBox();
+        var fixY = 0;
+        if (box.maxY > bottomY) {
+            // 南端太低 → 内容再上移
+            fixY = box.maxY - bottomY;
+        } else if (box.minY < topY) {
+            // 北端太高 → 内容下移
+            fixY = box.minY - topY;
+        }
+        if (Math.abs(fixY) > 0.5) {
+            map.panBy([0, fixY], { animate: false });
+        }
+
+        // 3) 硬约束：左右不越界（通常 lon 受限时已居中，这里兜底）
+        box = trackPixelBox();
+        var fixX = 0;
+        if (box.minX < leftX) {
+            fixX = box.minX - leftX;
+        } else if (box.maxX > rightX) {
+            fixX = box.maxX - rightX;
+        }
+        if (Math.abs(fixX) > 0.5) {
+            map.panBy([fixX, 0], { animate: false });
+        }
+    } catch (_e2) {}
+}
+
+function init() {
+    renderPanel();
+    requestAnimationFrame(function() {
+        requestAnimationFrame(function() {
+            try {
+                applyMapView();
+
+                if (map && tileLayer && typeof setupStableTileRender === 'function') {
+                    setupStableTileRender(map, tileLayer, {
+                        readyDebounceMs: 500,
+                        readyFallbackMs: 20000,
+                        readyClass: 'map-ready',
+                        debug: false,
+                        onReady: function() {
+                            // 尺寸稳定后强制再算一次 zoom（这是关键）
+                            applyMapView();
+                            drawTrack();
+                            drawMiniChart();
+                        }
+                    });
+                } else {
+                    applyMapView();
+                    drawTrack();
+                    drawMiniChart();
+                    document.body.classList.add('map-ready');
+                }
+            } catch (e) {
+                try {
+                    applyMapView();
+                    drawTrack();
+                    drawMiniChart();
+                } catch (_e) {}
+                document.body.classList.add('map-ready');
+            }
+        });
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    setTimeout(init, 0);
+}
+
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

添加台风路径地图渲染，并在推送消息和查询命令中集成，包括专用的基于 Playwright 的渲染器以及配置选项。

New Features:
- 支持在推送通知中的台风事件生成并附加台风路径图片。
- 支持在台风查询命令结果中附加台风路径图片（当有可用的历史路径数据时）。

Enhancements:
- 引入专用的台风地图渲染器和 HTML 模板，用于消费 EQSC 原生的路径数据和风圈信息。
- 扩展浏览器预热和消息管理器组件，以覆盖台风地图渲染能力。
- 优化台风查询文本格式，使单 ID 查询直接输出摘要正文，而不再包含多余的标题。
- 将台风地图瓦片源配置从通用地图源配置中分离，并对两者进行校验。

Documentation:
- 在 README 中记录新的 `typhoon_map_source` 配置项，并说明其与通用 `map_source` 的关系。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add typhoon track map rendering and integration across push messages and query commands, including a dedicated Playwright-based renderer and configuration options.

New Features:
- Support generating and attaching typhoon path images for typhoon events in push notifications.
- Support attaching a typhoon track image to typhoon query command results when historical track data is available.

Enhancements:
- Introduce a dedicated typhoon map renderer and HTML template that consume EQSC-native track data and wind circles.
- Extend browser prewarming and message manager components to cover typhoon map rendering.
- Refine typhoon query text formatting so single-ID queries directly output the summary body without extra headers.
- Separate typhoon map tile source configuration from the general map source, with validation for both.

Documentation:
- Document the new `typhoon_map_source` configuration option and its relation to the general `map_source` in README.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 台风查询结果支持展示台风路径图，包含历史轨迹、预报路径、风圈及强度趋势。
  * 新增台风路径图地图源配置，支持独立选择并提供默认暗色地图。
  * 单台风详情查询可同时返回文字信息与路径图片。
* **改进**
  * 优化台风查询详情的文本展示，减少重复标题信息。
  * 地图渲染失败时自动回退为文本结果，提升消息发送稳定性。
* **文档**
  * 补充台风路径图地图源配置说明及示例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->