### PR TITLE
feat: 新增连接健康状态 Pages 组件，修复统计口径数问题

### DIFF
--- a/admin/css/views/status.css
+++ b/admin/css/views/status.css
@@ -1137,3 +1137,442 @@ body.dark-theme .connection-item--flippable:hover .connection-flip-face {
     border-top-color: var(--md-sys-color-primary);
     border-radius: 50%;
 }
+
+/* ==========================================================================
+   9. 通道健康 Statuspage（90 天条带 + 事故）
+   视觉：经典 statuspage 条带 + 管理端 surface/圆角体系
+   ========================================================================== */
+.connection-health-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.connection-health-subtitle {
+    display: block;
+    opacity: 0.68;
+    margin-top: 2px;
+    font-weight: 500 !important;
+    font-size: 0.86rem !important;
+}
+
+/* 总横幅：经典实心色条，圆角贴合管理端 */
+.connection-health-banner {
+    border-radius: 10px;
+    padding: 18px 22px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px 16px;
+    color: #fff;
+    font-weight: 700;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.connection-health-banner--operational {
+    background: #2f855a;
+}
+
+.connection-health-banner--degraded {
+    background: #b7791f;
+}
+
+.connection-health-banner--partial_outage {
+    background: #c05621;
+}
+
+.connection-health-banner--major_outage {
+    background: #c53030;
+}
+
+.connection-health-banner--not_monitored,
+.connection-health-banner--maintenance {
+    background: #718096;
+}
+
+.connection-health-banner__label {
+    font-size: 1.2rem;
+    letter-spacing: -0.01em;
+}
+
+.connection-health-banner__meta {
+    font-size: 0.84rem;
+    font-weight: 500;
+    opacity: 0.92;
+}
+
+.connection-health-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    padding: 2px 2px 0;
+}
+
+.connection-health-legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.connection-health-legend__swatch {
+    width: 10px;
+    height: 18px;
+    border-radius: 2px;
+    display: inline-block;
+}
+
+/* 经典 statuspage 色：绿 / 黄 / 橙 / 红 / 灰 */
+.connection-health-legend__swatch.is-operational,
+.connection-health-bar.is-operational {
+    background: #3ba55c;
+}
+
+.connection-health-legend__swatch.is-degraded,
+.connection-health-bar.is-degraded {
+    background: #f1c40f;
+}
+
+.connection-health-legend__swatch.is-partial_outage,
+.connection-health-bar.is-partial_outage {
+    background: #e67e22;
+}
+
+.connection-health-legend__swatch.is-major_outage,
+.connection-health-bar.is-major_outage {
+    background: #e74c3c;
+}
+
+.connection-health-legend__swatch.is-not_monitored,
+.connection-health-bar.is-not_monitored,
+.connection-health-legend__swatch.is-maintenance,
+.connection-health-bar.is-maintenance {
+    background: #dfe3e8;
+}
+
+body.dark-theme .connection-health-bar.is-not_monitored,
+html.theme-dark .connection-health-bar.is-not_monitored,
+body.dark-theme .connection-health-legend__swatch.is-not_monitored,
+html.theme-dark .connection-health-legend__swatch.is-not_monitored,
+body.dark-theme .connection-health-bar.is-maintenance,
+html.theme-dark .connection-health-bar.is-maintenance {
+    background: #4a5568;
+}
+
+/* 组件列表：统一白底 + 细分割 */
+.connection-health-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 70%, transparent);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--md-sys-color-surface);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.connection-health-row {
+    padding: 20px 20px 16px;
+    border-bottom: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 45%, transparent);
+    background: var(--md-sys-color-surface);
+}
+
+.connection-health-row:last-child {
+    border-bottom: none;
+}
+
+.connection-health-row__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.connection-health-row__name {
+    font-weight: 700 !important;
+    font-size: 1.08rem !important;
+    color: var(--md-sys-color-on-surface);
+    line-height: 1.3 !important;
+}
+
+.connection-health-row__state {
+    font-weight: 700 !important;
+    font-size: 1rem !important;
+    line-height: 1.3 !important;
+}
+
+.connection-health-row__state.is-operational { color: #2f855a; }
+.connection-health-row__state.is-degraded { color: #b7791f; }
+.connection-health-row__state.is-partial_outage { color: #c05621; }
+.connection-health-row__state.is-major_outage { color: #c53030; }
+.connection-health-row__state.is-not_monitored,
+.connection-health-row__state.is-maintenance { color: #a0aec0; }
+
+/* 条带：经典竖条 */
+.connection-health-bars {
+    display: flex;
+    gap: 1.5px;
+    align-items: stretch;
+    height: 36px;
+    width: 100%;
+}
+
+.connection-health-bar {
+    flex: 1 1 0;
+    min-width: 0;
+    border: none;
+    padding: 0;
+    margin: 0;
+    border-radius: 1px;
+    cursor: pointer;
+    appearance: none;
+    background: #dfe3e8;
+    transition: filter 0.12s ease-out, transform 0.12s ease-out;
+}
+
+.connection-health-bar:hover,
+.connection-health-bar:focus-visible {
+    filter: brightness(0.92);
+    outline: none;
+    transform: scaleY(1.08);
+    transform-origin: center bottom;
+}
+
+.connection-health-row__footer {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    margin-top: 12px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--md-sys-color-on-surface-variant);
+    opacity: 0.82;
+    line-height: 1.2;
+}
+
+.connection-health-row__edge {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+.connection-health-row__rule {
+    flex: 1 1 0;
+    height: 1px;
+    min-width: 12px;
+    margin: 0 10px;
+    /* 经典 statuspage 分隔线：足够可见，又不抢正文 */
+    background: color-mix(in srgb, var(--md-sys-color-on-surface) 28%, transparent);
+    align-self: center;
+}
+
+body.dark-theme .connection-health-row__rule,
+html.theme-dark .connection-health-row__rule {
+    background: color-mix(in srgb, var(--md-sys-color-on-surface) 38%, transparent);
+}
+
+.connection-health-row__uptime {
+    flex: 0 0 auto;
+    text-align: center;
+    white-space: nowrap;
+    font-weight: 650;
+    font-size: 12.5px;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.connection-health-incidents {
+    margin-top: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 4px;
+}
+
+.connection-health-incidents__title {
+    font-weight: 800 !important;
+    letter-spacing: -0.02em;
+    font-size: 1.22rem !important;
+}
+
+.connection-health-incident-day {
+    padding-bottom: 4px;
+    border-bottom: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 40%, transparent);
+}
+
+.connection-health-incident-day:last-child {
+    border-bottom: none;
+}
+
+.connection-health-incident-day__label {
+    font-weight: 700 !important;
+    margin-bottom: 8px !important;
+    font-size: 1.05rem !important;
+}
+
+.connection-health-incidents__empty {
+    opacity: 0.58;
+    margin-bottom: 8px !important;
+    font-size: 0.95rem !important;
+}
+
+.connection-health-incident {
+    padding: 12px 14px;
+    border-radius: 8px;
+    border-left: 3px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 80%, transparent);
+    border-top: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 40%, transparent);
+    border-right: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 40%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 40%, transparent);
+    background: color-mix(in srgb, var(--md-sys-color-surface) 97%, var(--md-sys-color-on-surface) 3%);
+    margin-bottom: 10px;
+}
+
+.connection-health-incident__title {
+    font-weight: 700;
+    margin-bottom: 6px;
+    font-size: 0.95rem;
+}
+
+.connection-health-incident__title.is-major_outage {
+    color: #c53030;
+    border-color: #c53030;
+}
+
+.connection-health-incident:has(.is-major_outage) {
+    border-left-color: #c53030;
+}
+
+.connection-health-incident:has(.is-partial_outage) {
+    border-left-color: #c05621;
+}
+
+.connection-health-incident:has(.is-degraded) {
+    border-left-color: #b7791f;
+}
+
+.connection-health-incident__title.is-partial_outage { color: #c05621; }
+.connection-health-incident__title.is-degraded { color: #b7791f; }
+
+.connection-health-incident__meta,
+.connection-health-incident__time {
+    font-size: 12px;
+    color: var(--md-sys-color-on-surface-variant);
+    margin-bottom: 2px;
+}
+
+.connection-health-incident__timeline {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    font-size: 12px;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+/* 自定义 tooltip：JS 写 left/top 为左上角，禁止 translate 造成贴边裁切 */
+.connection-health-tooltip-layer {
+    position: fixed;
+    z-index: 1200;
+    left: 0;
+    top: 0;
+    transform: none;
+    pointer-events: none;
+    max-width: min(280px, calc(100vw - 16px));
+    box-sizing: border-box;
+}
+
+.connection-health-tooltip-layer.is-below {
+    transform: none;
+}
+
+.connection-health-tooltip {
+    min-width: 160px;
+    max-width: min(260px, calc(100vw - 16px));
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: #1a202c;
+    color: #f7fafc;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    box-sizing: border-box;
+}
+
+html.theme-dark .connection-health-tooltip,
+body.dark-theme .connection-health-tooltip {
+    background: #0f1419;
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.connection-health-tooltip__title {
+    font-weight: 700;
+    margin-bottom: 2px;
+    font-size: 12.5px;
+}
+
+.connection-health-tooltip__day {
+    opacity: 0.75;
+    margin-bottom: 6px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.connection-health-tooltip__line {
+    opacity: 0.92;
+}
+
+.connection-health-error {
+    color: #c53030;
+    opacity: 0.9;
+}
+
+.connection-health-skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.connection-health-skeleton-banner {
+    height: 52px;
+    border-radius: 10px;
+}
+
+.connection-health-skeleton-row {
+    height: 84px;
+    border-radius: 10px;
+}
+
+@media (max-width: 768px) {
+    .connection-health-bars {
+        height: 28px;
+        gap: 1px;
+    }
+
+    .connection-health-row {
+        padding: 16px 14px 14px;
+    }
+
+    .connection-health-banner {
+        padding: 14px 16px;
+    }
+
+    .connection-health-banner__label {
+        font-size: 1.05rem;
+    }
+
+    .connection-health-row__name {
+        font-size: 1rem !important;
+    }
+
+    .connection-health-row__state {
+        font-size: 0.95rem !important;
+    }
+
+    .connection-health-row__rule {
+        margin: 0 6px;
+        min-width: 8px;
+    }
+}

--- a/admin/css/views/status.css
+++ b/admin/css/views/status.css
@@ -1311,13 +1311,17 @@ html.theme-dark .connection-health-bar.is-maintenance {
 .connection-health-row__state.is-not_monitored,
 .connection-health-row__state.is-maintenance { color: #a0aec0; }
 
-/* 条带：经典竖条 */
+/* 条带：经典竖条
+   - 不用 flex gap：间隙是 pointer 死区，会触发 enter/leave 高频闪烁
+   - 分隔用 inset box-shadow，命中区域连续
+   - hover 仅调亮度，禁止 scale（会改命中盒导致抖动） */
 .connection-health-bars {
     display: flex;
-    gap: 1.5px;
+    gap: 0;
     align-items: stretch;
     height: 36px;
     width: 100%;
+    cursor: pointer;
 }
 
 .connection-health-bar {
@@ -1327,17 +1331,21 @@ html.theme-dark .connection-health-bar.is-maintenance {
     border: none;
     padding: 0;
     margin: 0;
-    border-radius: 1px;
-    cursor: pointer;
+    border-radius: 0;
+    cursor: inherit;
     background: #dfe3e8;
-    transition: filter 0.12s ease-out, transform 0.12s ease-out;
+    /* 右侧 1px 视觉分隔，不占用布局间隙 */
+    box-shadow: inset -1px 0 0 color-mix(in srgb, var(--md-sys-color-surface) 88%, transparent);
+    transition: filter 0.12s ease-out;
+    pointer-events: none; /* 事件由父容器统一处理，避免条间死区 */
 }
 
-.connection-health-bar:hover {
+.connection-health-bar:last-child {
+    box-shadow: none;
+}
+
+.connection-health-bar.is-hot {
     filter: brightness(0.92);
-    outline: none;
-    transform: scaleY(1.08);
-    transform-origin: center bottom;
 }
 
 .connection-health-row__footer {
@@ -1547,7 +1555,7 @@ body.dark-theme .connection-health-tooltip {
 @media (max-width: 768px) {
     .connection-health-bars {
         height: 28px;
-        gap: 1px;
+        gap: 0;
     }
 
     .connection-health-row {

--- a/admin/css/views/status.css
+++ b/admin/css/views/status.css
@@ -1323,18 +1323,17 @@ html.theme-dark .connection-health-bar.is-maintenance {
 .connection-health-bar {
     flex: 1 1 0;
     min-width: 0;
+    display: block;
     border: none;
     padding: 0;
     margin: 0;
     border-radius: 1px;
     cursor: pointer;
-    appearance: none;
     background: #dfe3e8;
     transition: filter 0.12s ease-out, transform 0.12s ease-out;
 }
 
-.connection-health-bar:hover,
-.connection-health-bar:focus-visible {
+.connection-health-bar:hover {
     filter: brightness(0.92);
     outline: none;
     transform: scaleY(1.08);

--- a/admin/index.html
+++ b/admin/index.html
@@ -186,6 +186,7 @@
     <!-- 12. 系统服务运行状态页专属子组件 -->
     <script type="text/babel" src="js/components/status/StatusCard.jsx" defer></script>
     <script type="text/babel" src="js/components/status/ConnectionsGrid.jsx" defer></script>
+    <script type="text/babel" src="js/components/status/ConnectionHealthPanel.jsx" defer></script>
     <script type="text/babel" src="js/components/status/NewsTicker.jsx" defer></script>
     <script type="text/babel" src="js/components/status/SimulationModal.jsx" defer></script>
     <script type="text/babel" src="js/components/status/EewStatusCard.jsx" defer></script>

--- a/admin/js/components/status/ConnectionHealthPanel.jsx
+++ b/admin/js/components/status/ConnectionHealthPanel.jsx
@@ -21,6 +21,8 @@ function ConnectionHealthPanel() {
     const tipRef = useRef(null);
     const dataRef = useRef(null);
     const lastFullAtRef = useRef(0);
+    // 条带 hover：记录当前命中的 day key，避免间隙抖动重复 setState
+    const hoverKeyRef = useRef('');
 
     const LIVE_INTERVAL_MS = 15000;
     const FULL_INTERVAL_MS = 5 * 60 * 1000;
@@ -292,16 +294,68 @@ function ConnectionHealthPanel() {
         return map[state] || state || '未知';
     };
 
-    const openTip = (event, comp, day) => {
-        const rect = event.currentTarget.getBoundingClientRect();
+    /**
+     * 在整条 bars 容器上做命中测试：按 x 比例映射到 day，
+     * 彻底避开 flex gap / 条间 1px 死区导致的 enter/leave 闪烁。
+     */
+    const handleBarsPointer = useCallback((event, comp, days) => {
+        const list = Array.isArray(days) ? days : [];
+        if (!list.length) return;
+        const container = event.currentTarget;
+        const rect = container.getBoundingClientRect();
+        if (rect.width <= 0) return;
+
+        const ratio = (event.clientX - rect.left) / rect.width;
+        const idx = Math.min(
+            list.length - 1,
+            Math.max(0, Math.floor(ratio * list.length)),
+        );
+        const day = list[idx];
+        if (!day) return;
+
+        const key = `${comp.group_key}:${day.day}`;
+        if (hoverKeyRef.current === key) {
+            setHoverTip((prev) => {
+                if (!prev) {
+                    return {
+                        component: comp,
+                        day,
+                        x: event.clientX,
+                        y: rect.top,
+                        barHeight: rect.height,
+                        barKey: key,
+                    };
+                }
+                // 同条内跟随鼠标 x，避免 tip 钉死在条中心；坐标变化很小时跳过
+                if (Math.abs((prev.x || 0) - event.clientX) < 2
+                    && Math.abs((prev.y || 0) - rect.top) < 1) {
+                    return prev;
+                }
+                return {
+                    ...prev,
+                    x: event.clientX,
+                    y: rect.top,
+                    barHeight: rect.height,
+                };
+            });
+            return;
+        }
+
+        hoverKeyRef.current = key;
         setHoverTip({
             component: comp,
             day,
-            x: rect.left + rect.width / 2,
+            x: event.clientX,
             y: rect.top,
             barHeight: rect.height,
+            barKey: key,
         });
-    };
+    }, []);
+
+    const clearBarsPointer = useCallback(() => {
+        hoverKeyRef.current = '';
+        setHoverTip(null);
+    }, []);
 
     const renderBarTooltip = (component, day) => {
         if (!day) return null;
@@ -434,18 +488,21 @@ function ConnectionHealthPanel() {
                             <div
                                 className="connection-health-bars"
                                 aria-label={`${comp.name} 近 ${days.length} 天可用性`}
+                                onMouseMove={(e) => handleBarsPointer(e, comp, days)}
+                                onMouseLeave={clearBarsPointer}
                             >
-                                {days.map((day) => (
-                                    <span
-                                        key={`${comp.group_key}-${day.day}`}
-                                        className={`connection-health-bar is-${day.state || 'not_monitored'}`}
-                                        role="img"
-                                        aria-label={`${comp.name} ${day.day} ${stateLabel(day.state)}`}
-                                        tabIndex={-1}
-                                        onMouseEnter={(e) => openTip(e, comp, day)}
-                                        onMouseLeave={() => setHoverTip(null)}
-                                    />
-                                ))}
+                                {days.map((day) => {
+                                    const barKey = `${comp.group_key}:${day.day}`;
+                                    const isHot = hoverTip?.barKey === barKey;
+                                    return (
+                                        <span
+                                            key={`${comp.group_key}-${day.day}`}
+                                            className={`connection-health-bar is-${day.state || 'not_monitored'}${isHot ? ' is-hot' : ''}`}
+                                            role="img"
+                                            aria-label={`${comp.name} ${day.day} ${stateLabel(day.state)}`}
+                                        />
+                                    );
+                                })}
                             </div>
 
                             <div className="connection-health-row__footer">

--- a/admin/js/components/status/ConnectionHealthPanel.jsx
+++ b/admin/js/components/status/ConnectionHealthPanel.jsx
@@ -1,0 +1,370 @@
+const { Box, Typography } = MaterialUI;
+const { useCallback, useEffect, useMemo, useRef, useState } = React;
+
+/**
+ * 连接健康 Statuspage 面板
+ * - 总横幅（全部通道正常 / 部分异常 / 核心中断）
+ * - 各连接组 90 天可用性条带
+ * - Past Incidents（通道事故，非地震事件）
+ */
+function ConnectionHealthPanel() {
+    const statusApi = window.DisasterStatusApi;
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [hoverTip, setHoverTip] = useState(null);
+    const tipRef = useRef(null);
+
+    const load = useCallback(async () => {
+        if (!statusApi || typeof statusApi.getConnectionHealth !== 'function') {
+            setError('连接健康接口不可用');
+            setLoading(false);
+            return;
+        }
+        try {
+            setError('');
+            const payload = await statusApi.getConnectionHealth(90);
+            setData(payload || null);
+        } catch (e) {
+            console.error('[ConnectionHealthPanel] load failed:', e);
+            setError(e?.message || '加载连接健康数据失败');
+        } finally {
+            setLoading(false);
+        }
+    }, [statusApi]);
+
+    useEffect(() => {
+        load();
+        // 实时态来自每次 API 拉取；10s 轮询以跟上 ConnectionsGrid 建连变化
+        const timer = setInterval(load, 10000);
+        return () => clearInterval(timer);
+    }, [load]);
+
+    // tooltip：left/top 为浮层左上角（禁止 translate 居中），贴边不裁切
+    useEffect(() => {
+        if (!hoverTip || !tipRef.current) return;
+        const el = tipRef.current;
+        el.style.transform = 'none';
+        el.classList.remove('is-below');
+
+        const vw = typeof window !== 'undefined' ? window.innerWidth : 800;
+        const vh = typeof window !== 'undefined' ? window.innerHeight : 600;
+        const pad = 8;
+        const tipW = Math.min(el.offsetWidth || 220, vw - pad * 2);
+        const tipH = el.offsetHeight || 80;
+        const barH = hoverTip.barHeight || 28;
+
+        let top = hoverTip.y - tipH - 8;
+        let below = false;
+        if (top < pad) {
+            below = true;
+            top = hoverTip.y + barH + 8;
+        }
+        if (top + tipH > vh - pad) {
+            top = Math.max(pad, vh - tipH - pad);
+        }
+
+        let left = hoverTip.x - tipW / 2;
+        left = Math.min(Math.max(left, pad), Math.max(pad, vw - tipW - pad));
+
+        el.style.left = `${Math.round(left)}px`;
+        el.style.top = `${Math.round(top)}px`;
+        el.style.transform = 'none';
+        el.classList.toggle('is-below', below);
+    }, [hoverTip]);
+
+    const overallClass = useMemo(() => {
+        const state = data?.overall?.state || 'not_monitored';
+        return `connection-health-banner connection-health-banner--${state}`;
+    }, [data]);
+
+    const formatDuration = (seconds) => {
+        const total = Math.max(0, Number(seconds) || 0);
+        const h = Math.floor(total / 3600);
+        const m = Math.floor((total % 3600) / 60);
+        if (h <= 0 && m <= 0) return `${total} 秒`;
+        if (h <= 0) return `${m} 分钟`;
+        if (m <= 0) return `${h} 小时`;
+        return `${h} 小时 ${m} 分钟`;
+    };
+
+    const formatMinutes = (minutes) => {
+        const m = Math.max(0, Number(minutes) || 0);
+        if (m < 1) return '< 1 分钟';
+        if (m < 60) return `${Math.round(m)} 分钟`;
+        const h = Math.floor(m / 60);
+        const rest = Math.round(m % 60);
+        return rest ? `${h} 小时 ${rest} 分钟` : `${h} 小时`;
+    };
+
+    /** 后端 ISO → 本地可读时间（避免直接 slice UTC） */
+    const formatDateTime = (value) => {
+        const text = String(value || '').trim();
+        if (!text) return '';
+        // 优先用后端已格式化的 display 字段
+        if (data?.overall?.updated_at_display && value === data.overall.updated_at) {
+            return data.overall.updated_at_display;
+        }
+        try {
+            const normalized = text.endsWith('Z') ? text : text;
+            const dt = new Date(normalized);
+            if (Number.isNaN(dt.getTime())) {
+                return text.replace('T', ' ').slice(0, 19);
+            }
+            const pad = (n) => String(n).padStart(2, '0');
+            return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())} ${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}`;
+        } catch (e) {
+            return text.replace('T', ' ').slice(0, 19);
+        }
+    };
+
+    const stateLabel = (state) => {
+        const map = {
+            operational: '正常',
+            degraded: '降级',
+            partial_outage: '部分中断',
+            major_outage: '中断',
+            maintenance: '维护',
+            not_monitored: '未启用',
+        };
+        return map[state] || state || '未知';
+    };
+
+    const openTip = (event, comp, day) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        setHoverTip({
+            component: comp,
+            day,
+            x: rect.left + rect.width / 2,
+            y: rect.top,
+            barHeight: rect.height,
+        });
+    };
+
+    const renderBarTooltip = (component, day) => {
+        if (!day) return null;
+        const lines = [];
+        if (day.state === 'not_monitored' || !day.minutes_monitored) {
+            lines.push('未纳入监控 / 无采样');
+        } else {
+            if (day.minutes_major > 0) {
+                lines.push(`中断 ${formatMinutes(day.minutes_major)}`);
+            }
+            if (day.minutes_partial > 0) {
+                lines.push(`部分中断 ${formatMinutes(day.minutes_partial)}`);
+            }
+            if (day.minutes_degraded > 0) {
+                lines.push(`降级 ${formatMinutes(day.minutes_degraded)}`);
+            }
+            if (
+                day.minutes_major <= 0
+                && day.minutes_partial <= 0
+                && day.minutes_degraded <= 0
+            ) {
+                lines.push('全天正常');
+            }
+            if (day.uptime_ratio != null) {
+                lines.push(`当日可用性 ${(Number(day.uptime_ratio) * 100).toFixed(2)}%`);
+            }
+        }
+        return (
+            <div className="connection-health-tooltip" role="tooltip">
+                <div className="connection-health-tooltip__title">{component.name}</div>
+                <div className="connection-health-tooltip__day">{day.day}</div>
+                {lines.map((line, idx) => (
+                    <div key={`${day.day}-L${idx}`} className="connection-health-tooltip__line">
+                        {line}
+                    </div>
+                ))}
+            </div>
+        );
+    };
+
+    if (loading && !data) {
+        return (
+            <div className="card connection-health-panel">
+                <Box className="status-card-header status-card-header--compact">
+                    <div className="status-card-icon status-card-icon--service">📡</div>
+                    <Typography variant="h6" className="status-card-title">通道健康</Typography>
+                </Box>
+                <div className="connection-health-skeleton">
+                    <div className="skeleton connection-health-skeleton-banner"></div>
+                    <div className="skeleton connection-health-skeleton-row"></div>
+                    <div className="skeleton connection-health-skeleton-row"></div>
+                    <div className="skeleton connection-health-skeleton-row"></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error && !data) {
+        return (
+            <div className="card connection-health-panel">
+                <Box className="status-card-header status-card-header--compact">
+                    <div className="status-card-icon status-card-icon--service">📡</div>
+                    <Typography variant="h6" className="status-card-title">通道健康</Typography>
+                </Box>
+                <Typography variant="body2" className="connection-health-error">
+                    {error}
+                </Typography>
+            </div>
+        );
+    }
+
+    const overall = data?.overall || {};
+    const meta = data?.meta || {};
+    const components = Array.isArray(data?.components) ? data.components : [];
+    const incidentsByDay = Array.isArray(data?.incidents_by_day) ? data.incidents_by_day : [];
+    const legend = Array.isArray(data?.legend) ? data.legend : [];
+    const updatedDisplay = overall.updated_at_display
+        || formatDateTime(overall.updated_at);
+
+    return (
+        <div className="card connection-health-panel">
+            <Box className="status-card-header status-card-header--compact">
+                <div className="status-card-icon status-card-icon--service">📡</div>
+                <Box>
+                    <Typography variant="h6" className="status-card-title">通道健康</Typography>
+                    <Typography variant="caption" className="connection-health-subtitle">
+                        近 {meta.days || 90} 天数据通道可用性
+                    </Typography>
+                </Box>
+            </Box>
+
+            <div className={overallClass} role="status" aria-live="polite">
+                <span className="connection-health-banner__label">
+                    {overall.label || '状态未知'}
+                </span>
+                <span className="connection-health-banner__meta">
+                    {overall.running === false ? '服务未运行 · ' : ''}
+                    {updatedDisplay ? `更新于 ${updatedDisplay}` : ''}
+                </span>
+            </div>
+
+            {legend.length > 0 && (
+                <div className="connection-health-legend" aria-label="状态图例">
+                    {legend.map((item) => (
+                        <span key={item.state} className="connection-health-legend__item">
+                            <span className={`connection-health-legend__swatch is-${item.state}`} />
+                            {item.label}
+                        </span>
+                    ))}
+                </div>
+            )}
+
+            <div className="connection-health-list">
+                {components.map((comp) => {
+                    const days = Array.isArray(comp.days) ? comp.days : [];
+                    const uptimeText = comp.uptime_percent != null
+                        ? `${Number(comp.uptime_percent).toFixed(2)}% uptime`
+                        : '暂无足够样本';
+                    return (
+                        <div key={comp.group_key} className="connection-health-row">
+                            <div className="connection-health-row__header">
+                                <Typography className="connection-health-row__name">
+                                    {comp.name}
+                                </Typography>
+                                <Typography className={`connection-health-row__state is-${comp.current_state}`}>
+                                    {comp.current_label || stateLabel(comp.current_state)}
+                                </Typography>
+                            </div>
+
+                            <div
+                                className="connection-health-bars"
+                                role="img"
+                                aria-label={`${comp.name} 近 ${days.length} 天可用性`}
+                            >
+                                {days.map((day) => (
+                                    <button
+                                        key={`${comp.group_key}-${day.day}`}
+                                        type="button"
+                                        className={`connection-health-bar is-${day.state || 'not_monitored'}`}
+                                        aria-label={`${comp.name} ${day.day} ${stateLabel(day.state)}`}
+                                        onMouseEnter={(e) => openTip(e, comp, day)}
+                                        onMouseLeave={() => setHoverTip(null)}
+                                        onFocus={(e) => openTip(e, comp, day)}
+                                        onBlur={() => setHoverTip(null)}
+                                    />
+                                ))}
+                            </div>
+
+                            <div className="connection-health-row__footer">
+                                <span className="connection-health-row__edge">{(meta.days || 90)} 天前</span>
+                                <span className="connection-health-row__rule" aria-hidden="true" />
+                                <span className="connection-health-row__uptime">{uptimeText}</span>
+                                <span className="connection-health-row__rule" aria-hidden="true" />
+                                <span className="connection-health-row__edge">今天</span>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+
+            <div className="connection-health-incidents">
+                <Typography variant="h6" className="connection-health-incidents__title">
+                    历史通道事故
+                </Typography>
+                {incidentsByDay.length === 0 ? (
+                    <Typography variant="body2" className="connection-health-incidents__empty">
+                        暂无事故记录
+                    </Typography>
+                ) : (
+                    incidentsByDay.map((group) => (
+                        <div key={group.day} className="connection-health-incident-day">
+                            <Typography className="connection-health-incident-day__label">
+                                {group.label || group.day}
+                            </Typography>
+                            {(!group.incidents || group.incidents.length === 0) ? (
+                                <Typography variant="body2" className="connection-health-incidents__empty">
+                                    {group.empty_text || '无通道事故'}
+                                </Typography>
+                            ) : (
+                                group.incidents.map((inc) => (
+                                    <div key={inc.id || `${inc.group_key}-${inc.started_at}`} className="connection-health-incident">
+                                        <div className={`connection-health-incident__title is-${inc.severity}`}>
+                                            {inc.title || `${inc.component_name} 异常`}
+                                        </div>
+                                        <div className="connection-health-incident__meta">
+                                            <strong>
+                                                {inc.status === 'resolved' ? '已解决' : '调查中'}
+                                            </strong>
+                                            {inc.severity_label ? ` · ${inc.severity_label}` : ''}
+                                            {inc.duration_seconds != null
+                                                ? ` · ${formatDuration(inc.duration_seconds)}`
+                                                : ''}
+                                        </div>
+                                        <div className="connection-health-incident__time">
+                                            {formatDateTime(inc.started_at)}
+                                            {inc.ended_at
+                                                ? ` → ${formatDateTime(inc.ended_at)}`
+                                                : ' → 进行中'}
+                                        </div>
+                                        {Array.isArray(inc.timeline) && inc.timeline.length > 0 && (
+                                            <ul className="connection-health-incident__timeline">
+                                                {inc.timeline.slice().reverse().map((node, idx) => (
+                                                    <li key={`${inc.id}-tl-${idx}`}>
+                                                        <strong>{node.status || ''}</strong>
+                                                        {node.message ? ` — ${node.message}` : ''}
+                                                        {node.at
+                                                            ? `（${formatDateTime(node.at).slice(0, 16)}）`
+                                                            : ''}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                    ))
+                )}
+            </div>
+
+            {hoverTip && (
+                <div ref={tipRef} className="connection-health-tooltip-layer">
+                    {renderBarTooltip(hoverTip.component, hoverTip.day)}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/admin/js/components/status/ConnectionHealthPanel.jsx
+++ b/admin/js/components/status/ConnectionHealthPanel.jsx
@@ -1,11 +1,16 @@
 const { Box, Typography } = MaterialUI;
-const { useCallback, useEffect, useMemo, useRef, useState } = React;
+const { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } = React;
 
 /**
  * 连接健康 Statuspage 面板
  * - 总横幅（全部通道正常 / 部分异常 / 核心中断）
  * - 各连接组 90 天可用性条带
  * - Past Incidents（通道事故，非地震事件）
+ *
+ * 轮询策略：
+ * - 首屏 full 拉一次（实时 + 历史）
+ * - 可见时 live 每 15s 刷新实时态
+ * - full 历史每 5 分钟刷新；document.hidden 时暂停
  */
 function ConnectionHealthPanel() {
     const statusApi = window.DisasterStatusApi;
@@ -14,34 +19,192 @@ function ConnectionHealthPanel() {
     const [error, setError] = useState('');
     const [hoverTip, setHoverTip] = useState(null);
     const tipRef = useRef(null);
+    const dataRef = useRef(null);
+    const lastFullAtRef = useRef(0);
 
-    const load = useCallback(async () => {
+    const LIVE_INTERVAL_MS = 15000;
+    const FULL_INTERVAL_MS = 5 * 60 * 1000;
+
+    const mergeLiveIntoData = useCallback((prev, livePayload) => {
+        if (!livePayload) return prev;
+        if (!prev) {
+            return {
+                ...livePayload,
+                components: Array.isArray(livePayload.components)
+                    ? livePayload.components.map((c) => ({
+                        ...c,
+                        days: Array.isArray(c.days) ? c.days : [],
+                        uptime_ratio: c.uptime_ratio ?? null,
+                        uptime_percent: c.uptime_percent ?? null,
+                    }))
+                    : [],
+                incidents: Array.isArray(livePayload.incidents) ? livePayload.incidents : [],
+                incidents_by_day: Array.isArray(livePayload.incidents_by_day)
+                    ? livePayload.incidents_by_day
+                    : [],
+            };
+        }
+
+        const liveByKey = {};
+        (Array.isArray(livePayload.components) ? livePayload.components : []).forEach((c) => {
+            if (c && c.group_key) liveByKey[c.group_key] = c;
+        });
+
+        const prevComponents = Array.isArray(prev.components) ? prev.components : [];
+        const mergedComponents = prevComponents.map((comp) => {
+            const live = liveByKey[comp.group_key];
+            if (!live) return comp;
+            return {
+                ...comp,
+                name: live.name || comp.name,
+                current_state: live.current_state,
+                current_label: live.current_label,
+                enabled: live.enabled,
+                connected: live.connected,
+                latency_ms: live.latency_ms,
+                retry_count: live.retry_count,
+                circuit_open: live.circuit_open,
+            };
+        });
+
+        // 若 live 出现 prev 没有的组件，追加（通常不会）
+        Object.keys(liveByKey).forEach((key) => {
+            if (!mergedComponents.some((c) => c.group_key === key)) {
+                const live = liveByKey[key];
+                mergedComponents.push({
+                    ...live,
+                    days: [],
+                    uptime_ratio: null,
+                    uptime_percent: null,
+                });
+            }
+        });
+
+        return {
+            ...prev,
+            overall: livePayload.overall || prev.overall,
+            legend: livePayload.legend || prev.legend,
+            meta: {
+                ...(prev.meta || {}),
+                ...(livePayload.meta || {}),
+                // 保留历史窗口元信息
+                days: (prev.meta && prev.meta.days) || (livePayload.meta && livePayload.meta.days) || 90,
+                mode: 'full',
+            },
+            components: mergedComponents,
+        };
+    }, []);
+
+    const loadFull = useCallback(async ({ silent = false } = {}) => {
         if (!statusApi || typeof statusApi.getConnectionHealth !== 'function') {
             setError('连接健康接口不可用');
             setLoading(false);
             return;
         }
         try {
-            setError('');
-            const payload = await statusApi.getConnectionHealth(90);
+            if (!silent) setError('');
+            const payload = await statusApi.getConnectionHealth(90, 'full');
             setData(payload || null);
+            dataRef.current = payload || null;
+            lastFullAtRef.current = Date.now();
         } catch (e) {
-            console.error('[ConnectionHealthPanel] load failed:', e);
-            setError(e?.message || '加载连接健康数据失败');
+            console.error('[ConnectionHealthPanel] full load failed:', e);
+            if (!dataRef.current) {
+                setError(e?.message || '加载连接健康数据失败');
+            }
         } finally {
             setLoading(false);
         }
     }, [statusApi]);
 
+    const loadLive = useCallback(async () => {
+        if (!statusApi || typeof statusApi.getConnectionHealth !== 'function') {
+            return;
+        }
+        try {
+            const payload = await statusApi.getConnectionHealth(90, 'live');
+            setData((prev) => {
+                const next = mergeLiveIntoData(prev, payload);
+                dataRef.current = next;
+                return next;
+            });
+        } catch (e) {
+            // live 失败不打断历史展示
+            console.warn('[ConnectionHealthPanel] live load failed:', e);
+        }
+    }, [statusApi, mergeLiveIntoData]);
+
     useEffect(() => {
-        load();
-        // 实时态来自每次 API 拉取；10s 轮询以跟上 ConnectionsGrid 建连变化
-        const timer = setInterval(load, 10000);
-        return () => clearInterval(timer);
-    }, [load]);
+        let cancelled = false;
+        let liveTimer = null;
+        let fullTimer = null;
+
+        const clearTimers = () => {
+            if (liveTimer) {
+                clearInterval(liveTimer);
+                liveTimer = null;
+            }
+            if (fullTimer) {
+                clearInterval(fullTimer);
+                fullTimer = null;
+            }
+        };
+
+        const tickLive = () => {
+            if (cancelled) return;
+            if (typeof document !== 'undefined' && document.hidden) return;
+            loadLive();
+        };
+
+        const tickFull = () => {
+            if (cancelled) return;
+            if (typeof document !== 'undefined' && document.hidden) return;
+            loadFull({ silent: true });
+        };
+
+        const startTimers = () => {
+            clearTimers();
+            if (typeof document !== 'undefined' && document.hidden) return;
+            liveTimer = setInterval(tickLive, LIVE_INTERVAL_MS);
+            fullTimer = setInterval(tickFull, FULL_INTERVAL_MS);
+        };
+
+        const onVisibility = () => {
+            if (typeof document === 'undefined') return;
+            if (document.hidden) {
+                clearTimers();
+                return;
+            }
+            // 回到前台：立即补一次 live；若 full 过旧则补 full
+            loadLive();
+            if (Date.now() - lastFullAtRef.current >= FULL_INTERVAL_MS) {
+                loadFull({ silent: true });
+            }
+            startTimers();
+        };
+
+        // 首屏 full
+        loadFull({ silent: false }).then(() => {
+            if (cancelled) return;
+            startTimers();
+        });
+
+        if (typeof document !== 'undefined') {
+            document.addEventListener('visibilitychange', onVisibility);
+        }
+
+        return () => {
+            cancelled = true;
+            clearTimers();
+            if (typeof document !== 'undefined') {
+                document.removeEventListener('visibilitychange', onVisibility);
+            }
+        };
+    }, [loadFull, loadLive]);
 
     // tooltip：left/top 为浮层左上角（禁止 translate 居中），贴边不裁切
-    useEffect(() => {
+    // 使用 useLayoutEffect，避免 paint 后才定位导致首帧闪左上角
+    useLayoutEffect(() => {
         if (!hoverTip || !tipRef.current) return;
         const el = tipRef.current;
         el.style.transform = 'none';
@@ -106,8 +269,7 @@ function ConnectionHealthPanel() {
             return data.overall.updated_at_display;
         }
         try {
-            const normalized = text.endsWith('Z') ? text : text;
-            const dt = new Date(normalized);
+            const dt = new Date(text);
             if (Number.isNaN(dt.getTime())) {
                 return text.replace('T', ' ').slice(0, 19);
             }
@@ -271,19 +433,17 @@ function ConnectionHealthPanel() {
 
                             <div
                                 className="connection-health-bars"
-                                role="img"
                                 aria-label={`${comp.name} 近 ${days.length} 天可用性`}
                             >
                                 {days.map((day) => (
-                                    <button
+                                    <span
                                         key={`${comp.group_key}-${day.day}`}
-                                        type="button"
                                         className={`connection-health-bar is-${day.state || 'not_monitored'}`}
+                                        role="img"
                                         aria-label={`${comp.name} ${day.day} ${stateLabel(day.state)}`}
+                                        tabIndex={-1}
                                         onMouseEnter={(e) => openTip(e, comp, day)}
                                         onMouseLeave={() => setHoverTip(null)}
-                                        onFocus={(e) => openTip(e, comp, day)}
-                                        onBlur={() => setHoverTip(null)}
                                     />
                                 ))}
                             </div>

--- a/admin/js/services/statusApi.js
+++ b/admin/js/services/statusApi.js
@@ -19,9 +19,13 @@
         getStatus: () => client.request('/status'),
         getStatistics: () => client.request('/statistics'),
         getConnections: () => client.request('/connections'),
-        /** 连接健康 Statuspage：90 天条带 + 事故 */
-        getConnectionHealth: (days = 90) => client.request('/connection-health', {
-            query: { days },
+        /**
+         * 连接健康 Statuspage
+         * @param {number} days 历史窗口天数
+         * @param {'full'|'live'} mode full=条带+事故；live=仅实时态
+         */
+        getConnectionHealth: (days = 90, mode = 'full') => client.request('/connection-health', {
+            query: { days, mode },
         }),
         getConfig: () => client.request('/config'),
         sendSimulation: (data) => client.request('/simulate', {

--- a/admin/js/services/statusApi.js
+++ b/admin/js/services/statusApi.js
@@ -19,6 +19,10 @@
         getStatus: () => client.request('/status'),
         getStatistics: () => client.request('/statistics'),
         getConnections: () => client.request('/connections'),
+        /** 连接健康 Statuspage：90 天条带 + 事故 */
+        getConnectionHealth: (days = 90) => client.request('/connection-health', {
+            query: { days },
+        }),
         getConfig: () => client.request('/config'),
         sendSimulation: (data) => client.request('/simulate', {
             method: 'POST',

--- a/admin/js/views/StatusView.jsx
+++ b/admin/js/views/StatusView.jsx
@@ -223,6 +223,11 @@ function StatusView({ onOpenSimulation }) {
                     <ConnectionsGrid />
                 </div>
 
+                {/* 通道健康：90 天条带 + 历史事故 */}
+                <div className="span-12">
+                    <ConnectionHealthPanel />
+                </div>
+
                 {/* 地震预警（EEW）状态卡片 */}
                 <div className="span-12">
                     <EewStatusCard />

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -181,6 +181,11 @@ class DisasterWarningService:
         self.eqsc_tsunami_poll_service = EqscTsunamiPollService(self)
         # EQSC 台风 HTTP 独立轮询（不依赖 FAN 触发）
         self.eqsc_typhoon_poll_service = EqscTyphoonPollService(self)
+        # 连接健康采样 / 90 天条带 / 自动事故（Statuspage 风格）
+        # 延迟导入，避免 health ↔ app 包级循环依赖。
+        from ..services.health.connection_health_service import ConnectionHealthService
+
+        self.connection_health_service = ConnectionHealthService(self)
         self._setup_runtime_services()
 
     def _setup_runtime_services(self) -> None:

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -144,6 +144,14 @@ class DisasterServiceLifecycleService:
                 # 提前将运行标记切为 False，阻止新任务继续按“服务运行中”路径工作。
                 self.service.running = False
 
+                # 立刻停连接健康采样：避免 running=False 后仍采样，把通道误记为
+                # major_outage 并触发错误事故开单。
+                health_service = getattr(
+                    self.service, "connection_health_service", None
+                )
+                if health_service is not None:
+                    await health_service.stop()
+
                 # 只有服务曾实际运行过，缓存状态才有落盘意义；
                 # 若初始化后从未成功启动，则无需写出这些状态文件。
                 if was_running:
@@ -182,13 +190,6 @@ class DisasterServiceLifecycleService:
                     await (
                         self.service.http_fetcher.close()
                     )  # 关闭 HTTP 客户端 Session 连接池
-
-                # 先停连接健康采样，避免停机过程中继续写库
-                health_service = getattr(
-                    self.service, "connection_health_service", None
-                )
-                if health_service is not None:
-                    await health_service.stop()
 
                 # 先停 EQSC 海啸/台风轮询客户端（共享 token 时不会关闭 token_manager）
                 eqsc_tsunami_poll = getattr(

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -74,6 +74,12 @@ class DisasterServiceLifecycleService:
                 )
                 if eqsc_typhoon_poll is not None:
                     await eqsc_typhoon_poll.start()
+                # 连接健康采样：依赖 statistics_manager 已 initialize
+                health_service = getattr(
+                    self.service, "connection_health_service", None
+                )
+                if health_service is not None:
+                    await health_service.start()
                 if getattr(self.service, "notification_center", None):
                     await (
                         self.service.notification_center.start()
@@ -176,6 +182,13 @@ class DisasterServiceLifecycleService:
                     await (
                         self.service.http_fetcher.close()
                     )  # 关闭 HTTP 客户端 Session 连接池
+
+                # 先停连接健康采样，避免停机过程中继续写库
+                health_service = getattr(
+                    self.service, "connection_health_service", None
+                )
+                if health_service is not None:
+                    await health_service.stop()
 
                 # 先停 EQSC 海啸/台风轮询客户端（共享 token 时不会关闭 token_manager）
                 eqsc_tsunami_poll = getattr(

--- a/core/app/runtime/disaster_service_status.py
+++ b/core/app/runtime/disaster_service_status.py
@@ -40,24 +40,25 @@ class DisasterServiceStatusService:
             1 for status in connection_status.values() if status["connected"]
         )
         # EQSC 为 HTTP 辅助通道，不在 ws_manager 连接表中；
-        # AccessToken 有效时计入活跃连接，配置启用时计入总连接。
-        eqsc_active, eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
+        # AccessToken 有效时计入活跃连接。总连接数由 snapshot 按 catalog 期望通道统计。
+        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
             self.service
         )
         active_websocket_connections += eqsc_active
-        # S-Net HTTP 轮询：任务在跑计入活跃，配置启用计入总连接
+        # S-Net HTTP 轮询：任务在跑计入活跃
         snet_poll = getattr(self.service, "snet_poll_service", None)
-        snet_total = 0
         try:
             snet_enabled = bool(
                 self._source_runtime_query.is_source_enabled("snet_msil")
             )
         except Exception:
             snet_enabled = False
-        if snet_enabled:
-            snet_total = 1
-            if snet_poll is not None and getattr(snet_poll, "running", False):
-                active_websocket_connections += 1
+        if (
+            snet_enabled
+            and snet_poll is not None
+            and getattr(snet_poll, "running", False)
+        ):
+            active_websocket_connections += 1
         # global_quake 连接存在一定特殊性，管理端会单独关心它是否在线，
         # 这里通过任务名快速整理出一个独立布尔状态。
         global_quake_connected = any(
@@ -78,10 +79,8 @@ class DisasterServiceStatusService:
             else False,
             global_quake_connected=global_quake_connected,
         )
-        # total_connections 默认只统计 WS；补上 EQSC / S-Net 后与活跃连接口径一致
-        snapshot["total_connections"] = (
-            int(snapshot.get("total_connections", 0) or 0) + eqsc_total + snet_total
-        )
+        # total_connections 已由 runtime snapshot 按 catalog 期望通道统计
+        # （含 EQSC / S-Net / 已停用通道），此处不再二次累加。
         return {
             **snapshot,
             # 统计摘要直接挂在顶层，便于管理端一次请求同时拿到运行状态与统计概览。

--- a/core/app/runtime/disaster_service_status.py
+++ b/core/app/runtime/disaster_service_status.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ...services.query.source_runtime_query_service import SourceRuntimeQueryService
-from ..services.typhoon_enrichment_service import TyphoonEnrichmentService
 
 
 class DisasterServiceStatusService:
@@ -34,36 +33,11 @@ class DisasterServiceStatusService:
         connection_status = (
             self.service.ws_manager.get_all_connections_status()
         )  # 物理 WebSocket 连接活跃表
-        # 该值反映的是“当前已连上的 WebSocket 连接数量”，
-        # 与配置中声明了多少连接、启动过多少任务并不完全等价。
-        active_websocket_connections = sum(
-            1 for status in connection_status.values() if status["connected"]
-        )
-        # EQSC 为 HTTP 辅助通道，不在 ws_manager 连接表中；
-        # AccessToken 有效时计入活跃连接。总连接数由 snapshot 按 catalog 期望通道统计。
-        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
-            self.service
-        )
-        active_websocket_connections += eqsc_active
-        # S-Net HTTP 轮询：任务在跑计入活跃
-        snet_poll = getattr(self.service, "snet_poll_service", None)
-        try:
-            snet_enabled = bool(
-                self._source_runtime_query.is_source_enabled("snet_msil")
-            )
-        except Exception:
-            snet_enabled = False
-        if (
-            snet_enabled
-            and snet_poll is not None
-            and getattr(snet_poll, "running", False)
-        ):
-            active_websocket_connections += 1
-        # global_quake 连接存在一定特殊性，管理端会单独关心它是否在线，
-        # 这里通过任务名快速整理出一个独立布尔状态。
-        global_quake_connected = any(
-            "global_quake" in task.get_name() if hasattr(task, "get_name") else False
-            for task in self.service.connection_tasks
+        # 活跃连接 / Global Quake 标记统一由 SourceRuntimeQueryService 计算，
+        # 避免与 RealtimePayloadBuilder 口径漂移。
+        metrics = self._source_runtime_query.resolve_active_connection_metrics(
+            self.service,
+            connection_status,
         )
 
         snapshot = self._source_runtime_query.build_runtime_snapshot(
@@ -73,11 +47,13 @@ class DisasterServiceStatusService:
             if hasattr(self.service, "start_time")
             else None,
             uptime=self.get_uptime(),
-            active_websocket_connections=active_websocket_connections,
+            active_websocket_connections=int(
+                metrics.get("active_websocket_connections", 0) or 0
+            ),
             message_logger_enabled=self.service.message_logger.enabled
             if self.service.message_logger
             else False,
-            global_quake_connected=global_quake_connected,
+            global_quake_connected=bool(metrics.get("global_quake_connected")),
         )
         # total_connections 已由 runtime snapshot 按 catalog 期望通道统计
         # （含 EQSC / S-Net / 已停用通道），此处不再二次累加。

--- a/core/network/admin/api/status_routes.py
+++ b/core/network/admin/api/status_routes.py
@@ -39,8 +39,12 @@ def register_status_routes(
             return ApiResponse.error(str(e), status_code=500)
 
     @app.get("/api/connection-health")
-    async def get_connection_health(days: int = 90):
-        """获取连接健康 Statuspage 载荷（90 天条带 + 事故）。"""
+    async def get_connection_health(days: int = 90, mode: str = "full"):
+        """获取连接健康 Statuspage 载荷。
+
+        mode=full: 实时态 + 90 天条带 + 事故
+        mode=live: 仅实时态（供前端高频轮询）
+        """
         try:
             guard_result = ApiResponse.guard_service_ready(disaster_service)
             if guard_result is not None:
@@ -58,8 +62,14 @@ def register_status_routes(
             except (TypeError, ValueError):
                 day_count = 90
             day_count = max(1, min(day_count, 180))
+            mode_norm = str(mode or "full").strip().lower()
+            if mode_norm not in {"full", "live"}:
+                mode_norm = "full"
 
-            payload = await health_service.build_statuspage_payload(days=day_count)
+            payload = await health_service.build_statuspage_payload(
+                days=day_count,
+                mode=mode_norm,
+            )
             return ApiResponse.success(payload)
         except Exception as e:
             logger.error(f"[灾害预警] 获取连接健康状态失败: {e}")

--- a/core/network/admin/api/status_routes.py
+++ b/core/network/admin/api/status_routes.py
@@ -38,6 +38,33 @@ def register_status_routes(
             logger.error(f"[灾害预警] 获取状态失败: {e}")
             return ApiResponse.error(str(e), status_code=500)
 
+    @app.get("/api/connection-health")
+    async def get_connection_health(days: int = 90):
+        """获取连接健康 Statuspage 载荷（90 天条带 + 事故）。"""
+        try:
+            guard_result = ApiResponse.guard_service_ready(disaster_service)
+            if guard_result is not None:
+                return guard_result
+
+            health_service = getattr(
+                disaster_service, "connection_health_service", None
+            )
+            if health_service is None:
+                return ApiResponse.error("连接健康服务未就绪", status_code=503)
+
+            # 允许 1–180；默认 90
+            try:
+                day_count = int(days or 90)
+            except (TypeError, ValueError):
+                day_count = 90
+            day_count = max(1, min(day_count, 180))
+
+            payload = await health_service.build_statuspage_payload(days=day_count)
+            return ApiResponse.success(payload)
+        except Exception as e:
+            logger.error(f"[灾害预警] 获取连接健康状态失败: {e}")
+            return ApiResponse.error(str(e), status_code=500)
+
     @app.get("/api/statistics")
     async def get_statistics():
         """获取统计数据。"""

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -151,6 +151,8 @@ class ConnectionsPayloadBuilder:
             connected = False
 
         return {
+            "group_key": "eqsc",
+            "display_name": self.EQSC_DISPLAY_NAME,
             "enabled": enabled,
             "connected": connected,
             "retry_count": 0,
@@ -241,6 +243,8 @@ class ConnectionsPayloadBuilder:
         }
 
         return {
+            "group_key": self.SNET_GROUP_KEY,
+            "display_name": self.SNET_DISPLAY_NAME,
             "enabled": enabled,
             "connected": connected,
             "retry_count": 0,

--- a/core/network/admin/payloads/realtime_payload_builder.py
+++ b/core/network/admin/payloads/realtime_payload_builder.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import Any
 
 from .....utils.version import get_plugin_version
-from ....app.services.typhoon_enrichment_service import TyphoonEnrichmentService
 from ....services.display import build_admin_statistics_projection
 from ....services.query.source_runtime_query_service import SourceRuntimeQueryService
 from .connections_payload_builder import ConnectionsPayloadBuilder
@@ -67,36 +66,10 @@ class RealtimePayloadBuilder:
                 self.disaster_service.ws_manager.get_all_connections_status()
             )
 
-        # 这里统计的是网络接入层的活动连接数，而不是管理端前端页面连接数。
-        active_websocket_connections = sum(
-            1
-            for status in actual_connections.values()
-            if isinstance(status, dict) and status.get("connected")
-        )
-        # EQSC HTTP 通道：AccessToken 有效计入活跃连接。
-        # 总连接数由 snapshot 按 catalog 期望通道统计（含已停用通道）。
-        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
-            self.disaster_service
-        )
-        active_websocket_connections += eqsc_active
-        # S-Net HTTP 轮询：任务在跑计入活跃
-        snet_poll = getattr(self.disaster_service, "snet_poll_service", None)
-        snet_enabled = False
-        try:
-            snet_enabled = bool(
-                self.source_runtime_query.is_source_enabled("snet_msil")
-            )
-        except Exception:
-            snet_enabled = False
-        if (
-            snet_enabled
-            and snet_poll is not None
-            and getattr(snet_poll, "running", False)
-        ):
-            active_websocket_connections += 1
-        global_quake_connected = any(
-            "global_quake" in task.get_name() if hasattr(task, "get_name") else False
-            for task in getattr(self.disaster_service, "connection_tasks", [])
+        # 活跃连接 / Global Quake 标记统一由 SourceRuntimeQueryService 计算。
+        metrics = self.source_runtime_query.resolve_active_connection_metrics(
+            self.disaster_service,
+            actual_connections,
         )
         snapshot = self.source_runtime_query.build_runtime_snapshot(
             actual_connections=actual_connections,
@@ -108,11 +81,13 @@ class RealtimePayloadBuilder:
             uptime=self.disaster_service.get_uptime()
             if hasattr(self.disaster_service, "get_uptime")
             else "未运行",
-            active_websocket_connections=active_websocket_connections,
+            active_websocket_connections=int(
+                metrics.get("active_websocket_connections", 0) or 0
+            ),
             message_logger_enabled=self.disaster_service.message_logger.enabled
             if getattr(self.disaster_service, "message_logger", None)
             else False,
-            global_quake_connected=global_quake_connected,
+            global_quake_connected=bool(metrics.get("global_quake_connected")),
         )
         # total_connections 已在 snapshot 内按期望通道统计，避免 EQSC/S-Net 重复累加。
         return snapshot

--- a/core/network/admin/payloads/realtime_payload_builder.py
+++ b/core/network/admin/payloads/realtime_payload_builder.py
@@ -73,25 +73,27 @@ class RealtimePayloadBuilder:
             for status in actual_connections.values()
             if isinstance(status, dict) and status.get("connected")
         )
-        # EQSC HTTP 通道：AccessToken 有效计入活跃连接，配置启用计入总连接
-        eqsc_active, eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
+        # EQSC HTTP 通道：AccessToken 有效计入活跃连接。
+        # 总连接数由 snapshot 按 catalog 期望通道统计（含已停用通道）。
+        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
             self.disaster_service
         )
         active_websocket_connections += eqsc_active
-        # S-Net HTTP 轮询：任务在跑计入活跃，配置启用计入总连接
+        # S-Net HTTP 轮询：任务在跑计入活跃
         snet_poll = getattr(self.disaster_service, "snet_poll_service", None)
         snet_enabled = False
-        snet_total = 0
         try:
             snet_enabled = bool(
                 self.source_runtime_query.is_source_enabled("snet_msil")
             )
         except Exception:
             snet_enabled = False
-        if snet_enabled:
-            snet_total = 1
-            if snet_poll is not None and getattr(snet_poll, "running", False):
-                active_websocket_connections += 1
+        if (
+            snet_enabled
+            and snet_poll is not None
+            and getattr(snet_poll, "running", False)
+        ):
+            active_websocket_connections += 1
         global_quake_connected = any(
             "global_quake" in task.get_name() if hasattr(task, "get_name") else False
             for task in getattr(self.disaster_service, "connection_tasks", [])
@@ -112,10 +114,7 @@ class RealtimePayloadBuilder:
             else False,
             global_quake_connected=global_quake_connected,
         )
-        # 补上 EQSC / S-Net 后，活跃/总连接口径与状态卡片一致
-        snapshot["total_connections"] = (
-            int(snapshot.get("total_connections", 0) or 0) + eqsc_total + snet_total
-        )
+        # total_connections 已在 snapshot 内按期望通道统计，避免 EQSC/S-Net 重复累加。
         return snapshot
 
     def build_status_payload(self) -> dict[str, Any]:

--- a/core/network/monitoring/source_health_monitor.py
+++ b/core/network/monitoring/source_health_monitor.py
@@ -30,7 +30,7 @@ class SourceHealthMonitor:
     # 静态映射：数据源标识 -> 在管理后台展示的可读中文名称
     DISPLAY_MAP: dict[str, str] = {
         "fan_studio_all": "FAN Studio",
-        "fan_studio_cenc_ir": "FAN Studio 烈度速报",
+        "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
         "p2p_main": "P2P地震情報",
         "wolfx_all": "Wolfx",
         "global_quake": "Global Quake",

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -28,6 +28,16 @@ class GlobalQuakeParser(BaseParser):
     def __init__(self, message_logger=None):
         super().__init__("global_quake", message_logger)
 
+    @staticmethod
+    def _is_invalid_zero_coordinate(latitude: Any, longitude: Any) -> bool:
+        """判定经纬度是否同为 0（上游脏数据/空心跳常见形态）。"""
+        try:
+            lat = float(latitude) if latitude is not None else 0.0
+            lon = float(longitude) if longitude is not None else 0.0
+        except (TypeError, ValueError):
+            return False
+        return abs(lat) < 1e-9 and abs(lon) < 1e-9
+
     def decode_message(self, message: str | bytes):
         """解码 Global Quake 原始消息。"""
         # 返回原始载荷，交由下层进一步判断类型
@@ -216,6 +226,14 @@ class GlobalQuakeParser(BaseParser):
         try:
             eq_data = ws_msg.earthquake_data
 
+            # 上游异常时可能持续推送 lat=0/lon=0 的伪事件，直接丢弃避免入库污染。
+            if self._is_invalid_zero_coordinate(eq_data.latitude, eq_data.longitude):
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 忽略经纬度为 0 的脏数据 "
+                    f"(id={getattr(eq_data, 'id', '')})"
+                )
+                return None
+
             # 震源时间优先使用标准时间字符串，缺失时再回退到毫秒时间戳。
             shock_time = None
             if eq_data.origin_time_iso:
@@ -382,6 +400,12 @@ class GlobalQuakeParser(BaseParser):
             intensity = ScaleConverter.convert_roman_intensity(intensity_str)
             latitude = eq_data.get("latitude", 0)
             longitude = eq_data.get("longitude", 0)
+            if self._is_invalid_zero_coordinate(latitude, longitude):
+                plugin_logger.debug(
+                    f"[灾害预警] {self.source_id} 忽略经纬度为 0 的 JSON 脏数据 "
+                    f"(id={eq_data.get('id', '')})"
+                )
+                return None
 
             magnitude = safe_float_convert(eq_data.get("magnitude"))
             if magnitude is not None:

--- a/core/services/health/__init__.py
+++ b/core/services/health/__init__.py
@@ -1,0 +1,5 @@
+"""连接健康监控服务包。"""
+
+from .connection_health_service import ConnectionHealthService
+
+__all__ = ["ConnectionHealthService"]

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -113,6 +113,11 @@ class ConnectionHealthService:
         self._trackers: dict[str, dict[str, Any]] = {}
         self._last_purge_at: float = 0.0
         self._display_tz = "UTC+8"
+        # 完整 Statuspage 历史载荷短 TTL 缓存，降低管理端轮询对 DB 的压力
+        self._history_cache: dict[str, Any] | None = None
+        self._history_cache_key: str = ""
+        self._history_cache_at: float = 0.0
+        self._history_cache_ttl_seconds: float = 45.0
 
     # ──────────────────────────── 生命周期 ────────────────────────────
 
@@ -132,6 +137,11 @@ class ConnectionHealthService:
         if self._running:
             return
         self._running = True
+        # 启动时从 DB 回填未关闭事故，避免进程重启后 tracker 丢失导致重复开单。
+        try:
+            await self._hydrate_open_incidents()
+        except Exception as exc:
+            logger.warning(f"[灾害预警] 连接健康事故状态回填失败: {exc}")
         self._task = asyncio.create_task(self._loop())
         logger.info("[灾害预警] 连接健康采样服务已启动")
 
@@ -146,9 +156,33 @@ class ConnectionHealthService:
                 await task
             except asyncio.CancelledError:
                 pass
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(f"[灾害预警] 连接健康采样停止时异常: {exc}")
         logger.info("[灾害预警] 连接健康采样服务已停止")
+
+    async def _hydrate_open_incidents(self) -> None:
+        """从数据库恢复各连接组未关闭事故到内存 tracker。"""
+        repo = self._ensure_repo()
+        if repo is None:
+            return
+        for group_key in COMPONENT_ORDER:
+            open_inc = await repo.get_open_incident(group_key)
+            if open_inc is None:
+                continue
+            tracker = self._trackers.setdefault(
+                group_key,
+                {
+                    "bad_since": None,
+                    "good_since": None,
+                    "last_state": "not_monitored",
+                    "open_incident_id": None,
+                },
+            )
+            tracker["open_incident_id"] = int(open_inc.get("id") or 0) or None
+            started = self._parse_iso(open_inc.get("started_at"))
+            if started is not None:
+                tracker["bad_since"] = started
+            tracker["good_since"] = None
 
     async def _loop(self) -> None:
         # 启动后多等一会，让 WS/HTTP 通道先完成首轮建连与鉴权
@@ -221,13 +255,19 @@ class ConnectionHealthService:
         )
         connections = builder.build()
 
-        # display_name -> info；同时按别名映射到 group_key，避免文案微调后匹配失败
+        # 优先使用 payload 内稳定 group_key；展示名仅作兼容回退。
         by_display = connections if isinstance(connections, dict) else {}
         by_group: dict[str, dict[str, Any]] = {}
         for disp_name, info in by_display.items():
+            if not isinstance(info, dict):
+                continue
+            explicit_key = str(info.get("group_key") or "").strip()
+            if explicit_key:
+                by_group[explicit_key] = info
+                continue
             key = str(disp_name or "").strip()
             mapped = DISPLAY_NAME_ALIASES.get(key)
-            if mapped and isinstance(info, dict):
+            if mapped:
                 by_group[mapped] = info
 
         # 也读 raw WS status，补 retry / last_active
@@ -387,8 +427,9 @@ class ConnectionHealthService:
         now = self._now_utc()
         ts = self._iso(now)
         day = self._day_key(now)
-        # 每样本代表的监控分钟（按采样间隔折算，上限 5 分钟防长暂停）
-        minutes = max(0.25, min(self.sample_interval / 60.0, 5.0))
+        # 每样本代表的监控分钟（按采样间隔折算，上限 5 分钟防长暂停）。
+        # 使用浮点分钟写入 REAL 列，避免 int(0.25)=0 导致日聚合永不累加。
+        minutes = float(max(0.25, min(self.sample_interval / 60.0, 5.0)))
 
         components = self._build_live_components()
         samples: list[dict[str, Any]] = []
@@ -485,18 +526,23 @@ class ConnectionHealthService:
         is_bad = enabled and state in {"major_outage", "partial_outage"}
         is_good = enabled and state in {"operational", "degraded"}
 
+        # 始终按 group_key 查库恢复未关闭事故，避免仅依赖内存 id（进程重启后会丢）。
+        open_inc = await repo.get_open_incident(group_key)
+        if open_inc is not None:
+            tracker["open_incident_id"] = int(open_inc.get("id") or 0) or None
+            if tracker.get("bad_since") is None:
+                started = self._parse_iso(open_inc.get("started_at"))
+                if started is not None:
+                    tracker["bad_since"] = started
+        else:
+            tracker["open_incident_id"] = None
+
         if is_bad:
             tracker["good_since"] = None
             if tracker["bad_since"] is None:
                 tracker["bad_since"] = now
             bad_for = (now - tracker["bad_since"]).total_seconds()
             severity = "major_outage" if state == "major_outage" else "partial_outage"
-
-            open_inc = None
-            if tracker.get("open_incident_id"):
-                open_inc = await repo.get_open_incident(group_key)
-                if open_inc is None:
-                    tracker["open_incident_id"] = None
 
             if open_inc is None and bad_for >= OPEN_INCIDENT_SECONDS:
                 # 忽略极短闪断：若 bad_since 距今虽够，但中间曾恢复过由 good_since 重置
@@ -551,12 +597,6 @@ class ConnectionHealthService:
                 tracker["good_since"] = now
             good_for = (now - tracker["good_since"]).total_seconds()
 
-            open_inc = None
-            if tracker.get("open_incident_id"):
-                open_inc = await repo.get_open_incident(group_key)
-                if open_inc is None:
-                    tracker["open_incident_id"] = None
-
             if open_inc is not None and good_for >= RESOLVE_INCIDENT_SECONDS:
                 # 若事故总时长极短，仍关闭但 timeline 标注闪断恢复
                 timeline = list(open_inc.get("timeline") or [])
@@ -583,57 +623,170 @@ class ConnectionHealthService:
             # not_monitored：关闭进行中事故（用户关闭通道）
             tracker["bad_since"] = None
             tracker["good_since"] = None
-            if tracker.get("open_incident_id"):
-                open_inc = await repo.get_open_incident(group_key)
-                if open_inc is not None:
-                    timeline = list(open_inc.get("timeline") or [])
-                    timeline.append(
-                        {
-                            "at": self._iso(now),
-                            "status": "resolved",
-                            "message": f"{display_name} 已停用监控",
-                        }
-                    )
-                    await repo.update_incident(
-                        int(open_inc["id"]),
-                        {
-                            "status": "resolved",
-                            "ended_at": self._iso(now),
-                            "timeline": timeline,
-                        },
-                    )
-                tracker["open_incident_id"] = None
+            if open_inc is not None:
+                timeline = list(open_inc.get("timeline") or [])
+                timeline.append(
+                    {
+                        "at": self._iso(now),
+                        "status": "resolved",
+                        "message": f"{display_name} 已停用监控",
+                    }
+                )
+                await repo.update_incident(
+                    int(open_inc["id"]),
+                    {
+                        "status": "resolved",
+                        "ended_at": self._iso(now),
+                        "timeline": timeline,
+                    },
+                )
+            tracker["open_incident_id"] = None
 
         tracker["last_state"] = state
 
     # ──────────────────────────── 查询 API 载荷 ────────────────────────────
 
-    async def build_statuspage_payload(self, *, days: int = 90) -> dict[str, Any]:
-        """构建管理端 Statuspage 风格完整载荷。"""
+    def _build_overall_block(
+        self,
+        *,
+        monitored_states: list[str],
+        now: datetime,
+    ) -> dict[str, Any]:
+        running = bool(getattr(self.service, "running", False))
+        in_grace = self._startup_grace_active()
+        overall = self._overall_state(monitored_states, running=running)
+        if not running:
+            overall_label = "服务未运行"
+        elif in_grace and overall in {"degraded", "operational", "not_monitored"}:
+            # 建连宽限期内：即使多路仍在握手，也不用「核心中断」吓人
+            overall_label = (
+                "通道建连中" if overall == "degraded" else self._overall_label(overall)
+            )
+        else:
+            overall_label = self._overall_label(overall)
+        return {
+            "state": overall if running else "major_outage",
+            "label": overall_label,
+            "updated_at": self._iso(now),
+            "updated_at_display": self._format_display_datetime(now),
+            "running": running,
+        }
+
+    def _legend(self) -> list[dict[str, str]]:
+        return [
+            {"state": "operational", "label": "正常", "color": "green"},
+            {"state": "degraded", "label": "降级", "color": "yellow"},
+            {"state": "partial_outage", "label": "部分中断", "color": "orange"},
+            {"state": "major_outage", "label": "中断", "color": "red"},
+            {"state": "not_monitored", "label": "未启用", "color": "gray"},
+        ]
+
+    @staticmethod
+    def _uptime_percent(uptime_ratio: float | None) -> float | None:
+        if uptime_ratio is None:
+            return None
+        # 保留两位小数，与前端 toFixed(2) 对齐，避免假精度。
+        return round(float(uptime_ratio) * 10000) / 100.0
+
+    def build_live_status_payload(self) -> dict[str, Any]:
+        """仅构建实时态（不读历史日聚合/事故），供高频轮询。"""
+        now = self._now_utc()
+        live_components = self._build_live_components()
+        monitored_states: list[str] = []
+        components_out: list[dict[str, Any]] = []
+        for comp in live_components:
+            state = str(comp.get("state") or "not_monitored")
+            if state != "not_monitored":
+                monitored_states.append(state)
+            group_key = str(comp.get("group_key") or "")
+            components_out.append(
+                {
+                    "group_key": group_key,
+                    "name": comp.get("display_name")
+                    or COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                    "current_state": state,
+                    "current_label": comp.get("status_label")
+                    or STATE_LABELS_ZH.get(state, state),
+                    "enabled": bool(comp.get("enabled")),
+                    "connected": bool(comp.get("connected")),
+                    "latency_ms": comp.get("latency_ms"),
+                    "retry_count": int(comp.get("retry_count") or 0),
+                    "circuit_open": bool(comp.get("circuit_open")),
+                }
+            )
+        return {
+            "overall": self._build_overall_block(
+                monitored_states=monitored_states, now=now
+            ),
+            "legend": self._legend(),
+            "meta": {
+                "mode": "live",
+                "timezone": self._display_tz,
+                "sample_interval_seconds": self.sample_interval,
+            },
+            "components": components_out,
+        }
+
+    async def build_statuspage_payload(
+        self, *, days: int = 90, mode: str = "full"
+    ) -> dict[str, Any]:
+        """构建管理端 Statuspage 风格载荷。
+
+        mode:
+        - full: 实时态 + 90 天条带 + 事故（历史部分短 TTL 缓存）
+        - live: 仅实时态，不读库
+        """
+        mode_norm = str(mode or "full").strip().lower()
+        if mode_norm == "live":
+            return self.build_live_status_payload()
+
         days = max(1, min(int(days or 90), 180))
         now = self._now_utc()
         local_today = self._to_display(now).date()
         start_day = (local_today - timedelta(days=days - 1)).strftime("%Y-%m-%d")
+        cache_key = f"full:{days}:{start_day}"
 
         live_components = self._build_live_components()
         live_by_key = {c["group_key"]: c for c in live_components}
 
-        repo = self._ensure_repo()
         day_rows: list[dict[str, Any]] = []
         incidents: list[dict[str, Any]] = []
-        if repo is not None:
-            try:
-                day_rows = await repo.list_day_aggregates(
-                    days=days,
-                    group_keys=list(COMPONENT_ORDER),
-                    since_day=start_day,
-                )
-            except Exception as exc:
-                logger.warning(f"[灾害预警] 读取健康日聚合失败: {exc}")
-            try:
-                incidents = await repo.list_incidents(days=max(days, 14), limit=200)
-            except Exception as exc:
-                logger.warning(f"[灾害预警] 读取通道事故失败: {exc}")
+        use_history_cache = False
+        try:
+            mono = asyncio.get_running_loop().time()
+        except RuntimeError:
+            mono = 0.0
+        if (
+            self._history_cache is not None
+            and self._history_cache_key == cache_key
+            and mono
+            and (mono - self._history_cache_at) < self._history_cache_ttl_seconds
+        ):
+            use_history_cache = True
+            day_rows = list(self._history_cache.get("day_rows") or [])
+            incidents = list(self._history_cache.get("incidents") or [])
+
+        if not use_history_cache:
+            repo = self._ensure_repo()
+            if repo is not None:
+                try:
+                    day_rows = await repo.list_day_aggregates(
+                        days=days,
+                        group_keys=list(COMPONENT_ORDER),
+                        since_day=start_day,
+                    )
+                except Exception as exc:
+                    logger.warning(f"[灾害预警] 读取健康日聚合失败: {exc}")
+                try:
+                    incidents = await repo.list_incidents(days=max(days, 14), limit=200)
+                except Exception as exc:
+                    logger.warning(f"[灾害预警] 读取通道事故失败: {exc}")
+            self._history_cache = {
+                "day_rows": day_rows,
+                "incidents": incidents,
+            }
+            self._history_cache_key = cache_key
+            self._history_cache_at = mono
 
         # group -> day -> row
         day_map: dict[str, dict[str, dict[str, Any]]] = {}
@@ -690,8 +843,8 @@ class ConnectionHealthService:
                     day_str, row, live if offset == days - 1 else None
                 )
                 bars.append(bar)
-                if row and int(row.get("minutes_monitored") or 0) > 0:
-                    mon = float(row.get("minutes_monitored") or 0)
+                mon = float((row or {}).get("minutes_monitored") or 0)
+                if row is not None and mon > 0:
                     major = float(row.get("minutes_major") or 0)
                     partial = float(row.get("minutes_partial") or 0)
                     uptime_den += mon
@@ -720,27 +873,12 @@ class ConnectionHealthService:
                     "retry_count": int(live.get("retry_count") or 0),
                     "circuit_open": bool(live.get("circuit_open")),
                     "uptime_ratio": uptime_ratio,
-                    "uptime_percent": (
-                        round(uptime_ratio * 1000) / 10.0
-                        if uptime_ratio is not None
-                        else None
-                    ),
+                    "uptime_percent": self._uptime_percent(uptime_ratio),
                     "days": bars,
                 }
             )
 
-        running = bool(getattr(self.service, "running", False))
-        in_grace = self._startup_grace_active()
-        overall = self._overall_state(monitored_states, running=running)
-        if not running:
-            overall_label = "服务未运行"
-        elif in_grace and overall in {"degraded", "operational", "not_monitored"}:
-            # 建连宽限期内：即使多路仍在握手，也不用「核心中断」吓人
-            overall_label = (
-                "通道建连中" if overall == "degraded" else self._overall_label(overall)
-            )
-        else:
-            overall_label = self._overall_label(overall)
+        overall = self._build_overall_block(monitored_states=monitored_states, now=now)
 
         # Past incidents 按日分组
         incidents_by_day = self._group_incidents_by_day(
@@ -748,25 +886,15 @@ class ConnectionHealthService:
         )
 
         return {
-            "overall": {
-                "state": overall if running else "major_outage",
-                "label": overall_label,
-                "updated_at": self._iso(now),
-                "updated_at_display": self._format_display_datetime(now),
-                "running": running,
-            },
-            "legend": [
-                {"state": "operational", "label": "正常", "color": "green"},
-                {"state": "degraded", "label": "降级", "color": "yellow"},
-                {"state": "partial_outage", "label": "部分中断", "color": "orange"},
-                {"state": "major_outage", "label": "中断", "color": "red"},
-                {"state": "not_monitored", "label": "未启用", "color": "gray"},
-            ],
+            "overall": overall,
+            "legend": self._legend(),
             "meta": {
+                "mode": "full",
                 "days": days,
                 "timezone": self._display_tz,
                 "uptime_note": f"近 {days} 天可用性",
                 "sample_interval_seconds": self.sample_interval,
+                "history_cache_ttl_seconds": self._history_cache_ttl_seconds,
             },
             "components": components_out,
             "incidents": filtered_incidents[:100],
@@ -795,10 +923,11 @@ class ConnectionHealthService:
                 "uptime_ratio": None,
             }
 
-        monitored = int(row.get("minutes_monitored") or 0)
-        major = int(row.get("minutes_major") or 0)
-        partial = int(row.get("minutes_partial") or 0)
-        degraded = int(row.get("minutes_degraded") or 0)
+        # 分钟字段为 REAL，读取时用 float，避免截断亚分钟样本。
+        monitored = float(row.get("minutes_monitored") or 0)
+        major = float(row.get("minutes_major") or 0)
+        partial = float(row.get("minutes_partial") or 0)
+        degraded = float(row.get("minutes_degraded") or 0)
 
         if monitored <= 0:
             state = "not_monitored"

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -1,0 +1,939 @@
+"""
+连接健康采样、日聚合与自动事故服务。
+
+语义约定（管理端 Statuspage 风格）：
+- 行 = 物理连接组（fan_studio_all / fan_studio_cenc_ir / p2p_main ...）
+- degraded 不扣 uptime；partial_outage / major_outage 按 100% 计入中断
+- 未启用 (not_monitored) 不进 uptime 分母、不进总横幅
+- 闪断 < OPEN_INCIDENT_SECONDS 只记采样，不开 Past Incidents
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from astrbot.api import logger
+
+from ....utils.time_converter import TimeConverter
+from ...network.admin.payloads.connections_payload_builder import (
+    ConnectionsPayloadBuilder,
+)
+from ...storage.connection_health_repository import ConnectionHealthRepository
+from ..query.source_runtime_query_service import SourceRuntimeQueryService
+
+# 连接组展示顺序（与 ConnectionsGrid 列语义对齐）
+COMPONENT_ORDER: tuple[str, ...] = (
+    "fan_studio_all",
+    "fan_studio_cenc_ir",
+    "p2p_main",
+    "wolfx_all",
+    "global_quake",
+    "snet_msil",
+    "eqsc",
+)
+
+COMPONENT_DISPLAY_NAMES: dict[str, str] = {
+    "fan_studio_all": "FAN Studio",
+    "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
+    "p2p_main": "P2P地震情報",
+    "wolfx_all": "Wolfx",
+    "global_quake": "Global Quake",
+    "snet_msil": "NIED S-Net",
+    "eqsc": "EQSC API",
+}
+
+# ConnectionsPayloadBuilder / SourceRuntimeQuery 可能使用的展示名别名
+DISPLAY_NAME_ALIASES: dict[str, str] = {
+    "FAN Studio": "fan_studio_all",
+    "FAN Studio 烈度速报": "fan_studio_cenc_ir",
+    "FAN Studio（烈度速报）": "fan_studio_cenc_ir",
+    "Fan Studio（烈度速报）": "fan_studio_cenc_ir",
+    "P2P地震情報": "p2p_main",
+    "Wolfx": "wolfx_all",
+    "Global Quake": "global_quake",
+    "NIED S-Net": "snet_msil",
+    "EQSC API": "eqsc",
+}
+
+STATE_LABELS_ZH: dict[str, str] = {
+    "operational": "正常",
+    "degraded": "降级",
+    "partial_outage": "部分中断",
+    "major_outage": "中断",
+    "maintenance": "维护",
+    "not_monitored": "未启用",
+}
+
+STATE_RANK: dict[str, int] = {
+    "not_monitored": 0,
+    "operational": 1,
+    "degraded": 2,
+    "maintenance": 2,
+    "partial_outage": 3,
+    "major_outage": 4,
+}
+
+# 日格 worst 判定阈值（分钟）
+DAY_MAJOR_THRESHOLD_MIN = 5
+DAY_PARTIAL_THRESHOLD_MIN = 5
+DAY_DEGRADED_THRESHOLD_MIN = 15
+
+# 事故开单：连续 major/partial 达到该秒数才开单
+OPEN_INCIDENT_SECONDS = 180
+# 恢复稳定秒数后关单
+RESOLVE_INCIDENT_SECONDS = 120
+# 闪断不记事故
+FLAP_IGNORE_SECONDS = 60
+
+# 高延迟视为 degraded 的阈值（ms）
+HIGH_LATENCY_MS = 1500
+
+# 服务启动/重载后的建连宽限期：此期间「已启用但未连通」记为降级(连接中)，
+# 避免插件重载后几十秒内整页被误判为「核心通道中断」。
+STARTUP_GRACE_SECONDS = 180
+
+
+class ConnectionHealthService:
+    """连接健康监控服务。"""
+
+    def __init__(self, service, sample_interval_seconds: float = 60.0):
+        """
+        Args:
+            service: DisasterWarningService 主服务实例。
+            sample_interval_seconds: 周期采样间隔。
+        """
+        self.service = service
+        self.sample_interval = max(15.0, float(sample_interval_seconds))
+        self._task: asyncio.Task | None = None
+        self._running = False
+        self._repo: ConnectionHealthRepository | None = None
+        # group_key -> 运行态边沿追踪
+        self._trackers: dict[str, dict[str, Any]] = {}
+        self._last_purge_at: float = 0.0
+        self._display_tz = "UTC+8"
+
+    # ──────────────────────────── 生命周期 ────────────────────────────
+
+    def _ensure_repo(self) -> ConnectionHealthRepository | None:
+        stats = getattr(self.service, "statistics_manager", None)
+        if stats is None or not getattr(stats, "_db_initialized", False):
+            return None
+        db = getattr(stats, "db", None)
+        if db is None:
+            return None
+        if self._repo is None or self._repo.db is not db:
+            self._repo = ConnectionHealthRepository(db)
+        return self._repo
+
+    async def start(self) -> None:
+        """启动后台采样循环。"""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info("[灾害预警] 连接健康采样服务已启动")
+
+    async def stop(self) -> None:
+        """停止后台采样循环。"""
+        self._running = False
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+        logger.info("[灾害预警] 连接健康采样服务已停止")
+
+    async def _loop(self) -> None:
+        # 启动后多等一会，让 WS/HTTP 通道先完成首轮建连与鉴权
+        await asyncio.sleep(15.0)
+        while self._running:
+            try:
+                await self.sample_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(f"[灾害预警] 连接健康采样失败: {exc}")
+            try:
+                await asyncio.sleep(self.sample_interval)
+            except asyncio.CancelledError:
+                raise
+
+    def _startup_grace_active(self) -> bool:
+        """服务启动后宽限期内返回 True（重载建连中）。"""
+        start = getattr(self.service, "start_time", None)
+        if start is None:
+            return True
+        try:
+            if start.tzinfo is None:
+                start = start.replace(tzinfo=timezone.utc)
+            age = (self._now_utc() - start.astimezone(timezone.utc)).total_seconds()
+            return age < STARTUP_GRACE_SECONDS
+        except Exception:
+            return True
+
+    # ──────────────────────────── 时间工具 ────────────────────────────
+
+    def _now_utc(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _to_display(self, dt: datetime) -> datetime:
+        return TimeConverter.convert_timezone(dt, self._display_tz)
+
+    def _iso(self, dt: datetime) -> str:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+
+    def _format_display_datetime(self, dt: datetime) -> str:
+        """格式化为管理端展示时区墙钟时间（UTC+8）。"""
+        local = self._to_display(dt)
+        return local.strftime("%Y-%m-%d %H:%M:%S")
+
+    def _day_key(self, dt: datetime) -> str:
+        local = self._to_display(dt)
+        return local.strftime("%Y-%m-%d")
+
+    # ──────────────────────────── 快照采集 ────────────────────────────
+
+    def _latency_cache(self) -> dict[str, float | None]:
+        web = getattr(self.service, "web_admin_server", None)
+        if web is not None:
+            cache = getattr(web, "_latency_cache", None)
+            if isinstance(cache, dict):
+                return cache
+        return {}
+
+    def _build_live_components(self) -> list[dict[str, Any]]:
+        """从运行时连接状态构建各连接组当前健康快照。"""
+        config = getattr(self.service, "config", {}) or {}
+        latency_cache = self._latency_cache()
+        builder = ConnectionsPayloadBuilder(
+            disaster_service=self.service,
+            config=config,
+            latency_cache=latency_cache,
+        )
+        connections = builder.build()
+
+        # display_name -> info；同时按别名映射到 group_key，避免文案微调后匹配失败
+        by_display = connections if isinstance(connections, dict) else {}
+        by_group: dict[str, dict[str, Any]] = {}
+        for disp_name, info in by_display.items():
+            key = str(disp_name or "").strip()
+            mapped = DISPLAY_NAME_ALIASES.get(key)
+            if mapped and isinstance(info, dict):
+                by_group[mapped] = info
+
+        # 也读 raw WS status，补 retry / last_active
+        raw_ws: dict[str, dict[str, Any]] = {}
+        ws_manager = getattr(self.service, "ws_manager", None)
+        if ws_manager is not None:
+            try:
+                raw_ws = ws_manager.get_all_connections_status() or {}
+            except Exception:
+                raw_ws = {}
+
+        runtime_query = getattr(self.service, "source_runtime_query", None)
+        if runtime_query is None:
+            runtime_query = SourceRuntimeQueryService(config)
+
+        group_status = {}
+        try:
+            group_status = runtime_query.build_connection_group_status() or {}
+        except Exception:
+            group_status = {}
+
+        components: list[dict[str, Any]] = []
+        for group_key in COMPONENT_ORDER:
+            display_name = COMPONENT_DISPLAY_NAMES.get(group_key, group_key)
+            info = by_group.get(group_key) or by_display.get(display_name) or {}
+            raw = raw_ws.get(group_key) or {}
+
+            # 启用：优先 payload enabled；否则看 group 下任一子源
+            enabled = bool(info.get("enabled"))
+            if not enabled:
+                sub = group_status.get(group_key) or {}
+                if isinstance(sub, dict) and any(bool(v) for v in sub.values()):
+                    enabled = True
+
+            connected = bool(info.get("connected"))
+            if group_key in raw_ws and "connected" in raw:
+                # WS 组以 raw 为准更贴近物理连接
+                if group_key not in {"eqsc", "snet_msil"}:
+                    connected = bool(raw.get("connected"))
+
+            retry_count = int(info.get("retry_count") or raw.get("retry_count") or 0)
+            circuit_open = bool(info.get("circuit_open"))
+            latency = info.get("latency")
+            if latency is None and group_key in latency_cache:
+                latency = latency_cache.get(group_key)
+            try:
+                latency_ms = float(latency) if latency is not None else None
+            except (TypeError, ValueError):
+                latency_ms = None
+
+            status_text = str(info.get("status") or "").strip()
+            connection_type = str(
+                info.get("connection_type")
+                or raw.get("connection_type")
+                or ("http" if group_key in {"eqsc", "snet_msil"} else "websocket")
+            )
+
+            in_grace = self._startup_grace_active()
+            state = self._classify_state(
+                enabled=enabled,
+                connected=connected,
+                retry_count=retry_count,
+                circuit_open=circuit_open,
+                latency_ms=latency_ms,
+                status_text=status_text,
+                connection_type=connection_type,
+                access_token_valid=info.get("access_token_valid"),
+                startup_grace=in_grace,
+            )
+
+            # 插件整体未运行：已启用通道视为中断（避免停机期间“全绿”）
+            # 注意：running=True 但尚在宽限期建连时，不走这条。
+            if not bool(getattr(self.service, "running", False)) and enabled:
+                state = "major_outage"
+                connected = False
+
+            # 宽限期内未连通：展示「连接中」而非「中断」
+            if state == "degraded" and in_grace and enabled and not connected:
+                status_label = "连接中"
+            else:
+                status_label = STATE_LABELS_ZH.get(state, state)
+
+            components.append(
+                {
+                    "group_key": group_key,
+                    "display_name": display_name,
+                    "enabled": enabled,
+                    "connected": connected,
+                    "state": state,
+                    "status_label": status_label,
+                    "latency_ms": latency_ms,
+                    "retry_count": retry_count,
+                    "circuit_open": circuit_open,
+                    "connection_type": connection_type,
+                    "status_text": status_text,
+                    "startup_grace": in_grace,
+                }
+            )
+        return components
+
+    @staticmethod
+    def _classify_state(
+        *,
+        enabled: bool,
+        connected: bool,
+        retry_count: int,
+        circuit_open: bool,
+        latency_ms: float | None,
+        status_text: str,
+        connection_type: str,
+        access_token_valid: Any,
+        startup_grace: bool = False,
+    ) -> str:
+        if not enabled:
+            return "not_monitored"
+
+        text = (status_text or "").lower()
+        if circuit_open or "熔断" in (status_text or ""):
+            # 熔断是明确故障，宽限期也如实反映
+            return "partial_outage"
+        if connection_type == "http":
+            if access_token_valid is False and "鉴权" in (status_text or ""):
+                # 启动宽限期内 token 可能尚未预热完成 → 连接中
+                if startup_grace:
+                    return "degraded"
+                return "partial_outage"
+            if not connected:
+                # 建连/鉴权预热中：降级而非中断
+                if startup_grace:
+                    return "degraded"
+                return "major_outage"
+            if latency_ms is not None and latency_ms >= HIGH_LATENCY_MS:
+                return "degraded"
+            return "operational"
+
+        if not connected:
+            # WS 建连宽限期：尚未握手成功不记 major
+            if startup_grace:
+                return "degraded"
+            return "major_outage"
+        if retry_count > 0:
+            return "degraded"
+        if latency_ms is not None and latency_ms >= HIGH_LATENCY_MS:
+            return "degraded"
+        if "备用" in (status_text or "") or "fallback" in text:
+            return "degraded"
+        return "operational"
+
+    # ──────────────────────────── 采样主流程 ────────────────────────────
+
+    async def sample_once(self) -> list[dict[str, Any]]:
+        """执行一轮采样：写样本、累加日桶、推进事故状态机。"""
+        repo = self._ensure_repo()
+        if repo is None:
+            return []
+
+        now = self._now_utc()
+        ts = self._iso(now)
+        day = self._day_key(now)
+        # 每样本代表的监控分钟（按采样间隔折算，上限 5 分钟防长暂停）
+        minutes = max(0.25, min(self.sample_interval / 60.0, 5.0))
+
+        components = self._build_live_components()
+        samples: list[dict[str, Any]] = []
+
+        for comp in components:
+            group_key = comp["group_key"]
+            state = comp["state"]
+            enabled = bool(comp["enabled"])
+            connected = bool(comp["connected"])
+
+            sample = {
+                "group_key": group_key,
+                "ts": ts,
+                "state": state,
+                "enabled": enabled,
+                "connected": connected,
+                "latency_ms": comp.get("latency_ms"),
+                "retry_count": comp.get("retry_count") or 0,
+                "circuit_open": bool(comp.get("circuit_open")),
+                "detail": {
+                    "status_text": comp.get("status_text"),
+                    "connection_type": comp.get("connection_type"),
+                    "display_name": comp.get("display_name"),
+                },
+            }
+            samples.append(sample)
+
+            # 日聚合：未启用不计入 monitored
+            day_row = {
+                "group_key": group_key,
+                "day": day,
+                "minutes_monitored": minutes if enabled else 0,
+                "minutes_major": minutes if enabled and state == "major_outage" else 0,
+                "minutes_partial": (
+                    minutes if enabled and state == "partial_outage" else 0
+                ),
+                "minutes_degraded": minutes if enabled and state == "degraded" else 0,
+                "worst_state": state if enabled else "not_monitored",
+                "sample_count": 1,
+                "updated_at": ts,
+            }
+            try:
+                await repo.upsert_day_aggregate(day_row)
+            except Exception as exc:
+                logger.debug(f"[灾害预警] 日聚合写入失败 {group_key}: {exc}")
+
+            try:
+                await self._advance_incident(repo, comp, now)
+            except Exception as exc:
+                logger.debug(f"[灾害预警] 事故状态推进失败 {group_key}: {exc}")
+
+        try:
+            await repo.insert_samples_batch(samples)
+        except Exception as exc:
+            logger.warning(f"[灾害预警] 健康采样批量写入失败: {exc}")
+
+        # 每天最多清理一次旧数据
+        try:
+            mono = asyncio.get_running_loop().time()
+            if mono - self._last_purge_at > 86400:
+                await repo.purge_old_samples(keep_days=14)
+                await repo.purge_old_days(keep_days=180)
+                self._last_purge_at = mono
+        except Exception:
+            pass
+
+        return components
+
+    # ──────────────────────────── 事故状态机 ────────────────────────────
+
+    async def _advance_incident(
+        self,
+        repo: ConnectionHealthRepository,
+        comp: dict[str, Any],
+        now: datetime,
+    ) -> None:
+        group_key = comp["group_key"]
+        state = comp["state"]
+        enabled = bool(comp["enabled"])
+        display_name = comp.get("display_name") or COMPONENT_DISPLAY_NAMES.get(
+            group_key, group_key
+        )
+
+        tracker = self._trackers.setdefault(
+            group_key,
+            {
+                "bad_since": None,
+                "good_since": None,
+                "last_state": "not_monitored",
+                "open_incident_id": None,
+            },
+        )
+
+        is_bad = enabled and state in {"major_outage", "partial_outage"}
+        is_good = enabled and state in {"operational", "degraded"}
+
+        if is_bad:
+            tracker["good_since"] = None
+            if tracker["bad_since"] is None:
+                tracker["bad_since"] = now
+            bad_for = (now - tracker["bad_since"]).total_seconds()
+            severity = "major_outage" if state == "major_outage" else "partial_outage"
+
+            open_inc = None
+            if tracker.get("open_incident_id"):
+                open_inc = await repo.get_open_incident(group_key)
+                if open_inc is None:
+                    tracker["open_incident_id"] = None
+
+            if open_inc is None and bad_for >= OPEN_INCIDENT_SECONDS:
+                # 忽略极短闪断：若 bad_since 距今虽够，但中间曾恢复过由 good_since 重置
+                title = (
+                    f"{display_name} 中断"
+                    if severity == "major_outage"
+                    else f"{display_name} 部分中断"
+                )
+                timeline = [
+                    {
+                        "at": self._iso(tracker["bad_since"]),
+                        "status": "investigating",
+                        "message": f"检测到 {display_name} 进入{STATE_LABELS_ZH.get(state, state)}",
+                    }
+                ]
+                incident_id = await repo.create_incident(
+                    {
+                        "group_key": group_key,
+                        "severity": severity,
+                        "status": "investigating",
+                        "title": title,
+                        "started_at": self._iso(tracker["bad_since"]),
+                        "ended_at": None,
+                        "timeline": timeline,
+                    }
+                )
+                tracker["open_incident_id"] = incident_id
+            elif open_inc is not None:
+                # 可能升级 severity
+                prev_sev = str(open_inc.get("severity") or "")
+                if severity == "major_outage" and prev_sev != "major_outage":
+                    timeline = list(open_inc.get("timeline") or [])
+                    timeline.append(
+                        {
+                            "at": self._iso(now),
+                            "status": "identified",
+                            "message": f"{display_name} 升级为中断",
+                        }
+                    )
+                    await repo.update_incident(
+                        int(open_inc["id"]),
+                        {
+                            "severity": "major_outage",
+                            "status": "identified",
+                            "title": f"{display_name} 中断",
+                            "timeline": timeline,
+                        },
+                    )
+        elif is_good:
+            tracker["bad_since"] = None
+            if tracker["good_since"] is None:
+                tracker["good_since"] = now
+            good_for = (now - tracker["good_since"]).total_seconds()
+
+            open_inc = None
+            if tracker.get("open_incident_id"):
+                open_inc = await repo.get_open_incident(group_key)
+                if open_inc is None:
+                    tracker["open_incident_id"] = None
+
+            if open_inc is not None and good_for >= RESOLVE_INCIDENT_SECONDS:
+                # 若事故总时长极短，仍关闭但 timeline 标注闪断恢复
+                timeline = list(open_inc.get("timeline") or [])
+                timeline.append(
+                    {
+                        "at": self._iso(now),
+                        "status": "resolved",
+                        "message": f"{display_name} 已恢复正常",
+                    }
+                )
+                await repo.update_incident(
+                    int(open_inc["id"]),
+                    {
+                        "status": "resolved",
+                        "ended_at": self._iso(now),
+                        "timeline": timeline,
+                    },
+                )
+                tracker["open_incident_id"] = None
+            elif open_inc is None and tracker.get("bad_since") is None:
+                # 无事故：若曾短暂 bad 但未达开单阈值，自然丢弃
+                pass
+        else:
+            # not_monitored：关闭进行中事故（用户关闭通道）
+            tracker["bad_since"] = None
+            tracker["good_since"] = None
+            if tracker.get("open_incident_id"):
+                open_inc = await repo.get_open_incident(group_key)
+                if open_inc is not None:
+                    timeline = list(open_inc.get("timeline") or [])
+                    timeline.append(
+                        {
+                            "at": self._iso(now),
+                            "status": "resolved",
+                            "message": f"{display_name} 已停用监控",
+                        }
+                    )
+                    await repo.update_incident(
+                        int(open_inc["id"]),
+                        {
+                            "status": "resolved",
+                            "ended_at": self._iso(now),
+                            "timeline": timeline,
+                        },
+                    )
+                tracker["open_incident_id"] = None
+
+        tracker["last_state"] = state
+
+    # ──────────────────────────── 查询 API 载荷 ────────────────────────────
+
+    async def build_statuspage_payload(self, *, days: int = 90) -> dict[str, Any]:
+        """构建管理端 Statuspage 风格完整载荷。"""
+        days = max(1, min(int(days or 90), 180))
+        now = self._now_utc()
+        local_today = self._to_display(now).date()
+        start_day = (local_today - timedelta(days=days - 1)).strftime("%Y-%m-%d")
+
+        live_components = self._build_live_components()
+        live_by_key = {c["group_key"]: c for c in live_components}
+
+        repo = self._ensure_repo()
+        day_rows: list[dict[str, Any]] = []
+        incidents: list[dict[str, Any]] = []
+        if repo is not None:
+            try:
+                day_rows = await repo.list_day_aggregates(
+                    days=days,
+                    group_keys=list(COMPONENT_ORDER),
+                    since_day=start_day,
+                )
+            except Exception as exc:
+                logger.warning(f"[灾害预警] 读取健康日聚合失败: {exc}")
+            try:
+                incidents = await repo.list_incidents(days=max(days, 14), limit=200)
+            except Exception as exc:
+                logger.warning(f"[灾害预警] 读取通道事故失败: {exc}")
+
+        # group -> day -> row
+        day_map: dict[str, dict[str, dict[str, Any]]] = {}
+        for row in day_rows:
+            gk = str(row.get("group_key") or "")
+            d = str(row.get("day") or "")
+            if not gk or not d:
+                continue
+            day_map.setdefault(gk, {})[d] = row
+
+        # 过滤 incidents 到窗口内（按 display tz 日）
+        window_start_dt = datetime.combine(
+            local_today - timedelta(days=days - 1),
+            datetime.min.time(),
+            tzinfo=TimeConverter._get_timezone(self._display_tz),
+        )
+        filtered_incidents: list[dict[str, Any]] = []
+        for inc in incidents:
+            started = self._parse_iso(inc.get("started_at"))
+            if started is None:
+                continue
+            if started.astimezone(timezone.utc) < window_start_dt.astimezone(
+                timezone.utc
+            ) - timedelta(days=1):
+                # 略放宽，避免边界丢失
+                if (local_today - self._to_display(started).date()).days > days:
+                    continue
+            filtered_incidents.append(self._serialize_incident(inc))
+
+        components_out: list[dict[str, Any]] = []
+        monitored_states: list[str] = []
+
+        for group_key in COMPONENT_ORDER:
+            live = live_by_key.get(group_key) or {
+                "group_key": group_key,
+                "display_name": COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                "enabled": False,
+                "connected": False,
+                "state": "not_monitored",
+                "status_label": "未启用",
+                "latency_ms": None,
+                "retry_count": 0,
+                "circuit_open": False,
+            }
+            bars: list[dict[str, Any]] = []
+            uptime_num = 0.0
+            uptime_den = 0.0
+
+            for offset in range(days):
+                day_date = local_today - timedelta(days=days - 1 - offset)
+                day_str = day_date.strftime("%Y-%m-%d")
+                row = (day_map.get(group_key) or {}).get(day_str)
+                bar = self._day_row_to_bar(
+                    day_str, row, live if offset == days - 1 else None
+                )
+                bars.append(bar)
+                if row and int(row.get("minutes_monitored") or 0) > 0:
+                    mon = float(row.get("minutes_monitored") or 0)
+                    major = float(row.get("minutes_major") or 0)
+                    partial = float(row.get("minutes_partial") or 0)
+                    uptime_den += mon
+                    uptime_num += max(0.0, mon - min(mon, major + partial))
+
+            if uptime_den > 0:
+                uptime_ratio = uptime_num / uptime_den
+            else:
+                uptime_ratio = None
+
+            current_state = live.get("state") or "not_monitored"
+            if current_state != "not_monitored":
+                monitored_states.append(current_state)
+
+            components_out.append(
+                {
+                    "group_key": group_key,
+                    "name": live.get("display_name")
+                    or COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                    "current_state": current_state,
+                    "current_label": live.get("status_label")
+                    or STATE_LABELS_ZH.get(current_state, current_state),
+                    "enabled": bool(live.get("enabled")),
+                    "connected": bool(live.get("connected")),
+                    "latency_ms": live.get("latency_ms"),
+                    "retry_count": int(live.get("retry_count") or 0),
+                    "circuit_open": bool(live.get("circuit_open")),
+                    "uptime_ratio": uptime_ratio,
+                    "uptime_percent": (
+                        round(uptime_ratio * 1000) / 10.0
+                        if uptime_ratio is not None
+                        else None
+                    ),
+                    "days": bars,
+                }
+            )
+
+        running = bool(getattr(self.service, "running", False))
+        in_grace = self._startup_grace_active()
+        overall = self._overall_state(monitored_states, running=running)
+        if not running:
+            overall_label = "服务未运行"
+        elif in_grace and overall in {"degraded", "operational", "not_monitored"}:
+            # 建连宽限期内：即使多路仍在握手，也不用「核心中断」吓人
+            overall_label = (
+                "通道建连中" if overall == "degraded" else self._overall_label(overall)
+            )
+        else:
+            overall_label = self._overall_label(overall)
+
+        # Past incidents 按日分组
+        incidents_by_day = self._group_incidents_by_day(
+            filtered_incidents, local_today, history_days=14
+        )
+
+        return {
+            "overall": {
+                "state": overall if running else "major_outage",
+                "label": overall_label,
+                "updated_at": self._iso(now),
+                "updated_at_display": self._format_display_datetime(now),
+                "running": running,
+            },
+            "legend": [
+                {"state": "operational", "label": "正常", "color": "green"},
+                {"state": "degraded", "label": "降级", "color": "yellow"},
+                {"state": "partial_outage", "label": "部分中断", "color": "orange"},
+                {"state": "major_outage", "label": "中断", "color": "red"},
+                {"state": "not_monitored", "label": "未启用", "color": "gray"},
+            ],
+            "meta": {
+                "days": days,
+                "timezone": self._display_tz,
+                "uptime_note": f"近 {days} 天可用性",
+                "sample_interval_seconds": self.sample_interval,
+            },
+            "components": components_out,
+            "incidents": filtered_incidents[:100],
+            "incidents_by_day": incidents_by_day,
+        }
+
+    def _day_row_to_bar(
+        self,
+        day: str,
+        row: dict[str, Any] | None,
+        live_today: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if row is None:
+            # 今日尚无样本时，用 live 填一格弱提示
+            if live_today and bool(live_today.get("enabled")):
+                state = live_today.get("state") or "operational"
+            else:
+                state = "not_monitored"
+            return {
+                "day": day,
+                "state": state,
+                "minutes_monitored": 0,
+                "minutes_major": 0,
+                "minutes_partial": 0,
+                "minutes_degraded": 0,
+                "uptime_ratio": None,
+            }
+
+        monitored = int(row.get("minutes_monitored") or 0)
+        major = int(row.get("minutes_major") or 0)
+        partial = int(row.get("minutes_partial") or 0)
+        degraded = int(row.get("minutes_degraded") or 0)
+
+        if monitored <= 0:
+            state = "not_monitored"
+        elif major >= DAY_MAJOR_THRESHOLD_MIN:
+            state = "major_outage"
+        elif partial >= DAY_PARTIAL_THRESHOLD_MIN:
+            state = "partial_outage"
+        elif degraded >= DAY_DEGRADED_THRESHOLD_MIN:
+            state = "degraded"
+        else:
+            # 即使不足阈值，worst_state 若已是 outage 且有分钟，仍反映
+            worst = str(row.get("worst_state") or "operational")
+            if major > 0:
+                state = "major_outage"
+            elif partial > 0:
+                state = "partial_outage"
+            elif worst == "degraded" and degraded > 0:
+                state = "degraded"
+            else:
+                state = "operational"
+
+        uptime_ratio = row.get("uptime_ratio")
+        try:
+            uptime_ratio = float(uptime_ratio) if uptime_ratio is not None else None
+        except (TypeError, ValueError):
+            uptime_ratio = None
+
+        return {
+            "day": day,
+            "state": state,
+            "minutes_monitored": monitored,
+            "minutes_major": major,
+            "minutes_partial": partial,
+            "minutes_degraded": degraded,
+            "uptime_ratio": uptime_ratio,
+        }
+
+    @staticmethod
+    def _overall_state(monitored_states: list[str], *, running: bool) -> str:
+        if not running:
+            return "major_outage"
+        if not monitored_states:
+            return "not_monitored"
+        worst = "operational"
+        for state in monitored_states:
+            if STATE_RANK.get(state, 0) > STATE_RANK.get(worst, 0):
+                worst = state
+        return worst
+
+    @staticmethod
+    def _overall_label(state: str) -> str:
+        mapping = {
+            "operational": "全部通道正常",
+            "degraded": "部分通道降级",
+            "partial_outage": "部分通道异常",
+            "major_outage": "核心通道中断",
+            "not_monitored": "无已启用通道",
+            "maintenance": "维护中",
+        }
+        return mapping.get(state, STATE_LABELS_ZH.get(state, state))
+
+    def _serialize_incident(self, inc: dict[str, Any]) -> dict[str, Any]:
+        group_key = str(inc.get("group_key") or "")
+        started = self._parse_iso(inc.get("started_at"))
+        ended = self._parse_iso(inc.get("ended_at"))
+        duration_seconds = None
+        if started is not None:
+            end_ref = ended or self._now_utc()
+            duration_seconds = max(
+                0,
+                int(
+                    (
+                        end_ref.astimezone(timezone.utc)
+                        - started.astimezone(timezone.utc)
+                    ).total_seconds()
+                ),
+            )
+        return {
+            "id": inc.get("id"),
+            "group_key": group_key,
+            "component_name": COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+            "severity": inc.get("severity"),
+            "severity_label": STATE_LABELS_ZH.get(
+                str(inc.get("severity") or ""), str(inc.get("severity") or "")
+            ),
+            "status": inc.get("status"),
+            "title": inc.get("title"),
+            "started_at": inc.get("started_at"),
+            "ended_at": inc.get("ended_at"),
+            "duration_seconds": duration_seconds,
+            "timeline": inc.get("timeline") or [],
+        }
+
+    def _group_incidents_by_day(
+        self,
+        incidents: list[dict[str, Any]],
+        local_today,
+        *,
+        history_days: int = 14,
+    ) -> list[dict[str, Any]]:
+        """生成近 N 日的事故分组（无事故也占位）。"""
+        by_day: dict[str, list[dict[str, Any]]] = {}
+        for inc in incidents:
+            started = self._parse_iso(inc.get("started_at"))
+            if started is None:
+                continue
+            day = self._to_display(started).strftime("%Y-%m-%d")
+            by_day.setdefault(day, []).append(inc)
+
+        result: list[dict[str, Any]] = []
+        for offset in range(history_days):
+            day_date = local_today - timedelta(days=offset)
+            day_str = day_date.strftime("%Y-%m-%d")
+            items = by_day.get(day_str) or []
+            result.append(
+                {
+                    "day": day_str,
+                    "label": day_date.strftime("%Y年%m月%d日"),
+                    "incidents": items,
+                    "empty_text": ("今日无通道事故" if offset == 0 else "无通道事故"),
+                }
+            )
+        return result
+
+    @staticmethod
+    def _parse_iso(value: Any) -> datetime | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        try:
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            dt = datetime.fromisoformat(text)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except Exception:
+            return None

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -24,7 +24,7 @@ _CONNECTION_GROUP_ALIAS: dict[str, str] = {
 # 物理连接的友好展示名称，供管理后台和 API 使用
 _CONNECTION_DISPLAY_NAME: dict[str, str] = {
     "fan_studio_all": "FAN Studio",
-    "fan_studio_cenc_ir": "FAN Studio 烈度速报",
+    "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
     "p2p_main": "P2P地震情報",
     "wolfx_all": "Wolfx",
     "global_quake": "Global Quake",
@@ -182,12 +182,15 @@ class SourceRuntimeQueryService:
             conn_info["source_ids"] = list(group_source_map.get(group_key, []))
             connections[display_name] = conn_info
 
+        # 总连接数按 catalog 期望的物理通道口径统计（含已停用但应展示的通道），
+        # 避免数据源被临时关闭后从分母消失，出现 6/6 而非 6/7。
+        # expected_groups 已包含 WS（FAN/P2P/Wolfx/GQ）与 HTTP（EQSC/S-Net）。
         return {
             "running": running,
             "uptime": uptime,
             "active_websocket_connections": active_websocket_connections,
             "global_quake_connected": global_quake_connected,
-            "total_connections": len(actual_connections),
+            "total_connections": len(expected_groups),
             "connection_details": actual_connections,
             "connections": connections,
             "sub_source_status": self.build_sub_source_status(),

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -138,6 +138,58 @@ class SourceRuntimeQueryService:
             grouped[group_key][source_id] = self.is_source_enabled(source_id)
         return dict(grouped)
 
+    def resolve_active_connection_metrics(
+        self,
+        service: Any | None,
+        actual_connections: dict[str, dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """统一计算活跃连接数与 Global Quake 在线标记。
+
+        口径：
+        - WebSocket：ws_manager 连接表中 connected=True
+        - EQSC HTTP：AccessToken 有效计入活跃
+        - S-Net HTTP：配置启用且轮询任务 running 计入活跃
+        - total_connections 不在此计算，由 build_runtime_snapshot 按 expected_groups 统计
+        """
+        actual_connections = actual_connections or {}
+        active = sum(
+            1
+            for status in actual_connections.values()
+            if isinstance(status, dict) and bool(status.get("connected"))
+        )
+
+        # 延迟导入，避免 query 层与 app 层形成硬循环依赖。
+        from ...app.services.typhoon_enrichment_service import TyphoonEnrichmentService
+
+        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
+            service
+        )
+        active += int(eqsc_active or 0)
+
+        snet_poll = getattr(service, "snet_poll_service", None) if service else None
+        try:
+            snet_enabled = bool(self.is_source_enabled("snet_msil"))
+        except Exception:
+            snet_enabled = False
+        if (
+            snet_enabled
+            and snet_poll is not None
+            and getattr(snet_poll, "running", False)
+        ):
+            active += 1
+
+        connection_tasks = (
+            getattr(service, "connection_tasks", []) if service is not None else []
+        )
+        global_quake_connected = any(
+            "global_quake" in task.get_name() if hasattr(task, "get_name") else False
+            for task in connection_tasks
+        )
+        return {
+            "active_websocket_connections": int(active),
+            "global_quake_connected": bool(global_quake_connected),
+        }
+
     def build_runtime_snapshot(
         self,
         *,
@@ -174,6 +226,9 @@ class SourceRuntimeQueryService:
                     },
                 )
             )
+            # 稳定主键：健康采样 / 前端映射优先读 group_key，避免展示名微调后失配。
+            conn_info["group_key"] = group_key
+            conn_info["display_name"] = display_name
             # 计算该物理连接链路下是否有任何一个子数据源开关被开启
             conn_info["enabled"] = any(group_status_map.get(group_key, {}).values())
             # 写入当前链路的探测网络延时

--- a/core/storage/connection_health_repository.py
+++ b/core/storage/connection_health_repository.py
@@ -101,96 +101,126 @@ class ConnectionHealthRepository:
         return len(rows)
 
     async def upsert_day_aggregate(self, day_row: dict[str, Any]) -> None:
-        """按 (group_key, day) 累加日聚合分钟数。"""
+        """按 (group_key, day) 原子累加日聚合分钟数。
+
+        minutes_* 使用 REAL，支持亚分钟采样；冲突更新在 SQL 端完成，
+        避免 SELECT + 写回的竞态丢更新。
+        """
         connection = await self._connection()
         group_key = str(day_row.get("group_key") or "").strip()
         day = str(day_row.get("day") or "").strip()
         if not group_key or not day:
             return
 
-        add_monitored = int(day_row.get("minutes_monitored") or 0)
-        add_major = int(day_row.get("minutes_major") or 0)
-        add_partial = int(day_row.get("minutes_partial") or 0)
-        add_degraded = int(day_row.get("minutes_degraded") or 0)
+        def _as_float(value: Any) -> float:
+            try:
+                return float(value or 0)
+            except (TypeError, ValueError):
+                return 0.0
+
+        add_monitored = _as_float(day_row.get("minutes_monitored"))
+        add_major = _as_float(day_row.get("minutes_major"))
+        add_partial = _as_float(day_row.get("minutes_partial"))
+        add_degraded = _as_float(day_row.get("minutes_degraded"))
         add_samples = int(day_row.get("sample_count") or 1)
         candidate_worst = str(day_row.get("worst_state") or "not_monitored")
         updated_at = str(day_row.get("updated_at") or "").strip() or None
 
+        # worst_state 用 CASE 比较严重度，避免 Python 侧二次读写。
+        # degraded 不扣 uptime；partial/major 按 100% 计入中断。
         cursor = await connection.cursor()
-        await cursor.execute(
-            """
-            SELECT minutes_monitored, minutes_major, minutes_partial,
-                   minutes_degraded, worst_state, sample_count
-            FROM connection_health_days
-            WHERE group_key = ? AND day = ?
-            LIMIT 1
-            """,
-            (group_key, day),
-        )
-        existing = await cursor.fetchone()
-
-        rank = {
-            "not_monitored": 0,
-            "operational": 1,
-            "degraded": 2,
-            "partial_outage": 3,
-            "major_outage": 4,
-            "maintenance": 2,
-        }
-
-        if existing is None:
-            monitored = add_monitored
-            major = add_major
-            partial = add_partial
-            degraded = add_degraded
-            worst = candidate_worst
-            samples = add_samples
-        else:
-            monitored = int(existing["minutes_monitored"] or 0) + add_monitored
-            major = int(existing["minutes_major"] or 0) + add_major
-            partial = int(existing["minutes_partial"] or 0) + add_partial
-            degraded = int(existing["minutes_degraded"] or 0) + add_degraded
-            samples = int(existing["sample_count"] or 0) + add_samples
-            prev_worst = str(existing["worst_state"] or "not_monitored")
-            worst = (
-                candidate_worst
-                if rank.get(candidate_worst, 0) >= rank.get(prev_worst, 0)
-                else prev_worst
-            )
-
-        # degraded 不扣 uptime；partial/major 按 100% 计入中断
-        if monitored > 0:
-            outage = min(monitored, major + partial)
-            uptime_ratio = max(0.0, min(1.0, 1.0 - (outage / float(monitored))))
-        else:
-            uptime_ratio = None
-
         await cursor.execute(
             """
             INSERT INTO connection_health_days (
                 group_key, day, minutes_monitored, minutes_major, minutes_partial,
                 minutes_degraded, worst_state, uptime_ratio, sample_count, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?,
+                CASE
+                    WHEN ? > 0 THEN MAX(
+                        0.0,
+                        MIN(
+                            1.0,
+                            1.0 - (MIN(?, ? + ?) / ?)
+                        )
+                    )
+                    ELSE NULL
+                END,
+                ?,
+                COALESCE(?, CURRENT_TIMESTAMP)
+            )
             ON CONFLICT(group_key, day) DO UPDATE SET
-                minutes_monitored = excluded.minutes_monitored,
-                minutes_major = excluded.minutes_major,
-                minutes_partial = excluded.minutes_partial,
-                minutes_degraded = excluded.minutes_degraded,
-                worst_state = excluded.worst_state,
-                uptime_ratio = excluded.uptime_ratio,
-                sample_count = excluded.sample_count,
+                minutes_monitored = connection_health_days.minutes_monitored
+                    + excluded.minutes_monitored,
+                minutes_major = connection_health_days.minutes_major
+                    + excluded.minutes_major,
+                minutes_partial = connection_health_days.minutes_partial
+                    + excluded.minutes_partial,
+                minutes_degraded = connection_health_days.minutes_degraded
+                    + excluded.minutes_degraded,
+                sample_count = connection_health_days.sample_count
+                    + excluded.sample_count,
+                worst_state = CASE
+                    WHEN CASE excluded.worst_state
+                        WHEN 'major_outage' THEN 4
+                        WHEN 'partial_outage' THEN 3
+                        WHEN 'degraded' THEN 2
+                        WHEN 'maintenance' THEN 2
+                        WHEN 'operational' THEN 1
+                        ELSE 0
+                    END >= CASE connection_health_days.worst_state
+                        WHEN 'major_outage' THEN 4
+                        WHEN 'partial_outage' THEN 3
+                        WHEN 'degraded' THEN 2
+                        WHEN 'maintenance' THEN 2
+                        WHEN 'operational' THEN 1
+                        ELSE 0
+                    END THEN excluded.worst_state
+                    ELSE connection_health_days.worst_state
+                END,
+                uptime_ratio = CASE
+                    WHEN (
+                        connection_health_days.minutes_monitored
+                        + excluded.minutes_monitored
+                    ) > 0 THEN MAX(
+                        0.0,
+                        MIN(
+                            1.0,
+                            1.0 - (
+                                MIN(
+                                    connection_health_days.minutes_monitored
+                                    + excluded.minutes_monitored,
+                                    connection_health_days.minutes_major
+                                    + excluded.minutes_major
+                                    + connection_health_days.minutes_partial
+                                    + excluded.minutes_partial
+                                )
+                                / (
+                                    connection_health_days.minutes_monitored
+                                    + excluded.minutes_monitored
+                                )
+                            )
+                        )
+                    )
+                    ELSE NULL
+                END,
                 updated_at = excluded.updated_at
             """,
             (
                 group_key,
                 day,
-                monitored,
-                major,
-                partial,
-                degraded,
-                worst,
-                uptime_ratio,
-                samples,
+                add_monitored,
+                add_major,
+                add_partial,
+                add_degraded,
+                candidate_worst,
+                # INSERT 时 uptime_ratio 计算参数
+                add_monitored,
+                add_monitored,
+                add_major,
+                add_partial,
+                add_monitored if add_monitored > 0 else 1.0,
+                add_samples,
                 updated_at,
             ),
         )
@@ -261,36 +291,53 @@ class ConnectionHealthRepository:
         return int(cursor.lastrowid or 0)
 
     async def update_incident(self, incident_id: int, fields: dict[str, Any]) -> None:
-        """更新事故字段。"""
+        """更新事故字段（固定列白名单，避免动态拼 SQL）。"""
         if not fields:
             return
         connection = await self._connection()
-        allowed = {
-            "severity",
-            "status",
-            "title",
-            "started_at",
-            "ended_at",
-            "timeline_json",
-            "timeline",
-        }
-        sets: list[str] = []
-        params: list[Any] = []
+
+        # 仅允许这些列；timeline 统一落到 timeline_json。
+        column_values: dict[str, Any] = {}
         for key, value in fields.items():
-            if key not in allowed and key != "timeline":
-                continue
-            col = "timeline_json" if key in {"timeline", "timeline_json"} else key
-            if key == "timeline" and not isinstance(value, str):
-                value = json.dumps(value, ensure_ascii=False)
-            sets.append(f"{col} = ?")
-            params.append(value)
-        if not sets:
+            if key == "timeline":
+                column_values["timeline_json"] = (
+                    value
+                    if isinstance(value, str)
+                    else json.dumps(value, ensure_ascii=False)
+                )
+            elif key == "timeline_json":
+                column_values["timeline_json"] = (
+                    value
+                    if isinstance(value, str)
+                    else json.dumps(value, ensure_ascii=False)
+                )
+            elif key in {"severity", "status", "title", "started_at", "ended_at"}:
+                column_values[key] = value
+
+        if not column_values:
             return
-        sets.append("updated_at = CURRENT_TIMESTAMP")
+
+        # 固定列顺序，SQL 文本由白名单列名拼接（非用户输入）。
+        ordered_cols = [
+            col
+            for col in (
+                "severity",
+                "status",
+                "title",
+                "started_at",
+                "ended_at",
+                "timeline_json",
+            )
+            if col in column_values
+        ]
+        set_sql = ", ".join(f"{col} = ?" for col in ordered_cols)
+        set_sql = f"{set_sql}, updated_at = CURRENT_TIMESTAMP"
+        params = [column_values[col] for col in ordered_cols]
         params.append(int(incident_id))
+
         cursor = await connection.cursor()
         await cursor.execute(
-            f"UPDATE connection_incidents SET {', '.join(sets)} WHERE id = ?",
+            f"UPDATE connection_incidents SET {set_sql} WHERE id = ?",
             params,
         )
         await connection.commit()

--- a/core/storage/connection_health_repository.py
+++ b/core/storage/connection_health_repository.py
@@ -1,0 +1,405 @@
+"""
+连接健康仓储。
+
+负责 connection_health_samples / connection_health_days / connection_incidents
+三张表的读写，与通用 events 事件流解耦。DatabaseManager 仅保留建表职责。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from astrbot.api import logger
+
+
+class ConnectionHealthRepository:
+    """连接健康采样、日聚合与事故仓储。"""
+
+    def __init__(self, db):
+        """
+        Args:
+            db: DatabaseManager 实例（复用其连接与 initialize 生命周期）。
+        """
+        self.db = db
+
+    async def _connection(self):
+        return await self.db._ensure_connection()
+
+    @staticmethod
+    def _row_to_dict(row) -> dict[str, Any]:
+        if row is None:
+            return {}
+        try:
+            return dict(row)
+        except Exception:
+            return {}
+
+    async def insert_sample(self, sample: dict[str, Any]) -> int:
+        """写入一条健康采样，返回 rowid。"""
+        connection = await self._connection()
+        detail = sample.get("detail")
+        if detail is not None and not isinstance(detail, str):
+            detail = json.dumps(detail, ensure_ascii=False)
+        cursor = await connection.cursor()
+        await cursor.execute(
+            """
+            INSERT INTO connection_health_samples (
+                group_key, ts, state, enabled, connected,
+                latency_ms, retry_count, circuit_open, detail_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(sample.get("group_key") or "").strip(),
+                str(sample.get("ts") or "").strip(),
+                str(sample.get("state") or "not_monitored").strip(),
+                1 if sample.get("enabled") else 0,
+                1 if sample.get("connected") else 0,
+                sample.get("latency_ms"),
+                int(sample.get("retry_count") or 0),
+                1 if sample.get("circuit_open") else 0,
+                detail,
+            ),
+        )
+        await connection.commit()
+        return int(cursor.lastrowid or 0)
+
+    async def insert_samples_batch(self, samples: list[dict[str, Any]]) -> int:
+        """批量写入采样，返回写入条数。"""
+        if not samples:
+            return 0
+        connection = await self._connection()
+        rows = []
+        for sample in samples:
+            detail = sample.get("detail")
+            if detail is not None and not isinstance(detail, str):
+                detail = json.dumps(detail, ensure_ascii=False)
+            rows.append(
+                (
+                    str(sample.get("group_key") or "").strip(),
+                    str(sample.get("ts") or "").strip(),
+                    str(sample.get("state") or "not_monitored").strip(),
+                    1 if sample.get("enabled") else 0,
+                    1 if sample.get("connected") else 0,
+                    sample.get("latency_ms"),
+                    int(sample.get("retry_count") or 0),
+                    1 if sample.get("circuit_open") else 0,
+                    detail,
+                )
+            )
+        cursor = await connection.cursor()
+        await cursor.executemany(
+            """
+            INSERT INTO connection_health_samples (
+                group_key, ts, state, enabled, connected,
+                latency_ms, retry_count, circuit_open, detail_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        await connection.commit()
+        return len(rows)
+
+    async def upsert_day_aggregate(self, day_row: dict[str, Any]) -> None:
+        """按 (group_key, day) 累加日聚合分钟数。"""
+        connection = await self._connection()
+        group_key = str(day_row.get("group_key") or "").strip()
+        day = str(day_row.get("day") or "").strip()
+        if not group_key or not day:
+            return
+
+        add_monitored = int(day_row.get("minutes_monitored") or 0)
+        add_major = int(day_row.get("minutes_major") or 0)
+        add_partial = int(day_row.get("minutes_partial") or 0)
+        add_degraded = int(day_row.get("minutes_degraded") or 0)
+        add_samples = int(day_row.get("sample_count") or 1)
+        candidate_worst = str(day_row.get("worst_state") or "not_monitored")
+        updated_at = str(day_row.get("updated_at") or "").strip() or None
+
+        cursor = await connection.cursor()
+        await cursor.execute(
+            """
+            SELECT minutes_monitored, minutes_major, minutes_partial,
+                   minutes_degraded, worst_state, sample_count
+            FROM connection_health_days
+            WHERE group_key = ? AND day = ?
+            LIMIT 1
+            """,
+            (group_key, day),
+        )
+        existing = await cursor.fetchone()
+
+        rank = {
+            "not_monitored": 0,
+            "operational": 1,
+            "degraded": 2,
+            "partial_outage": 3,
+            "major_outage": 4,
+            "maintenance": 2,
+        }
+
+        if existing is None:
+            monitored = add_monitored
+            major = add_major
+            partial = add_partial
+            degraded = add_degraded
+            worst = candidate_worst
+            samples = add_samples
+        else:
+            monitored = int(existing["minutes_monitored"] or 0) + add_monitored
+            major = int(existing["minutes_major"] or 0) + add_major
+            partial = int(existing["minutes_partial"] or 0) + add_partial
+            degraded = int(existing["minutes_degraded"] or 0) + add_degraded
+            samples = int(existing["sample_count"] or 0) + add_samples
+            prev_worst = str(existing["worst_state"] or "not_monitored")
+            worst = (
+                candidate_worst
+                if rank.get(candidate_worst, 0) >= rank.get(prev_worst, 0)
+                else prev_worst
+            )
+
+        # degraded 不扣 uptime；partial/major 按 100% 计入中断
+        if monitored > 0:
+            outage = min(monitored, major + partial)
+            uptime_ratio = max(0.0, min(1.0, 1.0 - (outage / float(monitored))))
+        else:
+            uptime_ratio = None
+
+        await cursor.execute(
+            """
+            INSERT INTO connection_health_days (
+                group_key, day, minutes_monitored, minutes_major, minutes_partial,
+                minutes_degraded, worst_state, uptime_ratio, sample_count, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+            ON CONFLICT(group_key, day) DO UPDATE SET
+                minutes_monitored = excluded.minutes_monitored,
+                minutes_major = excluded.minutes_major,
+                minutes_partial = excluded.minutes_partial,
+                minutes_degraded = excluded.minutes_degraded,
+                worst_state = excluded.worst_state,
+                uptime_ratio = excluded.uptime_ratio,
+                sample_count = excluded.sample_count,
+                updated_at = excluded.updated_at
+            """,
+            (
+                group_key,
+                day,
+                monitored,
+                major,
+                partial,
+                degraded,
+                worst,
+                uptime_ratio,
+                samples,
+                updated_at,
+            ),
+        )
+        await connection.commit()
+
+    async def list_day_aggregates(
+        self,
+        *,
+        days: int = 90,
+        group_keys: list[str] | None = None,
+        since_day: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """查询日聚合列表。"""
+        connection = await self._connection()
+        cursor = await connection.cursor()
+        params: list[Any] = []
+        clauses: list[str] = []
+
+        if since_day:
+            clauses.append("day >= ?")
+            params.append(str(since_day))
+        if group_keys:
+            placeholders = ",".join("?" for _ in group_keys)
+            clauses.append(f"group_key IN ({placeholders})")
+            params.extend([str(k) for k in group_keys])
+
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        # 多取一些再在服务层按 90 天窗口裁剪
+        limit = max(int(days) * 12, 90)
+        await cursor.execute(
+            f"""
+            SELECT group_key, day, minutes_monitored, minutes_major, minutes_partial,
+                   minutes_degraded, worst_state, uptime_ratio, sample_count, updated_at
+            FROM connection_health_days
+            {where_sql}
+            ORDER BY day ASC
+            LIMIT ?
+            """,
+            (*params, limit),
+        )
+        rows = await cursor.fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
+    async def create_incident(self, incident: dict[str, Any]) -> int:
+        """创建事故，返回 id。"""
+        connection = await self._connection()
+        timeline = incident.get("timeline") or []
+        if not isinstance(timeline, str):
+            timeline = json.dumps(timeline, ensure_ascii=False)
+        cursor = await connection.cursor()
+        await cursor.execute(
+            """
+            INSERT INTO connection_incidents (
+                group_key, severity, status, title, started_at, ended_at, timeline_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(incident.get("group_key") or "").strip(),
+                str(incident.get("severity") or "major_outage").strip(),
+                str(incident.get("status") or "investigating").strip(),
+                str(incident.get("title") or "").strip(),
+                str(incident.get("started_at") or "").strip(),
+                incident.get("ended_at"),
+                timeline,
+            ),
+        )
+        await connection.commit()
+        return int(cursor.lastrowid or 0)
+
+    async def update_incident(self, incident_id: int, fields: dict[str, Any]) -> None:
+        """更新事故字段。"""
+        if not fields:
+            return
+        connection = await self._connection()
+        allowed = {
+            "severity",
+            "status",
+            "title",
+            "started_at",
+            "ended_at",
+            "timeline_json",
+            "timeline",
+        }
+        sets: list[str] = []
+        params: list[Any] = []
+        for key, value in fields.items():
+            if key not in allowed and key != "timeline":
+                continue
+            col = "timeline_json" if key in {"timeline", "timeline_json"} else key
+            if key == "timeline" and not isinstance(value, str):
+                value = json.dumps(value, ensure_ascii=False)
+            sets.append(f"{col} = ?")
+            params.append(value)
+        if not sets:
+            return
+        sets.append("updated_at = CURRENT_TIMESTAMP")
+        params.append(int(incident_id))
+        cursor = await connection.cursor()
+        await cursor.execute(
+            f"UPDATE connection_incidents SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+        await connection.commit()
+
+    async def get_open_incident(self, group_key: str) -> dict[str, Any] | None:
+        """获取某连接组当前未关闭的事故。"""
+        connection = await self._connection()
+        cursor = await connection.cursor()
+        await cursor.execute(
+            """
+            SELECT id, group_key, severity, status, title, started_at, ended_at,
+                   timeline_json, created_at, updated_at
+            FROM connection_incidents
+            WHERE group_key = ?
+              AND status != 'resolved'
+              AND ended_at IS NULL
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (str(group_key or "").strip(),),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        data = self._row_to_dict(row)
+        raw_timeline = data.get("timeline_json")
+        if raw_timeline:
+            try:
+                data["timeline"] = json.loads(raw_timeline)
+            except Exception:
+                data["timeline"] = []
+        else:
+            data["timeline"] = []
+        return data
+
+    async def list_incidents(
+        self,
+        *,
+        days: int = 14,
+        limit: int = 100,
+        group_key: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """列出近期事故（含已解决）。"""
+        connection = await self._connection()
+        cursor = await connection.cursor()
+        params: list[Any] = []
+        clauses: list[str] = []
+        if group_key:
+            clauses.append("group_key = ?")
+            params.append(str(group_key).strip())
+        # 用 started_at 字符串比较：ISO 格式可字典序比较
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        await cursor.execute(
+            f"""
+            SELECT id, group_key, severity, status, title, started_at, ended_at,
+                   timeline_json, created_at, updated_at
+            FROM connection_incidents
+            {where_sql}
+            ORDER BY started_at DESC
+            LIMIT ?
+            """,
+            (*params, max(1, int(limit))),
+        )
+        rows = await cursor.fetchall()
+        result: list[dict[str, Any]] = []
+        for row in rows:
+            data = self._row_to_dict(row)
+            raw_timeline = data.get("timeline_json")
+            if raw_timeline:
+                try:
+                    data["timeline"] = json.loads(raw_timeline)
+                except Exception:
+                    data["timeline"] = []
+            else:
+                data["timeline"] = []
+            result.append(data)
+        # days 过滤在服务层按时区做更稳妥；这里先返回 limit 条
+        _ = days
+        return result
+
+    async def purge_old_samples(self, *, keep_days: int = 14) -> int:
+        """清理过期原始采样，返回删除行数。"""
+        connection = await self._connection()
+        cursor = await connection.cursor()
+        # SQLite datetime 对 ISO 文本可用；用 julianday 近似
+        await cursor.execute(
+            """
+            DELETE FROM connection_health_samples
+            WHERE julianday('now') - julianday(substr(ts, 1, 19)) > ?
+            """,
+            (max(1, int(keep_days)),),
+        )
+        deleted = cursor.rowcount if cursor.rowcount is not None else 0
+        await connection.commit()
+        if deleted:
+            logger.debug(f"[灾害预警] 已清理连接健康采样 {deleted} 条")
+        return int(deleted or 0)
+
+    async def purge_old_days(self, *, keep_days: int = 180) -> int:
+        """清理过期日聚合。"""
+        connection = await self._connection()
+        cursor = await connection.cursor()
+        await cursor.execute(
+            """
+            DELETE FROM connection_health_days
+            WHERE julianday('now') - julianday(day) > ?
+            """,
+            (max(90, int(keep_days)),),
+        )
+        deleted = cursor.rowcount if cursor.rowcount is not None else 0
+        await connection.commit()
+        return int(deleted or 0)

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -276,16 +276,17 @@ class DatabaseManager:
             """
         )
 
-        # 连接健康日聚合：Asia/Shanghai 日界，驱动 status 条带
+        # 连接健康日聚合：Asia/Shanghai 日界，驱动 status 条带。
+        # minutes_* 使用 REAL，支持亚分钟采样间隔累加（如 15s=0.25min）。
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS connection_health_days (
                 group_key            TEXT NOT NULL,
                 day                  TEXT NOT NULL,
-                minutes_monitored    INTEGER NOT NULL DEFAULT 0,
-                minutes_major        INTEGER NOT NULL DEFAULT 0,
-                minutes_partial      INTEGER NOT NULL DEFAULT 0,
-                minutes_degraded     INTEGER NOT NULL DEFAULT 0,
+                minutes_monitored    REAL NOT NULL DEFAULT 0,
+                minutes_major        REAL NOT NULL DEFAULT 0,
+                minutes_partial      REAL NOT NULL DEFAULT 0,
+                minutes_degraded     REAL NOT NULL DEFAULT 0,
                 worst_state          TEXT NOT NULL DEFAULT 'not_monitored',
                 uptime_ratio         REAL,
                 sample_count         INTEGER NOT NULL DEFAULT 0,

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -257,6 +257,62 @@ class DatabaseManager:
             """
         )
 
+        # 连接健康采样：按连接组记录瞬时健康态，供 90 天条带与事故回溯
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS connection_health_samples (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                group_key       TEXT NOT NULL,
+                ts              TEXT NOT NULL,
+                state           TEXT NOT NULL,
+                enabled         INTEGER NOT NULL DEFAULT 0,
+                connected       INTEGER NOT NULL DEFAULT 0,
+                latency_ms      REAL,
+                retry_count     INTEGER NOT NULL DEFAULT 0,
+                circuit_open    INTEGER NOT NULL DEFAULT 0,
+                detail_json     TEXT,
+                created_at      TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        # 连接健康日聚合：Asia/Shanghai 日界，驱动 status 条带
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS connection_health_days (
+                group_key            TEXT NOT NULL,
+                day                  TEXT NOT NULL,
+                minutes_monitored    INTEGER NOT NULL DEFAULT 0,
+                minutes_major        INTEGER NOT NULL DEFAULT 0,
+                minutes_partial      INTEGER NOT NULL DEFAULT 0,
+                minutes_degraded     INTEGER NOT NULL DEFAULT 0,
+                worst_state          TEXT NOT NULL DEFAULT 'not_monitored',
+                uptime_ratio         REAL,
+                sample_count         INTEGER NOT NULL DEFAULT 0,
+                updated_at           TEXT DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (group_key, day)
+            )
+            """
+        )
+
+        # 连接事故：自动开单的通道中断/部分中断记录
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS connection_incidents (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                group_key       TEXT NOT NULL,
+                severity        TEXT NOT NULL,
+                status          TEXT NOT NULL,
+                title           TEXT NOT NULL,
+                started_at      TEXT NOT NULL,
+                ended_at        TEXT,
+                timeline_json   TEXT,
+                created_at      TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at      TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
         # 索引集中覆盖事件标识、来源、类型、时间等高频检索维度，加速分页与汇总查询
         for sql in (
             "CREATE INDEX IF NOT EXISTS idx_ev_real_id   ON events(real_event_id)",
@@ -270,6 +326,11 @@ class DatabaseManager:
             "CREATE INDEX IF NOT EXISTS idx_upd_event_id ON event_updates(event_id)",
             "CREATE INDEX IF NOT EXISTS idx_snet_peaks_shindo ON snet_station_peaks(max_shindo DESC)",
             "CREATE INDEX IF NOT EXISTS idx_snet_peaks_time ON snet_station_peaks(max_shindo_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ch_samples_group_ts ON connection_health_samples(group_key, ts DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ch_samples_ts ON connection_health_samples(ts DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ch_days_day ON connection_health_days(day DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ch_incidents_group ON connection_incidents(group_key, started_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ch_incidents_status ON connection_incidents(status, started_at DESC)",
         ):
             await cursor.execute(sql)
 


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

添加一个类似 Statuspage 的连接健康监控面板及其后台服务和存储，并修正连接计数和上游数据处理，以提供更准确的统计数据。

New Features:
- 引入连接健康 Statuspage API 和管理面板，可按连接组可视化 90 天运行时间条带，并列出历史故障事件。
- 添加后台连接健康采样服务，用于按连接组聚合每日运行时间，并自动开启和关闭连接故障事件。

Bug Fixes:
- 将运行时和快照中的连接计数与目录中定义的连接组对齐，而不是重新计算总数，从而修复连接统计数据不一致的问题。
- 丢弃纬度/经度为零的 Global Quake 地震消息，防止污染已存储的事件数据。

Enhancements:
- 在运行时和监控视图中统一并明确 FAN Studio 强度数据源的显示名称。
- 为连接健康采样数据、每日聚合和故障事件添加专用仓库、索引和生命周期钩子，以支持高效的状态查询以及干净的关停/启动行为。

Build:
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表以及相关索引，用于存储连接健康监控数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a connection health monitoring Statuspage-style panel with backing services and storage, and correct connection counting and upstream data handling for more accurate statistics.

New Features:
- Introduce a connection health Statuspage API and admin panel that visualize 90-day uptime strips per connection group and list historical incidents.
- Add a background connection health sampling service that aggregates daily uptime per connection group and automatically opens and closes connection incidents.

Bug Fixes:
- Align runtime and snapshot connection counting with catalog-expected connection groups instead of recomputing totals, fixing mismatched connection statistics.
- Discard Global Quake earthquake messages with zero latitude/longitude to prevent polluting stored event data.

Enhancements:
- Clarify and unify the display name for the FAN Studio intensity data source across runtime and monitoring views.
- Add dedicated repositories, indices, and lifecycle hooks for connection health samples, daily aggregates, and incidents to support efficient status queries and clean shutdown/startup behavior.

Build:
- Extend the database schema with connection_health_samples, connection_health_days, and connection_incidents tables plus related indices for connection health monitoring data.

</details>

新功能：
- 引入连接健康 Statuspage API 和前端面板，展示每条连接过去 90 天的在线率条状图及历史事件。
- 添加后台连接健康采样服务，按连接组进行每日聚合，并自动开启/关闭连接健康事件。

缺陷修复：
- 调整运行时状态和快照中的连接计数逻辑，使总连接数从预期的目录连接组中推导，而非重新计算，修复统计不匹配的问题。
- 过滤掉 Global Quake 中纬度/经度为零的地震消息，避免污染存储的事件数据。

增强：
- 统一并明确 FAN Studio 强度数据源在运行时和监控视图中的显示名称。
- 为连接健康采样数据、每日聚合和事件新增专用仓库及索引，以支持高效的状态查询。

构建：
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表及相关索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个类似 Statuspage 的连接健康监控面板及其后台服务和存储，并修正连接计数和上游数据处理，以提供更准确的统计数据。

New Features:
- 引入连接健康 Statuspage API 和管理面板，可按连接组可视化 90 天运行时间条带，并列出历史故障事件。
- 添加后台连接健康采样服务，用于按连接组聚合每日运行时间，并自动开启和关闭连接故障事件。

Bug Fixes:
- 将运行时和快照中的连接计数与目录中定义的连接组对齐，而不是重新计算总数，从而修复连接统计数据不一致的问题。
- 丢弃纬度/经度为零的 Global Quake 地震消息，防止污染已存储的事件数据。

Enhancements:
- 在运行时和监控视图中统一并明确 FAN Studio 强度数据源的显示名称。
- 为连接健康采样数据、每日聚合和故障事件添加专用仓库、索引和生命周期钩子，以支持高效的状态查询以及干净的关停/启动行为。

Build:
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表以及相关索引，用于存储连接健康监控数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a connection health monitoring Statuspage-style panel with backing services and storage, and correct connection counting and upstream data handling for more accurate statistics.

New Features:
- Introduce a connection health Statuspage API and admin panel that visualize 90-day uptime strips per connection group and list historical incidents.
- Add a background connection health sampling service that aggregates daily uptime per connection group and automatically opens and closes connection incidents.

Bug Fixes:
- Align runtime and snapshot connection counting with catalog-expected connection groups instead of recomputing totals, fixing mismatched connection statistics.
- Discard Global Quake earthquake messages with zero latitude/longitude to prevent polluting stored event data.

Enhancements:
- Clarify and unify the display name for the FAN Studio intensity data source across runtime and monitoring views.
- Add dedicated repositories, indices, and lifecycle hooks for connection health samples, daily aggregates, and incidents to support efficient status queries and clean shutdown/startup behavior.

Build:
- Extend the database schema with connection_health_samples, connection_health_days, and connection_incidents tables plus related indices for connection health monitoring data.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个类似 Statuspage 的连接健康监控面板及其后台服务和存储，并修正连接计数和上游数据处理，以提供更准确的统计数据。

New Features:
- 引入连接健康 Statuspage API 和管理面板，可按连接组可视化 90 天运行时间条带，并列出历史故障事件。
- 添加后台连接健康采样服务，用于按连接组聚合每日运行时间，并自动开启和关闭连接故障事件。

Bug Fixes:
- 将运行时和快照中的连接计数与目录中定义的连接组对齐，而不是重新计算总数，从而修复连接统计数据不一致的问题。
- 丢弃纬度/经度为零的 Global Quake 地震消息，防止污染已存储的事件数据。

Enhancements:
- 在运行时和监控视图中统一并明确 FAN Studio 强度数据源的显示名称。
- 为连接健康采样数据、每日聚合和故障事件添加专用仓库、索引和生命周期钩子，以支持高效的状态查询以及干净的关停/启动行为。

Build:
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表以及相关索引，用于存储连接健康监控数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a connection health monitoring Statuspage-style panel with backing services and storage, and correct connection counting and upstream data handling for more accurate statistics.

New Features:
- Introduce a connection health Statuspage API and admin panel that visualize 90-day uptime strips per connection group and list historical incidents.
- Add a background connection health sampling service that aggregates daily uptime per connection group and automatically opens and closes connection incidents.

Bug Fixes:
- Align runtime and snapshot connection counting with catalog-expected connection groups instead of recomputing totals, fixing mismatched connection statistics.
- Discard Global Quake earthquake messages with zero latitude/longitude to prevent polluting stored event data.

Enhancements:
- Clarify and unify the display name for the FAN Studio intensity data source across runtime and monitoring views.
- Add dedicated repositories, indices, and lifecycle hooks for connection health samples, daily aggregates, and incidents to support efficient status queries and clean shutdown/startup behavior.

Build:
- Extend the database schema with connection_health_samples, connection_health_days, and connection_incidents tables plus related indices for connection health monitoring data.

</details>

新功能：
- 引入连接健康 Statuspage API 和前端面板，展示每条连接过去 90 天的在线率条状图及历史事件。
- 添加后台连接健康采样服务，按连接组进行每日聚合，并自动开启/关闭连接健康事件。

缺陷修复：
- 调整运行时状态和快照中的连接计数逻辑，使总连接数从预期的目录连接组中推导，而非重新计算，修复统计不匹配的问题。
- 过滤掉 Global Quake 中纬度/经度为零的地震消息，避免污染存储的事件数据。

增强：
- 统一并明确 FAN Studio 强度数据源在运行时和监控视图中的显示名称。
- 为连接健康采样数据、每日聚合和事件新增专用仓库及索引，以支持高效的状态查询。

构建：
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表及相关索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个类似 Statuspage 的连接健康监控面板及其后台服务和存储，并修正连接计数和上游数据处理，以提供更准确的统计数据。

New Features:
- 引入连接健康 Statuspage API 和管理面板，可按连接组可视化 90 天运行时间条带，并列出历史故障事件。
- 添加后台连接健康采样服务，用于按连接组聚合每日运行时间，并自动开启和关闭连接故障事件。

Bug Fixes:
- 将运行时和快照中的连接计数与目录中定义的连接组对齐，而不是重新计算总数，从而修复连接统计数据不一致的问题。
- 丢弃纬度/经度为零的 Global Quake 地震消息，防止污染已存储的事件数据。

Enhancements:
- 在运行时和监控视图中统一并明确 FAN Studio 强度数据源的显示名称。
- 为连接健康采样数据、每日聚合和故障事件添加专用仓库、索引和生命周期钩子，以支持高效的状态查询以及干净的关停/启动行为。

Build:
- 扩展数据库模式，新增 `connection_health_samples`、`connection_health_days` 和 `connection_incidents` 表以及相关索引，用于存储连接健康监控数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a connection health monitoring Statuspage-style panel with backing services and storage, and correct connection counting and upstream data handling for more accurate statistics.

New Features:
- Introduce a connection health Statuspage API and admin panel that visualize 90-day uptime strips per connection group and list historical incidents.
- Add a background connection health sampling service that aggregates daily uptime per connection group and automatically opens and closes connection incidents.

Bug Fixes:
- Align runtime and snapshot connection counting with catalog-expected connection groups instead of recomputing totals, fixing mismatched connection statistics.
- Discard Global Quake earthquake messages with zero latitude/longitude to prevent polluting stored event data.

Enhancements:
- Clarify and unify the display name for the FAN Studio intensity data source across runtime and monitoring views.
- Add dedicated repositories, indices, and lifecycle hooks for connection health samples, daily aggregates, and incidents to support efficient status queries and clean shutdown/startup behavior.

Build:
- Extend the database schema with connection_health_samples, connection_health_days, and connection_incidents tables plus related indices for connection health monitoring data.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 状态页新增“通道健康”面板，展示整体状态、90 天可用性趋势、每日健康详情及历史事故。
  * 支持状态图例、悬浮提示、事故时间线、加载占位和移动端自适应。
  * 通道健康数据自动采样并定期刷新，异常时显示错误提示。

* **Bug 修复**
  * 优化连接总数与活跃连接数统计口径。
  * 过滤经纬度为零的无效地震事件，避免展示伪事件。

* **样式**
  * 更新部分通道名称显示格式，完善健康状态、事故严重程度及深浅色主题样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->