### PR TITLE
fix: 地震情报类型不再附加 P/S 波走时

### DIFF
--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -165,8 +165,17 @@ def _resolve_shock_time(display_context: EarthquakeDisplayContext):
 def _append_local_estimation(
     lines: list[str],
     display_context: EarthquakeDisplayContext,
+    *,
+    include_travel_time: bool = True,
 ) -> None:
-    """把本地影响预估信息附加到文本尾部。"""
+    """把本地影响预估信息附加到文本尾部。
+
+    Args:
+        lines: 待追加的消息行列表。
+        display_context: 地震展示上下文。
+        include_travel_time: 是否附加 P/S 波预计到达时间。
+            仅地震预警（EEW）场景有意义；正式测定/情报类应传 False。
+    """
     local_est = display_context.local_estimation
     if not local_est:
         return
@@ -180,7 +189,10 @@ def _append_local_estimation(
     lines.append(f"📍{place}预估：")
     lines.append(f"距离震中 {dist:.1f} km，预估最大烈度 {inte:.1f} ({desc})")
 
-    # 追加 P/S 波预计到达时间
+    # P/S 波预计到达时间仅对预警类消息有意义（震后情报已无预警价值）
+    if not include_travel_time:
+        return
+
     p_sec = local_est.get("p_travel_sec")
     s_sec = local_est.get("s_travel_sec")
     if p_sec is not None:
@@ -606,6 +618,7 @@ class CencEarthquakePresenter(BasePresenter):
 
         本地预估跟随会话级 local_monitoring 配置生效。
         影响区县预估仅用于中国地震预警，正式测定不附加。
+        情报类不附加 P/S 波走时（震后测定已无预警价值）。
         """
         rendered = cls.format_message(
             display_context, _resolve_options(display_context, options)
@@ -614,8 +627,9 @@ class CencEarthquakePresenter(BasePresenter):
             return rendered
         lines = rendered.split("\n") if rendered else []
         # 本地预估仅在上下文携带 local_estimation 时输出（跟随会话级配置）
+        # 情报类不附加 P/S 波预计到达时间
         if not any("距离震中" in line for line in lines):
-            _append_local_estimation(lines, display_context)
+            _append_local_estimation(lines, display_context, include_travel_time=False)
         return "\n".join(lines)
 
 

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -319,8 +319,7 @@ class CeaEewPresenter(BasePresenter):
             return rendered
         lines = rendered.split("\n") if rendered else []
         # 本地预估仅在上下文携带 local_estimation 时输出（跟随会话级配置）
-        if not any("距离震中" in line for line in lines):
-            _append_local_estimation(lines, display_context)
+        _append_local_estimation(lines, display_context)
         # 追加中国影响区县预估列表（独立于本地监控配置）
         if not any("预估影响区县" in line for line in lines):
             _append_cn_district_estimation(lines, display_context)
@@ -404,8 +403,7 @@ class CwaEewPresenter(BasePresenter):
             if not inserted:
                 lines.append(f"⚠️影响区域：{impact_area_text}")
 
-        if not any("距离震中" in line for line in lines):
-            _append_local_estimation(lines, display_context)
+        _append_local_estimation(lines, display_context)
         return "\n".join(lines)
 
 
@@ -542,8 +540,7 @@ class JmaEewPresenter(BasePresenter):
                 ):
                     lines.append(f"💥预估震度范围：{shindo_range.strip()}")
 
-        if not any("距离震中" in line for line in lines):
-            _append_local_estimation(lines, display_context)
+        _append_local_estimation(lines, display_context)
         return "\n".join(lines)
 
 
@@ -628,8 +625,7 @@ class CencEarthquakePresenter(BasePresenter):
         lines = rendered.split("\n") if rendered else []
         # 本地预估仅在上下文携带 local_estimation 时输出（跟随会话级配置）
         # 情报类不附加 P/S 波预计到达时间
-        if not any("距离震中" in line for line in lines):
-            _append_local_estimation(lines, display_context, include_travel_time=False)
+        _append_local_estimation(lines, display_context, include_travel_time=False)
         return "\n".join(lines)
 
 


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

防止在仅对预警场景有意义的情况下，将 P/S 波传播时间估算附加到地震情报消息中。

Bug Fixes:
- 停止在事件发生后/情报类型的地震消息中添加 P/S 波预计到时，因为在这些场景中它们不再具有预警价值。

Enhancements:
- 通过一个标志位使本地估算的渲染行为可配置，以控制是否包含 P/S 波传播时间，并为不同类型的地震消息记录其预期用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent earthquake intelligence messages from appending P/S-wave travel time estimates that are only meaningful for early-warning scenarios.

Bug Fixes:
- Stop adding P/S-wave estimated arrival times to post-event/intelligence-type earthquake messages where they no longer provide warning value.

Enhancements:
- Make local estimation rendering configurable via a flag to control whether P/S-wave travel times are included, and document its intended usage for different earthquake message types.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 调整中国地震台网测定信息的本地影响预估展示，相关情报中不再显示 P 波和 S 波预计到达时间。
  * 保留其他本地影响预估内容，提升信息展示的准确性与清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->