### PR TITLE
feat: 接入 FAN Studio 应用鉴权，并优化台风查询轨迹与缓存策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 
 插件中目前最全面、最稳定的综合灾害数据流。
 
+> **鉴权说明**：FAN Studio 现已启用应用鉴权。无鉴权时仅 **FSSN** 服务可用；完整数据源需在配置中填写 `api_key`（用户需到 [开发者平台](https://api.fanstudio.tech/dev-platform/) 选择本应用申请 Key）。
+
 - **启用 (`enabled`)**: 开启后将订阅来自 FAN Studio 的实时推送。
 - **中国地震预警网 (`china_earthquake_warning`)**: 接入国内地震预警系统（国家级），通常能在地震横波到达前数秒至数十秒下发预警。
 - **中国地震预警网（省级）(`china_earthquake_warning_provincial`)**: FAN Studio 提供的省级地震预警通道，预警推送阈值比国家级更低，如果追求高覆盖率只开启省级预警网即可（同时避免重复推送）。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -37,12 +37,25 @@
       "fan_studio": {
         "description": "FAN Studio WebSocket 数据源",
         "type": "object",
-        "hint": "FAN Studio数据源总开关",
+        "hint": "FAN Studio 数据源总开关。启用前请先配置 appId 与 API Key；用户需到开发者平台选择本应用申请自己的 Key。",
         "items": {
           "enabled": {
-            "description": "启用 FAN Studio 数据源（除 FSSN 外已不可用）",
+            "description": "启用 FAN Studio 数据源",
             "type": "bool",
-            "default": false
+            "default": false,
+            "hint": "启用后将连接 FAN Studio WebSocket。需配置下方 appId 与 API Key，否则会跳过建连。"
+          },
+          "app_id": {
+            "description": "FAN Studio 应用 ID",
+            "type": "string",
+            "default": "97b68b51-ec96-42c3-80d7-83d2bff70d99",
+            "hint": "一般情况下保持默认配置即可，请勿修改。"
+          },
+          "api_key": {
+            "description": "FAN Studio API Key",
+            "type": "string",
+            "default": "",
+            "hint": "到 https://api.fanstudio.tech/dev-platform/ 选择本应用申请。格式通常为 sk- 开头。每个部署实例使用自己的 Key，请勿把 Key 提交到公开仓库或发给他人。"
           },
           "china_earthquake_warning": {
             "description": "中国地震网地震预警",
@@ -114,7 +127,7 @@
             "description": "中国气象局：实时活跃台风",
             "type": "bool",
             "default": false,
-            "hint": "原通过 FAN Studio WebSocket 触发台风推送。FAN 除 FSSN 外已停服，实时台风请改用 EQSC「启用台风轮询」。"
+            "hint": "通过 FAN Studio WebSocket 接收中国气象局台风信息。"
           }
         }
       },
@@ -388,7 +401,7 @@
             "description": "启用融合策略",
             "type": "bool",
             "default": false,
-            "hint": "开启后 Wolfx 仅作补充、不独立推送。FAN 不可用时请保持关闭。"
+            "hint": "开启后 Wolfx 仅作补充、不独立推送。未配置 FAN 鉴权时请保持关闭。"
           },
           "timeout": {
             "description": "等待超时时间",
@@ -412,7 +425,7 @@
             "description": "启用融合策略",
             "type": "bool",
             "default": false,
-            "hint": "开启后 Wolfx 仅作补充、不独立推送。FAN 不可用时请保持关闭。"
+            "hint": "开启后 Wolfx 仅作补充、不独立推送。未配置 FAN 鉴权时请保持关闭。"
           },
           "timeout": {
             "description": "等待超时时间",

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -17,6 +17,9 @@
         ['data_sources', 'eqsc', 'base_url'],
         ['data_sources', 'eqsc', 'refresh_token'],
         ['data_sources', 'eqsc', 'cache_ttl'],
+        // FAN Studio 鉴权影响全局 WebSocket 建连，会话模式隐藏且保存时剥离
+        ['data_sources', 'fan_studio', 'app_id'],
+        ['data_sources', 'fan_studio', 'api_key'],
     ];
 
     /**

--- a/core/app/runtime/disaster_service_reconnect.py
+++ b/core/app/runtime/disaster_service_reconnect.py
@@ -81,6 +81,11 @@ class DisasterServiceReconnectService:
             "established_time": None,
             "backup_url": conn_config.get("backup_url"),
         }
+        # FAN Studio 鉴权字段需一并补齐，否则手动重连后无法发送 auth 包。
+        if conn_config.get("fan_app_id"):
+            connection_info["fan_app_id"] = conn_config["fan_app_id"]
+        if conn_config.get("fan_api_key"):
+            connection_info["fan_api_key"] = conn_config["fan_api_key"]
         # 这里的结构与连接管理器常规建连流程保持一致，
         # 这样手动重连与自动重连在读取附加信息时不会出现字段缺失的问题。
         self.service.ws_manager.connection_info[conn_name] = {

--- a/core/app/runtime/disaster_service_reconnect.py
+++ b/core/app/runtime/disaster_service_reconnect.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from astrbot.api import logger
 
+from ...network.websocket.fan_studio_connection_policy import attach_fan_auth_from_plan
+
 
 class DisasterServiceReconnectService:
     """灾害服务手动重连编排服务。
@@ -82,10 +84,7 @@ class DisasterServiceReconnectService:
             "backup_url": conn_config.get("backup_url"),
         }
         # FAN Studio 鉴权字段需一并补齐，否则手动重连后无法发送 auth 包。
-        if conn_config.get("fan_app_id"):
-            connection_info["fan_app_id"] = conn_config["fan_app_id"]
-        if conn_config.get("fan_api_key"):
-            connection_info["fan_api_key"] = conn_config["fan_api_key"]
+        attach_fan_auth_from_plan(connection_info, conn_config)
         # 这里的结构与连接管理器常规建连流程保持一致，
         # 这样手动重连与自动重连在读取附加信息时不会出现字段缺失的问题。
         self.service.ws_manager.connection_info[conn_name] = {

--- a/core/app/runtime/disaster_service_runtime.py
+++ b/core/app/runtime/disaster_service_runtime.py
@@ -11,6 +11,7 @@ import json
 
 from astrbot.api import logger
 
+from ...network.websocket.fan_studio_connection_policy import attach_fan_auth_from_plan
 from ...services.query.source_runtime_query_service import SourceRuntimeQueryService
 
 
@@ -74,10 +75,7 @@ class DisasterServiceRuntimeService:
                     "backup_url": conn_config.get("backup_url"),
                 }
                 # FAN Studio 鉴权凭证随连接上下文传递，供建连后发送 auth 包。
-                if conn_config.get("fan_app_id"):
-                    connection_info["fan_app_id"] = conn_config["fan_app_id"]
-                if conn_config.get("fan_api_key"):
-                    connection_info["fan_api_key"] = conn_config["fan_api_key"]
+                attach_fan_auth_from_plan(connection_info, conn_config)
 
                 # 异步建连后台任务
                 task = asyncio.create_task(

--- a/core/app/runtime/disaster_service_runtime.py
+++ b/core/app/runtime/disaster_service_runtime.py
@@ -73,6 +73,11 @@ class DisasterServiceRuntimeService:
                     "established_time": None,
                     "backup_url": conn_config.get("backup_url"),
                 }
+                # FAN Studio 鉴权凭证随连接上下文传递，供建连后发送 auth 包。
+                if conn_config.get("fan_app_id"):
+                    connection_info["fan_app_id"] = conn_config["fan_app_id"]
+                if conn_config.get("fan_api_key"):
+                    connection_info["fan_api_key"] = conn_config["fan_api_key"]
 
                 # 异步建连后台任务
                 task = asyncio.create_task(

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -481,12 +481,17 @@ class TyphoonEnrichmentService:
         typhoon_id: str,
         name: str = "",
         name_en: str = "",
+        *,
+        use_cache: bool = True,
     ) -> dict[str, Any] | None:
         """尝试从 EQSC 获取台风数据（单次尝试，含 ID 查询 + 名称匹配兜底）。
 
         先统一获取一次 AccessToken，再复用到 ID 查询和名称兜底查询中，
         避免单次重试内重复鉴权导致日志刷两遍。
         缓存命中时 fetch 方法内部会跳过 token 使用，无需额外处理。
+
+        Args:
+            use_cache: 查询指令应传 False，避免短缓存挡住最新编报。
         """
         # 统一获取一次 AccessToken，复用到后续所有查询
         access_token = await self._token_manager.get_access_token()
@@ -497,7 +502,9 @@ class TyphoonEnrichmentService:
         eqsc_id = to_eqsc_id(typhoon_id)
         if eqsc_id:
             result = await self._typhoon_client.fetch_typhoon_by_id(
-                eqsc_id, access_token=access_token
+                eqsc_id,
+                access_token=access_token,
+                use_cache=use_cache,
             )
             if result:
                 return result
@@ -505,7 +512,8 @@ class TyphoonEnrichmentService:
         # ID 查询无结果，回退到无参查询 + 名称匹配
         if name or name_en:
             typhoon_list = await self._typhoon_client.fetch_typhoon_list(
-                access_token=access_token
+                access_token=access_token,
+                use_cache=use_cache,
             )
             if typhoon_list:
                 matched = self._typhoon_client.find_typhoon_by_name(
@@ -612,11 +620,15 @@ class TyphoonEnrichmentService:
         *,
         name: str = "",
         name_en: str = "",
+        use_cache: bool = False,
     ) -> dict[str, Any] | None:
         """按 ID/名称查询单条 EQSC 台风详情，供查询指令与管理端复用。
 
         优先按台风编号精确查询；编号缺失或未命中时，可按中英文名在列表中匹配。
         未启用、熔断或鉴权失败时返回 None，由上层决定是否回退本地数据库。
+
+        默认 use_cache=False：用户主动查询应尽量拿到最新编报，
+        避免与轮询侧短缓存互相污染。
         """
         if not self.is_enabled:
             return None
@@ -629,6 +641,7 @@ class TyphoonEnrichmentService:
                 str(typhoon_id or "").strip(),
                 str(name or "").strip(),
                 str(name_en or "").strip(),
+                use_cache=use_cache,
             )
             if result:
                 self._record_success()
@@ -640,11 +653,17 @@ class TyphoonEnrichmentService:
             logger.error(f"[灾害预警] EQSC 台风详情查询异常: {e}")
             return None
 
-    async def fetch_history_typhoons(self) -> list[dict[str, Any]]:
+    async def fetch_history_typhoons(
+        self,
+        *,
+        use_cache: bool = False,
+    ) -> list[dict[str, Any]]:
         """获取 EQSC 台风列表（至多 20 个最新台风，含历史）。
 
         无参查询 /typhoonNMC.json 时 EQSC 返回至多 20 个最新台风数据，
         包含已消亡的历史台风，可用于数据库冷启动重建。
+
+        默认 use_cache=False：查询/重建场景优先新鲜数据。
         """
         if not self.is_enabled:
             return []
@@ -662,7 +681,8 @@ class TyphoonEnrichmentService:
                 return []
 
             typhoon_list = await self._typhoon_client.fetch_typhoon_list(
-                access_token=access_token
+                access_token=access_token,
+                use_cache=use_cache,
             )
             if typhoon_list:
                 self._record_success()

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -57,6 +57,8 @@ class EqscTyphoonClient(EqscHttpClient):
         self,
         typhoon_id: str,
         access_token: str | None = None,
+        *,
+        use_cache: bool = True,
     ) -> dict[str, Any] | None:
         """按台风 ID 查询台风详细数据。
 
@@ -67,15 +69,17 @@ class EqscTyphoonClient(EqscHttpClient):
         Args:
             typhoon_id: EQSC 格式的台风 ID（4位）。
             access_token: 可复用的 AccessToken；若未提供则内部自行获取。
+            use_cache: 为 False 时强制绕过详情缓存（查询指令侧使用）。
 
         Returns:
             台风数据字典，或 None 表示查询失败/未找到。
         """
         # 检查缓存
-        cached = self._cache.get(typhoon_id)
-        if cached and self._is_cache_valid(cached[1]):
-            logger.debug(f"[灾害预警] EQSC 台风 {typhoon_id} 命中缓存")
-            return cached[0]
+        if use_cache:
+            cached = self._cache.get(typhoon_id)
+            if cached and self._is_cache_valid(cached[1]):
+                logger.debug(f"[灾害预警] EQSC 台风 {typhoon_id} 命中缓存")
+                return cached[0]
 
         # 获取 AccessToken
         access_token = await self._resolve_access_token(access_token)

--- a/core/network/websocket/fan_studio_connection_policy.py
+++ b/core/network/websocket/fan_studio_connection_policy.py
@@ -6,10 +6,12 @@ FAN Studio 连接配额与优先级策略。
 1. 启动时先建 fan_studio_all（/all），主通道在线后再建次要独立通道
 2. 运行中优先保活 /all；主通道遇配额/策略拒绝时，才释放次要通道让路
 3. 次要通道在主通道离线或命中配额时拉长退避，避免与 /all 抢连接
+4. 建连成功后发送应用层鉴权包：{"type":"auth","appId":"...","key":"sk-..."}
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from astrbot.api import logger
@@ -178,3 +180,63 @@ def resolve_secondary_reconnect_interval(
     if quota_hit:
         return max(base, SECONDARY_QUOTA_RECONNECT_INTERVAL)
     return base
+
+
+def resolve_fan_auth_credentials(
+    connection_info: dict[str, Any] | None,
+) -> tuple[str, str]:
+    """从连接附加信息解析 FAN Studio appId 与 API Key。"""
+    info = connection_info if isinstance(connection_info, dict) else {}
+    app_id = str(
+        info.get("fan_app_id") or info.get("app_id") or info.get("appId") or ""
+    ).strip()
+    api_key = str(
+        info.get("fan_api_key") or info.get("api_key") or info.get("key") or ""
+    ).strip()
+    return app_id, api_key
+
+
+def build_fan_auth_payload(app_id: str, api_key: str) -> dict[str, str]:
+    """构造 FAN Studio WebSocket 鉴权 JSON 对象。"""
+    return {
+        "type": "auth",
+        "appId": str(app_id or "").strip(),
+        "key": str(api_key or "").strip(),
+    }
+
+
+async def send_fan_studio_auth(
+    websocket: Any,
+    *,
+    connection_name: str,
+    connection_info: dict[str, Any] | None,
+) -> bool:
+    """在 FAN Studio 连接建立后发送鉴权包。
+
+    Returns:
+        True 表示已成功发送；False 表示缺少凭证或发送失败。
+    """
+    if not is_fan_studio_connection(connection_name):
+        return True
+
+    app_id, api_key = resolve_fan_auth_credentials(connection_info)
+    if not app_id or not api_key:
+        logger.error(
+            f"[灾害预警] FAN Studio 连接 {connection_name} 缺少 appId/api_key，"
+            "无法发送鉴权包"
+        )
+        return False
+
+    payload = build_fan_auth_payload(app_id, api_key)
+    try:
+        await websocket.send_str(json.dumps(payload, ensure_ascii=False))
+        logger.debug(
+            f"[灾害预警] 已向 FAN Studio 连接 {connection_name} 发送鉴权包 "
+            f"(appId 为 {app_id[:8]}…)"
+        )
+        return True
+    except Exception as exc:
+        logger.error(
+            f"[灾害预警] FAN Studio 连接 {connection_name} 鉴权包发送失败: {exc}"
+        )
+        return False

--- a/core/network/websocket/fan_studio_connection_policy.py
+++ b/core/network/websocket/fan_studio_connection_policy.py
@@ -196,6 +196,22 @@ def resolve_fan_auth_credentials(
     return app_id, api_key
 
 
+def attach_fan_auth_from_plan(
+    connection_info: dict[str, Any],
+    conn_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """将连接计划中的 FAN 鉴权字段写入 connection_info。
+
+    供 runtime 建连与手动重连共用，避免两处字段拷贝逻辑漂移。
+    """
+    cfg = conn_config if isinstance(conn_config, dict) else {}
+    if cfg.get("fan_app_id"):
+        connection_info["fan_app_id"] = cfg["fan_app_id"]
+    if cfg.get("fan_api_key"):
+        connection_info["fan_api_key"] = cfg["fan_api_key"]
+    return connection_info
+
+
 def build_fan_auth_payload(app_id: str, api_key: str) -> dict[str, str]:
     """构造 FAN Studio WebSocket 鉴权 JSON 对象。"""
     return {
@@ -214,7 +230,11 @@ async def send_fan_studio_auth(
     """在 FAN Studio 连接建立后发送鉴权包。
 
     Returns:
-        True 表示已成功发送；False 表示缺少凭证或发送失败。
+        True 表示已成功发送；False 表示缺少凭证（配置问题）。
+
+    Raises:
+        网络/传输相关异常会原样向上抛出，由 websocket_manager
+        走标准重试与退避逻辑，避免被误判为永久配置失败。
     """
     if not is_fan_studio_connection(connection_name):
         return True
@@ -228,15 +248,10 @@ async def send_fan_studio_auth(
         return False
 
     payload = build_fan_auth_payload(app_id, api_key)
-    try:
-        await websocket.send_str(json.dumps(payload, ensure_ascii=False))
-        logger.debug(
-            f"[灾害预警] 已向 FAN Studio 连接 {connection_name} 发送鉴权包 "
-            f"(appId 为 {app_id[:8]}…)"
-        )
-        return True
-    except Exception as exc:
-        logger.error(
-            f"[灾害预警] FAN Studio 连接 {connection_name} 鉴权包发送失败: {exc}"
-        )
-        return False
+    # 不吞掉 send_str 异常：瞬时网络错误应进入 manager 的重试路径。
+    await websocket.send_str(json.dumps(payload, ensure_ascii=False))
+    logger.debug(
+        f"[灾害预警] 已向 FAN Studio 连接 {connection_name} 发送鉴权包 "
+        f"(appId 为 {app_id[:8]}…)"
+    )
+    return True

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -169,7 +169,7 @@ class WebSocketManager:
                 logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
 
                 # FAN Studio：握手成功后立即发送应用层鉴权包。
-                # 缺少凭证或发送失败时主动关闭，避免无鉴权空连接占用配额。
+                # 仅“缺少凭证”返回 False；网络异常会向上抛出并由下方 except 重试。
                 if is_fan_studio_connection(name):
                     auth_ok = await send_fan_studio_auth(
                         websocket,
@@ -177,14 +177,19 @@ class WebSocketManager:
                         connection_info=self.connection_info.get(name),
                     )
                     if not auth_ok:
+                        # 配置缺失：关闭空连接，走统一错误处理以便后续可重连。
                         try:
                             await websocket.close(
                                 code=1008,
-                                message=b"fan studio auth missing or failed",
+                                message=b"fan studio auth credentials missing",
                             )
                         except Exception:
                             pass
-                        raise RuntimeError(f"FAN Studio 鉴权失败或缺少凭证: {name}")
+                        error = RuntimeError(f"FAN Studio 缺少鉴权凭证: {name}")
+                        logger.error(f"[灾害预警] {error}")
+                        await self._apply_fan_quota_policy_on_error(name, error)
+                        self._handle_connection_error(name, uri, headers, error)
+                        return
 
                 # 重置重连相关的状态变量
                 self.connection_retry_counts[name] = 0

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -18,7 +18,9 @@ from .fan_studio_connection_policy import (
     is_connection_limit_signal,
     is_fan_primary_connection,
     is_fan_secondary_connection,
+    is_fan_studio_connection,
     is_primary_fan_connected,
+    send_fan_studio_auth,
     yield_secondary_for_primary,
 )
 from .websocket_dispatch_service import WebSocketDispatchService
@@ -165,6 +167,24 @@ class WebSocketManager:
                 self.connection_info[name].pop("quota_hit", None)
                 self.connection_info[name].pop("quota_deferred", None)
                 logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
+
+                # FAN Studio：握手成功后立即发送应用层鉴权包。
+                # 缺少凭证或发送失败时主动关闭，避免无鉴权空连接占用配额。
+                if is_fan_studio_connection(name):
+                    auth_ok = await send_fan_studio_auth(
+                        websocket,
+                        connection_name=name,
+                        connection_info=self.connection_info.get(name),
+                    )
+                    if not auth_ok:
+                        try:
+                            await websocket.close(
+                                code=1008,
+                                message=b"fan studio auth missing or failed",
+                            )
+                        except Exception:
+                            pass
+                        raise RuntimeError(f"FAN Studio 鉴权失败或缺少凭证: {name}")
 
                 # 重置重连相关的状态变量
                 self.connection_retry_counts[name] = 0

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -384,7 +384,7 @@ class ConfigValidator:
                     )
                     cenc_fusion["timeout"] = 60
 
-            # FAN 停服后默认关闭，避免 Wolfx 被融合链路吞推；已有显式 true 配置不强制改写。
+            # 未配置 FAN 鉴权时默认关闭融合；已有显式 true 配置不强制改写。
             if "enabled" not in cenc_fusion:
                 cenc_fusion["enabled"] = False
             ConfigValidator._ensure_bool(cenc_fusion, "enabled", False)
@@ -1229,10 +1229,10 @@ class ConfigValidator:
                 )
                 snet_cfg["poll_interval_seconds"] = 60
 
-        # 校验 FAN Studio 下的扩展开关
+        # 校验 FAN Studio 下的扩展开关与鉴权字段
         fan_studio_cfg = cfg.get("fan_studio")
         if isinstance(fan_studio_cfg, dict):
-            # FAN 台风触发已不可用；缺省关闭，已有显式配置不强制改写。
+            # FAN 台风触发为遗留路径；缺省关闭。
             if "china_typhoon" not in fan_studio_cfg:
                 fan_studio_cfg["china_typhoon"] = False
             ConfigValidator._ensure_bool(fan_studio_cfg, "china_typhoon", False)
@@ -1240,6 +1240,46 @@ class ConfigValidator:
             if "usa_shakealert" not in fan_studio_cfg:
                 fan_studio_cfg["usa_shakealert"] = False
             ConfigValidator._ensure_bool(fan_studio_cfg, "usa_shakealert", False)
+
+            # app_id / api_key：WebSocket 建连后发送 {"type":"auth","appId","key"}
+            app_id = fan_studio_cfg.get("app_id")
+            if app_id is None:
+                fan_studio_cfg["app_id"] = "97b68b51-ec96-42c3-80d7-83d2bff70d99"
+            elif not isinstance(app_id, str):
+                logger.warning(
+                    "[灾害预警] 配置警告: FAN Studio app_id 类型错误，已重置为默认应用 ID。"
+                )
+                fan_studio_cfg["app_id"] = "97b68b51-ec96-42c3-80d7-83d2bff70d99"
+            else:
+                fan_studio_cfg["app_id"] = app_id.strip()
+
+            api_key = fan_studio_cfg.get("api_key")
+            if api_key is None:
+                fan_studio_cfg["api_key"] = ""
+            elif not isinstance(api_key, str):
+                logger.warning(
+                    "[灾害预警] 配置警告: FAN Studio api_key 类型错误，已重置为空。"
+                )
+                fan_studio_cfg["api_key"] = ""
+            else:
+                fan_studio_cfg["api_key"] = api_key.strip()
+
+            if (
+                fan_studio_cfg.get("enabled")
+                and not str(fan_studio_cfg.get("api_key", "")).strip()
+            ):
+                logger.warning(
+                    "[灾害预警] 配置警告: FAN Studio 数据源已启用但未配置 api_key，"
+                    "WebSocket 鉴权将无法完成，相关连接会被跳过。"
+                )
+            if (
+                fan_studio_cfg.get("enabled")
+                and not str(fan_studio_cfg.get("app_id", "")).strip()
+            ):
+                logger.warning(
+                    "[灾害预警] 配置警告: FAN Studio 数据源已启用但未配置 app_id，"
+                    "WebSocket 鉴权将无法完成，相关连接会被跳过。"
+                )
 
         # 校验 EQSC 数据源配置（组总闸 + 台风富化 + 海啸轮询子开关）
         eqsc_cfg = cfg.get("eqsc")

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -39,12 +39,27 @@ class ConnectionPlanBuilder:
             if key != "group_key" and value not in (None, "")
         }
 
+    @staticmethod
+    def _resolve_fan_studio_auth(config: dict[str, Any]) -> tuple[str, str]:
+        """从全局配置解析 FAN Studio 鉴权字段。"""
+        data_sources = config.get("data_sources")
+        fan_cfg: dict[str, Any] = {}
+        if isinstance(data_sources, dict):
+            raw = data_sources.get("fan_studio")
+            if isinstance(raw, dict):
+                fan_cfg = raw
+        app_id = str(fan_cfg.get("app_id") or "").strip()
+        api_key = str(fan_cfg.get("api_key") or "").strip()
+        return app_id, api_key
+
     @classmethod
     def build(cls, config: dict[str, Any]) -> dict[str, dict[str, Any]]:
         """根据统一数据源目录与启用状态构建连接计划。"""
         # 使用运行时查询服务拉取当前的物理数据源启用列表
         runtime_query = SourceRuntimeQueryService(config)
         connections: dict[str, dict[str, Any]] = {}
+        fan_app_id, fan_api_key = cls._resolve_fan_studio_auth(config)
+        fan_auth_warned = False
 
         # 只为当前已启用的数据源生成连接计划，避免创建无效连接占位。
         enabled_source_ids = runtime_query.get_enabled_source_ids()
@@ -62,6 +77,20 @@ class ConnectionPlanBuilder:
             # 同一连接分组只保留一份计划，避免多个子源重复覆盖/创建同一连接。
             if group_key in connections:
                 continue
+
+            # FAN Studio 连接必须携带 appId + API Key，否则跳过建连计划。
+            if group_key.startswith("fan_studio"):
+                if not fan_app_id or not fan_api_key:
+                    if not fan_auth_warned:
+                        logger.warning(
+                            "[灾害预警] FAN Studio 相关数据源已启用，但未配置 AppID 或 API Key，已跳过 FAN 连接。"
+                            "请到开发者平台申请 Key 后填入配置。"
+                        )
+                        fan_auth_warned = True
+                    continue
+                plan["fan_app_id"] = fan_app_id
+                plan["fan_api_key"] = fan_api_key
+
             connections[group_key] = plan
             if group_key == "fan_studio_all":
                 logger.info("[灾害预警] 已配置 FAN Studio 全量数据连接")

--- a/core/services/query/typhoon_data_adapter.py
+++ b/core/services/query/typhoon_data_adapter.py
@@ -44,11 +44,15 @@ def format_cn_time(value: Any, with_seconds: bool = False) -> str:
     return TimeConverter._safe_strftime(cn_dt, fmt)
 
 
-def _history_node_time_key(node: dict[str, Any]) -> float:
-    """历史节点排序键：按观测时间升序；无效时间沉底。"""
+def _history_node_time_key(node: dict[str, Any]) -> float | None:
+    """历史节点排序键：按观测时间升序。
+
+    Returns:
+        有效时间戳；无法解析时返回 None（调用方应沉底并避免当作最新观测）。
+    """
     parsed = TimeConverter.parse_datetime(node.get("time"))
     if parsed is None:
-        return 0.0
+        return None
     if parsed.tzinfo is None:
         # 与 EQSC/Fan 业务习惯一致：无时区按北京时间解释。
         parsed = parsed.replace(tzinfo=TimeConverter._get_timezone("UTC+8"))
@@ -59,19 +63,33 @@ def sort_history_track(history_track: list[Any] | None) -> list[dict[str, Any]]:
     """将 EQSC historyTrack 规范为按观测时间升序的字典节点列表。
 
     EQSC 返回顺序不保证，不能直接用数组末项当作最新报。
+    无效时间节点沉底，避免排在正常时间之前。
     """
     if not isinstance(history_track, list):
         return []
     nodes = [node for node in history_track if isinstance(node, dict)]
     if not nodes:
         return []
-    return sorted(nodes, key=_history_node_time_key)
+    # 有效时间在前按时间升序；无效时间沉底并保持相对稳定。
+    return sorted(
+        nodes,
+        key=lambda node: (
+            1 if _history_node_time_key(node) is None else 0,
+            _history_node_time_key(node) or 0.0,
+        ),
+    )
 
 
 def latest_history_node(history_track: list[Any]) -> dict[str, Any] | None:
-    """取历史轨迹中时间最新的观测节点。"""
+    """取历史轨迹中时间最新的有效观测节点。
+
+    跳过无法解析时间的节点，避免把无效时间误判为最新观测。
+    """
     nodes = sort_history_track(history_track)
-    return nodes[-1] if nodes else None
+    for node in reversed(nodes):
+        if _history_node_time_key(node) is not None:
+            return node
+    return None
 
 
 def build_track_summary(

--- a/core/services/query/typhoon_data_adapter.py
+++ b/core/services/query/typhoon_data_adapter.py
@@ -26,7 +26,7 @@ from .typhoon_query_models import TyphoonQueryItem
 from .typhoon_query_parser import DETAIL_FULL
 
 
-def format_cn_time(value: Any) -> str:
+def format_cn_time(value: Any, with_seconds: bool = False) -> str:
     """将任意时间值格式化为北京时间中文展示。
 
     无时区信息时按 UTC+8 解释，与 EQSC/Fan 业务时区习惯一致。
@@ -38,17 +38,40 @@ def format_cn_time(value: Any) -> str:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=TimeConverter._get_timezone("UTC+8"))
     cn_dt = parsed.astimezone(TimeConverter._get_timezone("UTC+8"))
-    return TimeConverter._safe_strftime(cn_dt, "%Y年%m月%d日 %H时%M分")
+    fmt = (
+        "%Y年%m月%d日 %H时%M分%S秒 (UTC+8)" if with_seconds else "%Y年%m月%d日 %H时%M分"
+    )
+    return TimeConverter._safe_strftime(cn_dt, fmt)
+
+
+def _history_node_time_key(node: dict[str, Any]) -> float:
+    """历史节点排序键：按观测时间升序；无效时间沉底。"""
+    parsed = TimeConverter.parse_datetime(node.get("time"))
+    if parsed is None:
+        return 0.0
+    if parsed.tzinfo is None:
+        # 与 EQSC/Fan 业务习惯一致：无时区按北京时间解释。
+        parsed = parsed.replace(tzinfo=TimeConverter._get_timezone("UTC+8"))
+    return parsed.timestamp()
+
+
+def sort_history_track(history_track: list[Any] | None) -> list[dict[str, Any]]:
+    """将 EQSC historyTrack 规范为按观测时间升序的字典节点列表。
+
+    EQSC 返回顺序不保证，不能直接用数组末项当作最新报。
+    """
+    if not isinstance(history_track, list):
+        return []
+    nodes = [node for node in history_track if isinstance(node, dict)]
+    if not nodes:
+        return []
+    return sorted(nodes, key=_history_node_time_key)
 
 
 def latest_history_node(history_track: list[Any]) -> dict[str, Any] | None:
-    """取历史轨迹末节点（通常即最新观测）。"""
-    if not isinstance(history_track, list):
-        return None
-    for node in reversed(history_track):
-        if isinstance(node, dict):
-            return node
-    return None
+    """取历史轨迹中时间最新的观测节点。"""
+    nodes = sort_history_track(history_track)
+    return nodes[-1] if nodes else None
 
 
 def build_track_summary(
@@ -63,7 +86,8 @@ def build_track_summary(
     完整路径查询默认不做节点截断（max_history / max_future 为 None）。
     若调用方显式传入正整数，则分别截取历史末段与预报前段。
     """
-    history = [node for node in (history_track or []) if isinstance(node, dict)]
+    # 摘要展示同样按时间排序，避免完整路径列表时间乱序。
+    history = sort_history_track(history_track)
     future = [node for node in (future_track or []) if isinstance(node, dict)]
 
     def _node_line(node: dict[str, Any], *, prefix: str) -> str:
@@ -160,12 +184,15 @@ def normalize_eqsc_typhoon(
     fan_id = to_fan_id(eqsc_id)
     name_cn = clean_text(raw.get("nameCN") or raw.get("name"))
     name_en = clean_text(raw.get("nameEN") or raw.get("name_en"))
-    history_track = raw.get("historyTrack") or raw.get("history_track") or []
+    # EQSC 历史轨迹顺序不保证：先按时间升序，再取最新观测。
+    history_track = sort_history_track(
+        raw.get("historyTrack") or raw.get("history_track") or []
+    )
     future_track = raw.get("futureTrack") or raw.get("future_track") or []
-    if not isinstance(history_track, list):
-        history_track = []
     if not isinstance(future_track, list):
         future_track = []
+    else:
+        future_track = [node for node in future_track if isinstance(node, dict)]
 
     latest = latest_history_node(history_track) or {}
     wind_circle = latest.get("windCircle") or latest.get("wind_circle") or {}
@@ -215,7 +242,7 @@ def normalize_eqsc_typhoon(
         "radius10": radius10,
         "wind_circle": wind_circle or {},
         "updated_at": updated_at,
-        "updated_at_text": format_cn_time(updated_at),
+        "updated_at_text": format_cn_time(updated_at, with_seconds=True),
         "info_type": "eqsc",
         "data_source": data_source,
         "source_label": "EQSC",
@@ -293,7 +320,9 @@ def normalize_local_typhoon(
         "radius10": detail_fields.get("radius10"),
         "wind_circle": {},
         "updated_at": clean_text(raw.get("time") or raw.get("updated_at")),
-        "updated_at_text": format_cn_time(raw.get("time") or raw.get("updated_at")),
+        "updated_at_text": format_cn_time(
+            raw.get("time") or raw.get("updated_at"), with_seconds=True
+        ),
         "info_type": info_type,
         "data_source": "local",
         "source_label": source_label_map.get(mode, "本地数据库"),
@@ -374,5 +403,6 @@ __all__ = [
     "normalize_eqsc_typhoon",
     "normalize_local_typhoon",
     "parse_local_detail_fields",
+    "sort_history_track",
     "sort_items_stable",
 ]

--- a/core/services/query/typhoon_query_presenter.py
+++ b/core/services/query/typhoon_query_presenter.py
@@ -73,12 +73,16 @@ def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
     """生成单条台风摘要文本，供命令侧与详情卡片复用。"""
     lines: list[str] = []
     display_name = item.get("display_name") or "未知台风"
-    typhoon_type = item.get("typhoon_type") or ""
-    level_emoji = get_typhoon_level_emoji(typhoon_type)
-    title = f"🌀 {display_name}"
-    if typhoon_type:
-        title = f"{title} · {typhoon_type}{level_emoji}"
-    lines.append(title)
+
+    # 状态后缀
+    status_suffix = ""
+    if item.get("is_active") is False:
+        status_suffix = "（已停止编报）"
+    elif item.get("is_active") is True:
+        status_suffix = "（活跃编报中）"
+
+    lines.append(f"{display_name}{status_suffix}")
+    lines.append("")
 
     short_id = _format_typhoon_short_id(
         item.get("eqsc_id"),
@@ -89,10 +93,10 @@ def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
     if short_id:
         lines.append(f"📌编号：{short_id}")
 
-    if item.get("is_active") is False:
-        lines.append("✅状态：已停止编报")
-    elif item.get("is_active") is True:
-        lines.append("🔴状态：活跃编报中")
+    typhoon_type = item.get("typhoon_type") or ""
+    level_emoji = get_typhoon_level_emoji(typhoon_type)
+    if typhoon_type:
+        lines.append(f"⚠️等级：{typhoon_type}{level_emoji}")
 
     coords = format_coordinates(item.get("latitude"), item.get("longitude"))
     if coords:
@@ -120,6 +124,7 @@ def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
 
     circle_lines = format_wind_circle(item.get("wind_circle") or {})
     if circle_lines:
+        lines.append("")
         lines.append("🌪️风圈半径：")
         lines.extend(circle_lines)
     else:
@@ -129,15 +134,13 @@ def build_summary_text(item: dict[str, Any], *, detail: str) -> str:
         if is_valid_radius_value(item.get("radius10")):
             radius_lines.append(f"  • 10级风圈：{item.get('radius10')} km")
         if radius_lines:
+            lines.append("")
             lines.append("🌪️风圈半径：")
             lines.extend(radius_lines)
 
     if item.get("updated_at_text"):
+        lines.append("")
         lines.append(f"🕒更新时间：{item.get('updated_at_text')}")
-
-    source_label = item.get("source_label") or item.get("data_source") or ""
-    if source_label:
-        lines.append(f"📡数据来源：{source_label}")
 
     if detail == DETAIL_FULL:
         track = item.get("track_summary") or {}

--- a/core/sources/source_catalog.py
+++ b/core/sources/source_catalog.py
@@ -714,7 +714,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         payload_signatures=(("type",),),
         payload_predicates=("weather_alert",),
     ),
-    # typhoon_fanstudio: 实时活跃台风 - FAN Studio（遗留触发源，上游已停服）
+    # typhoon_fanstudio: 实时活跃台风 - FAN Studio
     "typhoon_fanstudio": SourceEntry(
         source_id="typhoon_fanstudio",
         source_enum="fan_studio_typhoon",
@@ -729,7 +729,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         intensity_mode="none",
         priority=0,
         display_name="中国气象局：实时活跃台风 - Fan",
-        description="实时活跃台风 - FAN Studio WebSocket（遗留触发源，上游除 FSSN 外已停服）",
+        description="实时活跃台风 - FAN Studio WebSocket",
         default_timezone="Asia/Shanghai",
         publish_time_field="update_time",
         fingerprint_prefix="typhoon",

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -61,6 +61,9 @@ class SessionConfigManager:
         ("data_sources", "eqsc", "cache_ttl"),
         ("data_sources", "eqsc", "tsunami_cache_ttl"),
         ("data_sources", "eqsc", "jma_tsunami_poll_interval_seconds"),
+        # FAN Studio 鉴权影响全局 WebSocket 建连，不允许会话级覆写。
+        ("data_sources", "fan_studio", "app_id"),
+        ("data_sources", "fan_studio", "api_key"),
     )
 
     def __init__(self, default_config_ref: dict[str, Any]):


### PR DESCRIPTION
## 📝 描述 / Description

feat #182 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

将 FAN Studio 应用级认证集成到 WebSocket 连接中，并收紧 EQSC 台风查询、格式化和缓存行为。

New Features:
- 使用配置和连接上下文中的 `app_id` 和 `api_key` 处理 FAN Studio WebSocket 认证负载。
- 暴露 FAN Studio 的 `app_id`/`api_key` 配置字段，并将其传递到连接计划和运行时重连流程中。

Enhancements:
- 按观测时间规范化并排序 EQSC 台风历史路径，以确保最新节点选择和有序摘要。
- 在 EQSC 和本地源的台风更新时间格式中包含秒和时区信息。
- 调整台风摘要展示方式，简化标题/状态显示以及风圈部分。
- 将 FAN Studio 连接和融合策略绑定到有效认证凭据的存在，并进行配置验证和警告提示。
- 优化 EQSC 台风客户端和增强服务，使其在活跃用户/查询场景下可选地绕过缓存。

Documentation:
- 更新 README，记录 FAN Studio 认证要求及密钥获取步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate FAN Studio application-level authentication into WebSocket connections and tighten EQSC typhoon querying, formatting, and caching behavior.

New Features:
- Add FAN Studio WebSocket auth payload handling using app_id and api_key from configuration and connection context.
- Expose FAN Studio app_id/api_key configuration fields and propagate them into connection plans and runtime reconnection flows.

Enhancements:
- Normalize and sort EQSC typhoon history tracks by observation time to ensure latest-node selection and ordered summaries.
- Include seconds and timezone in formatted typhoon update timestamps for EQSC and local sources.
- Adjust typhoon summary presentation to simplify title/status display and wind-circle sections.
- Gate FAN Studio connections and fusion strategies on presence of valid auth credentials with configuration validation and warnings.
- Refine EQSC typhoon client and enrichment service to optionally bypass caches for active user/query scenarios.

Documentation:
- Update README to document FAN Studio authentication requirements and key acquisition steps.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 FAN Studio 应用级认证集成到 WebSocket 连接中，并收紧 EQSC 台风查询、格式化和缓存行为。

New Features:
- 使用配置和连接上下文中的 `app_id` 和 `api_key` 处理 FAN Studio WebSocket 认证负载。
- 暴露 FAN Studio 的 `app_id`/`api_key` 配置字段，并将其传递到连接计划和运行时重连流程中。

Enhancements:
- 按观测时间规范化并排序 EQSC 台风历史路径，以确保最新节点选择和有序摘要。
- 在 EQSC 和本地源的台风更新时间格式中包含秒和时区信息。
- 调整台风摘要展示方式，简化标题/状态显示以及风圈部分。
- 将 FAN Studio 连接和融合策略绑定到有效认证凭据的存在，并进行配置验证和警告提示。
- 优化 EQSC 台风客户端和增强服务，使其在活跃用户/查询场景下可选地绕过缓存。

Documentation:
- 更新 README，记录 FAN Studio 认证要求及密钥获取步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate FAN Studio application-level authentication into WebSocket connections and tighten EQSC typhoon querying, formatting, and caching behavior.

New Features:
- Add FAN Studio WebSocket auth payload handling using app_id and api_key from configuration and connection context.
- Expose FAN Studio app_id/api_key configuration fields and propagate them into connection plans and runtime reconnection flows.

Enhancements:
- Normalize and sort EQSC typhoon history tracks by observation time to ensure latest-node selection and ordered summaries.
- Include seconds and timezone in formatted typhoon update timestamps for EQSC and local sources.
- Adjust typhoon summary presentation to simplify title/status display and wind-circle sections.
- Gate FAN Studio connections and fusion strategies on presence of valid auth credentials with configuration validation and warnings.
- Refine EQSC typhoon client and enrichment service to optionally bypass caches for active user/query scenarios.

Documentation:
- Update README to document FAN Studio authentication requirements and key acquisition steps.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 FAN Studio 应用级认证集成到 WebSocket 连接中，并收紧 EQSC 台风查询、格式化和缓存行为。

New Features:
- 使用配置和连接上下文中的 `app_id` 和 `api_key` 处理 FAN Studio WebSocket 认证负载。
- 暴露 FAN Studio 的 `app_id`/`api_key` 配置字段，并将其传递到连接计划和运行时重连流程中。

Enhancements:
- 按观测时间规范化并排序 EQSC 台风历史路径，以确保最新节点选择和有序摘要。
- 在 EQSC 和本地源的台风更新时间格式中包含秒和时区信息。
- 调整台风摘要展示方式，简化标题/状态显示以及风圈部分。
- 将 FAN Studio 连接和融合策略绑定到有效认证凭据的存在，并进行配置验证和警告提示。
- 优化 EQSC 台风客户端和增强服务，使其在活跃用户/查询场景下可选地绕过缓存。

Documentation:
- 更新 README，记录 FAN Studio 认证要求及密钥获取步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate FAN Studio application-level authentication into WebSocket connections and tighten EQSC typhoon querying, formatting, and caching behavior.

New Features:
- Add FAN Studio WebSocket auth payload handling using app_id and api_key from configuration and connection context.
- Expose FAN Studio app_id/api_key configuration fields and propagate them into connection plans and runtime reconnection flows.

Enhancements:
- Normalize and sort EQSC typhoon history tracks by observation time to ensure latest-node selection and ordered summaries.
- Include seconds and timezone in formatted typhoon update timestamps for EQSC and local sources.
- Adjust typhoon summary presentation to simplify title/status display and wind-circle sections.
- Gate FAN Studio connections and fusion strategies on presence of valid auth credentials with configuration validation and warnings.
- Refine EQSC typhoon client and enrichment service to optionally bypass caches for active user/query scenarios.

Documentation:
- Update README to document FAN Studio authentication requirements and key acquisition steps.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 FAN Studio 应用级认证集成到 WebSocket 连接中，并收紧 EQSC 台风查询、格式化和缓存行为。

New Features:
- 使用配置和连接上下文中的 `app_id` 和 `api_key` 处理 FAN Studio WebSocket 认证负载。
- 暴露 FAN Studio 的 `app_id`/`api_key` 配置字段，并将其传递到连接计划和运行时重连流程中。

Enhancements:
- 按观测时间规范化并排序 EQSC 台风历史路径，以确保最新节点选择和有序摘要。
- 在 EQSC 和本地源的台风更新时间格式中包含秒和时区信息。
- 调整台风摘要展示方式，简化标题/状态显示以及风圈部分。
- 将 FAN Studio 连接和融合策略绑定到有效认证凭据的存在，并进行配置验证和警告提示。
- 优化 EQSC 台风客户端和增强服务，使其在活跃用户/查询场景下可选地绕过缓存。

Documentation:
- 更新 README，记录 FAN Studio 认证要求及密钥获取步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate FAN Studio application-level authentication into WebSocket connections and tighten EQSC typhoon querying, formatting, and caching behavior.

New Features:
- Add FAN Studio WebSocket auth payload handling using app_id and api_key from configuration and connection context.
- Expose FAN Studio app_id/api_key configuration fields and propagate them into connection plans and runtime reconnection flows.

Enhancements:
- Normalize and sort EQSC typhoon history tracks by observation time to ensure latest-node selection and ordered summaries.
- Include seconds and timezone in formatted typhoon update timestamps for EQSC and local sources.
- Adjust typhoon summary presentation to simplify title/status display and wind-circle sections.
- Gate FAN Studio connections and fusion strategies on presence of valid auth credentials with configuration validation and warnings.
- Refine EQSC typhoon client and enrichment service to optionally bypass caches for active user/query scenarios.

Documentation:
- Update README to document FAN Studio authentication requirements and key acquisition steps.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 FAN Studio 应用鉴权，配置 `app_id` 与 `api_key` 后可使用完整数据源。
  * 增强配置提示与校验，缺少鉴权信息时提供明确告警。
  * 管理端查询台风详情和历史数据时默认优先获取最新结果。

* **问题修复**
  * 优化台风轨迹排序与最新观测识别，提升轨迹展示准确性。
  * 改进台风摘要排版、更新时间显示及异常数据处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->