### PR TITLE
feat: 管理端台风相关信息补充编号展示

### DIFF
--- a/admin/css/views/events.css
+++ b/admin/css/views/events.css
@@ -2540,7 +2540,7 @@ body.dark-theme .weather-query-error {
 /* 查询结果正文第一行：台风编号 */
 .typhoon-query-id-line {
     font-weight: 600;
-    opacity: 0.95 !important;
+    opacity: 0.95;
 }
 
 .typhoon-query-source-line {

--- a/admin/css/views/events.css
+++ b/admin/css/views/events.css
@@ -2537,6 +2537,12 @@ body.dark-theme .weather-query-error {
     line-height: 1.45 !important;
 }
 
+/* 查询结果正文第一行：台风编号 */
+.typhoon-query-id-line {
+    font-weight: 600;
+    opacity: 0.95 !important;
+}
+
 .typhoon-query-source-line {
     opacity: 0.7 !important;
     margin-top: 2px !important;

--- a/admin/js/components/events/EventCard.jsx
+++ b/admin/js/components/events/EventCard.jsx
@@ -161,14 +161,15 @@ function EventCard({
             evt._snapshot_longitude ?? evt.longitude,
         )
         : '';
-    // 编号优先 real_event_id（稳定台风编号），兼容 unique_id / event_id
+    // 短编号字段优先级与查询面板/后端对齐：eqsc_id → typhoon_id → real_event_id → unique_id
+    // event_id 仅作事件卡片兜底（查询结果项通常无此字段）
     const typhoonShortId = isTyphoon && typhoonFormatters?.formatTyphoonShortId
         ? typhoonFormatters.formatTyphoonShortId(
+            evt.eqsc_id,
+            evt.typhoon_id,
             evt.real_event_id,
             evt.unique_id,
             evt.event_id,
-            evt.typhoon_id,
-            evt.eqsc_id,
         )
         : '';
     const typhoonMeta = isTyphoon

--- a/admin/js/components/events/EventCard.jsx
+++ b/admin/js/components/events/EventCard.jsx
@@ -153,7 +153,7 @@ function EventCard({
     const typhoonCurrentLevel = evt._snapshot_level || '';
     const typhoonPeakLevel = evt.level || '';
     const typhoonShowPeakDiff = typhoonCurrentLevel && typhoonPeakLevel && typhoonCurrentLevel !== typhoonPeakLevel;
-    // 台风中心位置：复用 typhoonFormatters 的坐标格式化工具
+    // 台风中心位置 / 编号：复用 typhoonFormatters 的统一格式化工具
     const typhoonFormatters = window.DisasterTyphoonFormatters;
     const typhoonCoords = isTyphoon && typhoonFormatters
         ? typhoonFormatters.formatTyphoonCoords(
@@ -161,8 +161,20 @@ function EventCard({
             evt._snapshot_longitude ?? evt.longitude,
         )
         : '';
+    // 编号优先 real_event_id（稳定台风编号），兼容 unique_id / event_id
+    const typhoonShortId = isTyphoon && typhoonFormatters?.formatTyphoonShortId
+        ? typhoonFormatters.formatTyphoonShortId(
+            evt.real_event_id,
+            evt.unique_id,
+            evt.event_id,
+            evt.typhoon_id,
+            evt.eqsc_id,
+        )
+        : '';
     const typhoonMeta = isTyphoon
         ? [
+            // 小字最前统一附带编号，例如「编号：2609」
+            typhoonShortId ? `编号：${typhoonShortId}` : '',
             typhoonCurrentLevel
                 ? (typhoonShowPeakDiff
                     ? `当前强度：${typhoonCurrentLevel}（峰值：${typhoonPeakLevel}）`

--- a/admin/js/components/events/TyphoonQueryPanel.jsx
+++ b/admin/js/components/events/TyphoonQueryPanel.jsx
@@ -95,7 +95,15 @@ function TyphoonQueryPanel() {
         if (!item) return null;
         const coords = formatCoords(item.latitude, item.longitude);
         const level = item.typhoon_type || '未知等级';
-        const shortId = item.eqsc_id || item.typhoon_id || '未知';
+        // 统一 4 位短编号（2609）；兼容 eqsc_id / typhoon_id 等字段
+        const shortId = (typhoonFormatters?.formatTyphoonShortId
+            ? typhoonFormatters.formatTyphoonShortId(
+                item.eqsc_id,
+                item.typhoon_id,
+                item.real_event_id,
+                item.unique_id,
+            )
+            : (item.eqsc_id || item.typhoon_id || '')) || '未知';
         const expandKey = `${keyPrefix}-${shortId}-${item.updated_at || ''}`;
 
         return (
@@ -104,12 +112,13 @@ function TyphoonQueryPanel() {
                     <Typography variant="subtitle1" className="weather-query-result-title">
                         {getLevelEmoji(level)} {item.display_name || '未知台风'}
                     </Typography>
-                    <Typography variant="caption" className="weather-query-result-meta">
-                        编号：{shortId}
-                    </Typography>
                 </div>
 
                 <div className="weather-query-result-body typhoon-query-result-body">
+                    {/* 结果正文第一行：编号 */}
+                    <Typography variant="body2" className="typhoon-query-meta-line typhoon-query-id-line">
+                        编号：{shortId}
+                    </Typography>
                     <Typography variant="body2" className="typhoon-query-meta-line">
                         等级：{level}{getLevelEmoji(level)}
                     </Typography>
@@ -219,7 +228,14 @@ function TyphoonQueryPanel() {
                 </div>
 
                 {pagedItems.map((item, index) => {
-                    const shortId = item.eqsc_id || item.typhoon_id || `idx-${startIndex + index}`;
+                    const shortId = (typhoonFormatters?.formatTyphoonShortId
+                        ? typhoonFormatters.formatTyphoonShortId(
+                            item.eqsc_id,
+                            item.typhoon_id,
+                            item.real_event_id,
+                            item.unique_id,
+                        )
+                        : (item.eqsc_id || item.typhoon_id || '')) || `idx-${startIndex + index}`;
                     const expandKey = `list-${shortId}-${item.updated_at || startIndex + index}`;
                     const expanded = Boolean(expandedIds[expandKey]);
                     return (

--- a/admin/js/components/events/TyphoonQueryPanel.jsx
+++ b/admin/js/components/events/TyphoonQueryPanel.jsx
@@ -91,20 +91,37 @@ function TyphoonQueryPanel() {
         );
     };
 
-    const renderDetailCard = (item, { showExpand = false, expanded = true, onToggle = null, keyPrefix = 'detail' } = {}) => {
-        if (!item) return null;
-        const coords = formatCoords(item.latitude, item.longitude);
-        const level = item.typhoon_type || '未知等级';
-        // 统一 4 位短编号（2609）；兼容 eqsc_id / typhoon_id 等字段
-        const shortId = (typhoonFormatters?.formatTyphoonShortId
+    /**
+     * 统一短编号解析：eqsc_id → typhoon_id → real_event_id → unique_id
+     * 与后端 _format_typhoon_short_id / EventCard 保持一致。
+     */
+    const resolveShortId = (item, fallback = '未知') => {
+        if (!item) return fallback;
+        const resolved = typhoonFormatters?.formatTyphoonShortId
             ? typhoonFormatters.formatTyphoonShortId(
                 item.eqsc_id,
                 item.typhoon_id,
                 item.real_event_id,
                 item.unique_id,
             )
-            : (item.eqsc_id || item.typhoon_id || '')) || '未知';
-        const expandKey = `${keyPrefix}-${shortId}-${item.updated_at || ''}`;
+            : (item.eqsc_id || item.typhoon_id || item.real_event_id || item.unique_id || '');
+        return resolved || fallback;
+    };
+
+    const renderDetailCard = (item, {
+        showExpand = false,
+        expanded = true,
+        onToggle = null,
+        keyPrefix = 'detail',
+        shortId: shortIdProp = null,
+        expandKey: expandKeyProp = null,
+    } = {}) => {
+        if (!item) return null;
+        const coords = formatCoords(item.latitude, item.longitude);
+        const level = item.typhoon_type || '未知等级';
+        // 优先使用调用方传入的 shortId/expandKey，避免列表与详情各自计算导致折叠键不一致
+        const shortId = shortIdProp || resolveShortId(item, '未知');
+        const expandKey = expandKeyProp || `${keyPrefix}-${shortId}-${item.updated_at || ''}`;
 
         return (
             <div className="weather-query-result-card typhoon-query-result-card" key={expandKey}>
@@ -228,14 +245,8 @@ function TyphoonQueryPanel() {
                 </div>
 
                 {pagedItems.map((item, index) => {
-                    const shortId = (typhoonFormatters?.formatTyphoonShortId
-                        ? typhoonFormatters.formatTyphoonShortId(
-                            item.eqsc_id,
-                            item.typhoon_id,
-                            item.real_event_id,
-                            item.unique_id,
-                        )
-                        : (item.eqsc_id || item.typhoon_id || '')) || `idx-${startIndex + index}`;
+                    // 只算一次 shortId/expandKey，并下传给详情卡片，保证折叠状态键一致
+                    const shortId = resolveShortId(item, `idx-${startIndex + index}`);
                     const expandKey = `list-${shortId}-${item.updated_at || startIndex + index}`;
                     const expanded = Boolean(expandedIds[expandKey]);
                     return (
@@ -245,6 +256,8 @@ function TyphoonQueryPanel() {
                                 expanded,
                                 onToggle: toggleExpanded,
                                 keyPrefix: 'list',
+                                shortId,
+                                expandKey,
                             })}
                         </div>
                     );

--- a/admin/js/utils/typhoonFormatters.js
+++ b/admin/js/utils/typhoonFormatters.js
@@ -153,6 +153,46 @@
         return `${Math.abs(latNum).toFixed(1)}°${latDir}, ${Math.abs(lonNum).toFixed(1)}°${lonDir}`;
     }
 
+    /**
+     * 统一输出台风短编号（优先 4 位 EQSC 形态，如 2609）。
+     * 兼容 6 位 Fan 编号、NAMELESS 无名低压，以及 eqsc_id / typhoon_id / real_event_id 等字段。
+     *
+     * 注意：NAMELESS_2604 不能再抽成 2604，否则会与正式编号 202604（森拉克）冲突。
+     * @param {...(string|number|null|undefined)} candidates
+     * @returns {string}
+     */
+    function formatTyphoonShortId(...candidates) {
+        for (const candidate of candidates) {
+            const text = String(candidate ?? '').trim();
+            if (!text) continue;
+            if (text.toLowerCase() === 'unknown' || text === '未知') continue;
+
+            // 纯数字官方编号：202609 -> 2609，2609 -> 2609
+            if (/^\d{4,}$/.test(text)) {
+                return text.slice(-4);
+            }
+
+            // 无名热带低压：NAMELESS_03 / NAMELESS_2604 -> TD03 / TD2604
+            // 保留 TD 前缀，避免与同年正式台风编号撞车
+            const namelessMatch = text.match(/^NAMELESS[_-]?(.+)$/i);
+            if (namelessMatch) {
+                const suffix = String(namelessMatch[1] || '').trim();
+                if (!suffix) return 'TD';
+                if (/^\d+$/.test(suffix)) return `TD${suffix}`;
+                return suffix.toUpperCase().startsWith('TD') ? suffix.toUpperCase() : `TD${suffix}`;
+            }
+
+            // 已是 TD 形态则规范化大小写
+            if (/^TD[_-]?\d+/i.test(text)) {
+                return text.replace(/^TD[_-]?/i, 'TD');
+            }
+
+            // 其他非标准编号原样返回，绝不从混合文本里硬抠 4 位数字
+            return text;
+        }
+        return '';
+    }
+
     const api = {
         TYPHOON_LEVEL_EMOJI,
         TYPHOON_LEVEL_FILTER_OPTIONS,
@@ -164,6 +204,7 @@
         getTyphoonWindColor,
         formatTyphoonWindCircle,
         formatTyphoonCoords,
+        formatTyphoonShortId,
         matchLevelKey,
     };
 

--- a/admin/js/utils/typhoonFormatters.js
+++ b/admin/js/utils/typhoonFormatters.js
@@ -172,9 +172,9 @@
                 return text.slice(-4);
             }
 
-            // 无名热带低压：NAMELESS_03 / NAMELESS_2604 -> TD03 / TD2604
-            // 保留 TD 前缀，避免与同年正式台风编号撞车
-            const namelessMatch = text.match(/^NAMELESS[_-]?(.+)$/i);
+            // 无名热带低压：NAMELESS / NAMELESS_03 / NAMELESS_2604 -> TD / TD03 / TD2604
+            // 保留 TD 前缀，避免与同年正式台风编号撞车；裸 NAMELESS 也统一为 TD
+            const namelessMatch = text.match(/^NAMELESS(?:[_-]?(.*))?$/i);
             if (namelessMatch) {
                 const suffix = String(namelessMatch[1] || '').trim();
                 if (!suffix) return 'TD';

--- a/core/services/query/typhoon_query_presenter.py
+++ b/core/services/query/typhoon_query_presenter.py
@@ -38,9 +38,20 @@ def _format_typhoon_short_id(*candidates: object) -> str:
             return text[-4:]
 
         upper = text.upper()
-        if upper.startswith("NAMELESS"):
+        # 裸 NAMELESS / NAMELESS_03 / NAMELESS_2604 均统一为 TD 前缀
+        if (
+            upper == "NAMELESS"
+            or upper.startswith("NAMELESS_")
+            or upper.startswith("NAMELESS-")
+        ):
+            if upper == "NAMELESS":
+                return "TD"
             suffix = (
-                text.split("_", 1)[1].strip() if "_" in text else text[8:].lstrip("_-")
+                text.split("_", 1)[1].strip()
+                if "_" in text
+                else text.split("-", 1)[1].strip()
+                if "-" in text
+                else text[8:].lstrip("_-")
             )
             suffix = suffix.strip()
             if not suffix:

--- a/core/services/query/typhoon_query_presenter.py
+++ b/core/services/query/typhoon_query_presenter.py
@@ -19,6 +19,45 @@ from ...domain.typhoon.typhoon_display_format import (
 from .typhoon_query_parser import DETAIL_CURRENT, DETAIL_FULL
 
 
+def _format_typhoon_short_id(*candidates: object) -> str:
+    """统一输出台风短编号，规则与前端 formatTyphoonShortId 对齐。
+
+    - 纯数字官方编号：202609 / 2609 -> 2609
+    - NAMELESS 无名低压：NAMELESS_2604 -> TD2604（避免与正式编号 2604 冲突）
+    - 其他非标准编号：原样返回，不从混合文本硬抠数字
+    """
+    for candidate in candidates:
+        text = str(candidate or "").strip()
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in {"unknown", "未知"}:
+            continue
+
+        if text.isdigit() and len(text) >= 4:
+            return text[-4:]
+
+        upper = text.upper()
+        if upper.startswith("NAMELESS"):
+            suffix = (
+                text.split("_", 1)[1].strip() if "_" in text else text[8:].lstrip("_-")
+            )
+            suffix = suffix.strip()
+            if not suffix:
+                return "TD"
+            if suffix.isdigit():
+                return f"TD{suffix}"
+            if suffix.upper().startswith("TD"):
+                return suffix.upper()
+            return f"TD{suffix}"
+
+        if upper.startswith("TD"):
+            return "TD" + text[2:].lstrip("_-")
+
+        return text
+    return ""
+
+
 def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
     """生成单条台风摘要文本，供命令侧与详情卡片复用。"""
     lines: list[str] = []
@@ -30,11 +69,13 @@ def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
         title = f"{title} · {typhoon_type}{level_emoji}"
     lines.append(title)
 
-    typhoon_id = item.get("typhoon_id") or item.get("eqsc_id") or ""
-    if typhoon_id:
-        short_id = (
-            str(typhoon_id)[-4:] if len(str(typhoon_id)) >= 4 else str(typhoon_id)
-        )
+    short_id = _format_typhoon_short_id(
+        item.get("eqsc_id"),
+        item.get("typhoon_id"),
+        item.get("real_event_id"),
+        item.get("unique_id"),
+    )
+    if short_id:
         lines.append(f"📌编号：{short_id}")
 
     if item.get("is_active") is False:
@@ -181,7 +222,15 @@ def build_typhoon_query_text(result: dict[str, Any]) -> str:
 
     for index, item in enumerate(items, start=1):
         lines.append(f"[{index}] {item.get('display_name') or '未知台风'}")
-        short_id = item.get("eqsc_id") or item.get("typhoon_id") or "未知"
+        short_id = (
+            _format_typhoon_short_id(
+                item.get("eqsc_id"),
+                item.get("typhoon_id"),
+                item.get("real_event_id"),
+                item.get("unique_id"),
+            )
+            or "未知"
+        )
         lines.append(f"编号：{short_id}")
         level = item.get("typhoon_type") or "未知等级"
         level_emoji = get_typhoon_level_emoji(level)


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

在后端和管理界面中统一台风短 ID 的格式，并在管理视图中更突出地展示标准化后的 ID。

New Features:
- 添加一个共享的台风短 ID 格式化器，将后端中各种不同形式的台风标识符规范化为一致的短 ID 表示。
- 在管理界面的台风查询结果和事件卡片中显示标准化后的台风短 ID。

Enhancements:
- 将后端台风 ID 的格式化逻辑与前端实现对齐，避免不同视图之间出现不一致。
- 在管理端的台风查询面板中通过专门样式强化台风 ID 的视觉突出效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify typhoon short ID formatting across backend and admin UI and surface the standardized IDs more prominently in management views.

New Features:
- Add a shared typhoon short ID formatter that normalizes various backend typhoon identifiers into a consistent short ID representation.
- Display the standardized typhoon short ID in typhoon query results and event cards within the admin interface.

Enhancements:
- Align the backend typhoon ID formatting logic with the frontend implementation to avoid inconsistencies between views.
- Improve visual emphasis of typhoon IDs in the admin typhoon query panel with dedicated styling.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 统一台风编号格式，支持多种编号来源和格式。
  * 在台风查询结果中优先显示标准化的短编号。
  * 列表结果在缺少编号时提供稳定的备用标识。

* **样式优化**
  * 突出显示台风查询结果中的编号信息。
  * 统一详情卡片与列表中的编号展示格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->