### PR TITLE
feat(startup): 以门闩状态机重构静默启动，过滤建连首轮噪音

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
   - `log_max_files`：轮转文件最大保留数量。
 - **过滤机制**: 可过滤心跳包、P2P 节点状态、重复事件、连接状态等日志噪音。
 - **Wolfx 列表日志上限 (`wolfx_list_log_max_items`)**: 记录 Wolfx 列表时的最大条目数。
-- **启动静默期 (`startup_silence_duration`)**: 插件启动后在此时间内自动忽略所有事件。
+- **是否静默启动插件 (`silent_startup`)**: 开启后，插件在建连与首轮数据同步完成前自动忽略事件推送、原始日志与统计，并播种去重指纹，用于过滤启动噪音。
 
 ```json
 "debug_config": {
@@ -921,7 +921,7 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
   "filter_duplicate_events": true,                   // 是否过滤重复事件日志
   "filter_connection_status": true,                  // 是否过滤连接状态日志
   "wolfx_list_log_max_items": 5,                     // Wolfx 列表日志最大记录条数
-  "startup_silence_duration": 0                      // 启动静默期（秒），0 表示禁用
+  "silent_startup": true                             // 是否静默启动（建连/首轮同步完成前不推送）
 }
 ```
 
@@ -2173,7 +2173,7 @@ graph TB
 >    - 最简单的配置方法：在目标群聊/私聊中发送 `/sid` 指令，直接复制返回的完整会话 ID 填入即可。
 > 3. **连接状态**：使用命令 `/灾害预警状态` 确认 WebSocket 连接是否正常 (🟢)。如果显示 🔴，请尝试使用 `/灾害预警重连` 指令重连数据源。也可以重载插件并检查网络或确认上游服务是否宕机。
 > 4. **过滤器拦截**：检查 **地震/气象过滤器** 或 **本地监控** 的阈值设置是否过高。
-> 5. **启动静默期**：确认当前不在插件启动后的 **静默期** 内。
+> 5. **静默启动**：确认 `debug_config.silent_startup` 未处于建连/首轮同步静默阶段（或已关闭该开关）。
 > 6. **数据源开关**：确保在 `data_sources` 中启用了具体的子数据源。
 
 **Q: 为什么收到了地震消息，但没有地图卡片/图片？**

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1412,16 +1412,11 @@
           "step": 1
         }
       },
-      "startup_silence_duration": {
-        "description": "启动后静默时间",
-        "type": "int",
-        "hint": "单位：秒。插件启动后在此时间内自动忽略所有事件，不进行推送、日志记录和统计。适用于频繁重启的开发环境或不稳定的生产环境。0表示禁用",
-        "default": 0,
-        "slider": {
-          "min": 0,
-          "max": 3600,
-          "step": 10
-        }
+      "silent_startup": {
+        "description": "是否静默启动插件",
+        "type": "bool",
+        "hint": "开启后，插件在建连与首轮数据同步完成前自动忽略事件推送、原始日志与统计，用于过滤启动噪音。关闭后事件立即进入正常推送链路。",
+        "default": true
       }
     }
   },

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -11,7 +11,6 @@
 import asyncio
 import os
 import traceback
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
 from astrbot.api import logger
@@ -59,6 +58,7 @@ from .runtime.disaster_service_notice import DisasterServiceNoticeService
 from .runtime.disaster_service_reconnect import DisasterServiceReconnectService
 from .runtime.disaster_service_runtime import DisasterServiceRuntimeService
 from .runtime.disaster_service_status import DisasterServiceStatusService
+from .runtime.startup_silence_coordinator import StartupSilenceCoordinator
 from .services.typhoon_enrichment_service import TyphoonEnrichmentService
 from .services.typhoon_history_rebuild_service import TyphoonHistoryRebuildService
 
@@ -186,6 +186,10 @@ class DisasterWarningService:
         from ..services.health.connection_health_service import ConnectionHealthService
 
         self.connection_health_service = ConnectionHealthService(self)
+        # 启动静默协调器：建连/首包完成前抑制推送并播种去重指纹
+        self.startup_silence = StartupSilenceCoordinator()
+        self.startup_silence.bind_service(self)
+        self.message_logger.set_silence_checker(self.is_silencing)
         self._setup_runtime_services()
 
     def _setup_runtime_services(self) -> None:
@@ -373,6 +377,13 @@ class DisasterWarningService:
         registry.register_all(self.ws_manager)
         self.ws_manager.set_offline_notify_callback(self._handle_offline_notification)
 
+        def _on_ws_established(name: str) -> None:
+            coordinator = getattr(self, "startup_silence", None)
+            if coordinator is not None:
+                coordinator.note_connection_established(name)
+
+        self.ws_manager.on_connection_established = _on_ws_established
+
     def _configure_connections(self):
         """根据数据源配置生成连接计划。"""
         self.connections = ConnectionPlanBuilder.build(self.config)
@@ -409,19 +420,40 @@ class DisasterWarningService:
         """启动清理任务。"""
         await self.runtime_service.start_cleanup_task()
 
+    def is_silencing(self) -> bool:
+        """是否处于启动静默（建连/首轮同步阶段）。"""
+        coordinator = getattr(self, "startup_silence", None)
+        if coordinator is None:
+            return False
+        return bool(coordinator.is_silencing())
+
     def is_in_silence_period(self) -> bool:
-        """检查是否处于启动后的静默期。"""
-        if not hasattr(self, "start_time"):
-            return False
+        """兼容旧接口：等价于 is_silencing()。"""
+        return self.is_silencing()
 
-        debug_config = self.config.get("debug_config", {})
-        silence_duration = debug_config.get("startup_silence_duration", 0)
-
-        if silence_duration <= 0:
-            return False
-
-        elapsed = (datetime.now(timezone.utc) - self.start_time).total_seconds()
-        return elapsed < silence_duration
+    def _seed_event_for_silence(self, event: EventEnvelope) -> None:
+        """静默期播种去重指纹（推送管理器 + 统计侧，若存在）。"""
+        managers = []
+        message_manager = getattr(self, "message_manager", None)
+        if message_manager is not None:
+            managers.append(getattr(message_manager, "deduplicator", None))
+        stats_manager = getattr(self, "statistics_manager", None)
+        if stats_manager is not None:
+            managers.append(getattr(stats_manager, "deduplicator", None))
+        seen: set[int] = set()
+        for deduplicator in managers:
+            if deduplicator is None:
+                continue
+            ident = id(deduplicator)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            seed = getattr(deduplicator, "seed_event", None)
+            if callable(seed):
+                try:
+                    seed(event)
+                except Exception as exc:
+                    logger.debug(f"[灾害预警] 静默播种去重指纹失败（已忽略）: {exc}")
 
     async def _handle_disaster_event(self, event: EventEnvelope):
         """处理灾害事件。主链路仅接收解析器产出的统一事件。"""
@@ -431,14 +463,13 @@ class DisasterWarningService:
         except Exception as e:
             logger.debug(f"[灾害预警] 更新 EEW 查询状态失败（已忽略）: {e}")
 
-        # 启动静默期过滤逻辑，防止插件重载后反复造成消息推送
-        if self.is_in_silence_period():
-            debug_config = self.config.get("debug_config", {})
-            silence_duration = debug_config.get("startup_silence_duration", 0)
-            elapsed = (datetime.now(timezone.utc) - self.start_time).total_seconds()
-            logger.debug(
-                f"[灾害预警] 处于启动静默期 (剩余 {silence_duration - elapsed:.1f}s)，忽略事件: {event.id}"
-            )
+        # 启动静默：不推送/不统计，但播种指纹并推进门闩
+        if self.is_silencing():
+            self._seed_event_for_silence(event)
+            coordinator = getattr(self, "startup_silence", None)
+            if coordinator is not None:
+                coordinator.note_event_absorbed(event)
+            logger.debug(f"[灾害预警] 静默启动中，已吸收并播种事件: {event.id}")
             return
 
         try:

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -135,15 +135,17 @@ class DisasterServiceLifecycleService:
                 debug_config = raw_debug
         enabled = coordinator.resolve_enabled(debug_config)
 
+        # connections 由 ConnectionPlanBuilder 产出，本身即为 WebSocket 连接计划，
+        # 无需再按 handler 名称白名单过滤，以免遗漏新增数据源。
         expected_ws: list[str] = []
         connections = getattr(self.service, "connections", None) or {}
         if isinstance(connections, dict):
             for name, plan in connections.items():
                 if not isinstance(plan, dict):
                     continue
-                handler = str(plan.get("handler") or "").strip()
-                if handler in {"fan_studio", "p2p", "wolfx", "global_quake"}:
-                    expected_ws.append(str(name))
+                conn_name = str(name or "").strip()
+                if conn_name:
+                    expected_ws.append(conn_name)
 
         expected_polls: list[str] = []
         snet_poll = getattr(self.service, "snet_poll_service", None)

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -37,6 +37,9 @@ class DisasterServiceLifecycleService:
                 )  # 服务启动UTC时间戳
                 logger.info("[灾害预警] 正在启动灾害预警服务...")
 
+                # 武装启动静默：在真正建连/轮询前注册门闩
+                self._arm_startup_silence()
+
                 # 启动顺序刻意遵循“先恢复状态，再开放接入”的原则：
                 # 1. 初始化统计存储；
                 # 2. 恢复地震列表缓存；
@@ -110,11 +113,60 @@ class DisasterServiceLifecycleService:
                 # 启动失败时必须回滚运行标记，避免外部误判服务已可用。
                 logger.error(f"[灾害预警] 启动服务失败: {e}")
                 self.service.running = False
+                coordinator = getattr(self.service, "startup_silence", None)
+                if coordinator is not None:
+                    coordinator.disarm()
                 if self.service._telemetry and self.service._telemetry.enabled:
                     await self.service._telemetry.track_error(
                         e, module="core.disaster_service.start"
                     )
                 raise
+
+    def _arm_startup_silence(self) -> None:
+        """根据配置与连接计划武装启动静默协调器。"""
+        coordinator = getattr(self.service, "startup_silence", None)
+        if coordinator is None:
+            return
+        debug_config: dict = {}
+        config = getattr(self.service, "config", {}) or {}
+        if isinstance(config, dict):
+            raw_debug = config.get("debug_config", {})
+            if isinstance(raw_debug, dict):
+                debug_config = raw_debug
+        enabled = coordinator.resolve_enabled(debug_config)
+
+        expected_ws: list[str] = []
+        connections = getattr(self.service, "connections", None) or {}
+        if isinstance(connections, dict):
+            for name, plan in connections.items():
+                if not isinstance(plan, dict):
+                    continue
+                handler = str(plan.get("handler") or "").strip()
+                if handler in {"fan_studio", "p2p", "wolfx", "global_quake"}:
+                    expected_ws.append(str(name))
+
+        expected_polls: list[str] = []
+        snet_poll = getattr(self.service, "snet_poll_service", None)
+        if snet_poll is not None and getattr(snet_poll, "is_enabled", lambda: False)():
+            expected_polls.append("snet_msil")
+        eqsc_tsunami = getattr(self.service, "eqsc_tsunami_poll_service", None)
+        if (
+            eqsc_tsunami is not None
+            and getattr(eqsc_tsunami, "is_enabled", lambda: False)()
+        ):
+            expected_polls.append("eqsc_tsunami")
+        eqsc_typhoon = getattr(self.service, "eqsc_typhoon_poll_service", None)
+        if (
+            eqsc_typhoon is not None
+            and getattr(eqsc_typhoon, "is_enabled", lambda: False)()
+        ):
+            expected_polls.append("eqsc_typhoon")
+
+        coordinator.arm(
+            enabled=enabled,
+            expected_ws=expected_ws,
+            expected_polls=expected_polls,
+        )
 
     async def cancel_and_wait(self, tasks: list[asyncio.Task]) -> None:
         """
@@ -143,6 +195,9 @@ class DisasterServiceLifecycleService:
                 was_running = self.service.running
                 # 提前将运行标记切为 False，阻止新任务继续按“服务运行中”路径工作。
                 self.service.running = False
+                coordinator = getattr(self.service, "startup_silence", None)
+                if coordinator is not None:
+                    coordinator.disarm()
 
                 # 立刻停连接健康采样：避免 running=False 后仍采样，把通道误记为
                 # major_outage 并触发错误事故开单。

--- a/core/app/runtime/disaster_service_status.py
+++ b/core/app/runtime/disaster_service_status.py
@@ -57,10 +57,19 @@ class DisasterServiceStatusService:
         )
         # total_connections 已由 runtime snapshot 按 catalog 期望通道统计
         # （含 EQSC / S-Net / 已停用通道），此处不再二次累加。
+        silence_status = None
+        coordinator = getattr(self.service, "startup_silence", None)
+        if coordinator is not None and hasattr(coordinator, "get_status"):
+            try:
+                silence_status = coordinator.get_status()
+            except Exception:
+                silence_status = None
+
         return {
             **snapshot,
             # 统计摘要直接挂在顶层，便于管理端一次请求同时拿到运行状态与统计概览。
             "statistics_summary": self.service.statistics_manager.get_summary(),
+            "startup_silence": silence_status,
         }
 
     def get_sub_source_status(self) -> dict[str, dict[str, bool]]:

--- a/core/app/runtime/startup_silence_coordinator.py
+++ b/core/app/runtime/startup_silence_coordinator.py
@@ -60,6 +60,9 @@ class StartupSilenceCoordinator:
     - ARMING：start() 后进入，等待注册门闩
     - PRIMING：建连/首轮轮询中，吸收事件并播种
     - READY：门闩满足 + settle，或硬超时
+
+    时长判定统一使用单调时钟（event loop time），避免系统墙钟回拨
+    导致硬超时失效；started_at / ready_at 仅用于展示。
     """
 
     # 时序参数（秒）
@@ -67,18 +70,21 @@ class StartupSilenceCoordinator:
     settle_seconds: float = 2.0
     hard_timeout_seconds: float = 60.0
     first_payload_timeout_seconds: float = 5.0
+    # 轮询门闩：武装后若长时间无成功首轮，按超时视为可跳过，避免拖到硬超时
+    first_poll_timeout_seconds: float = 15.0
 
     state: SilenceState = SilenceState.DISABLED
     enabled: bool = False
     started_at: datetime | None = None
     ready_at: datetime | None = None
+    # 单调时钟起点，专用于超时/最小静默等时长计算
+    started_mono: float | None = None
     ready_reason: str = ""
     absorbed_events: int = 0
     last_bootstrap_at: float | None = None
 
     gates: dict[str, GateState] = field(default_factory=dict)
     _watchdog_task: asyncio.Task | None = field(default=None, repr=False)
-    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
     _service: Any = field(default=None, repr=False)
 
     def bind_service(self, service: Any) -> None:
@@ -99,9 +105,9 @@ class StartupSilenceCoordinator:
             return False
         if self.state in {SilenceState.DISABLED, SilenceState.READY}:
             return False
-        # 硬超时兜底：即使 watchdog 未跑，查询时也强制退出
-        if self.started_at is not None:
-            age = (self._now() - self.started_at).total_seconds()
+        # 硬超时兜底：即使 watchdog 未跑，查询时也强制退出（单调钟）
+        if self.started_mono is not None:
+            age = self._try_mono() - self.started_mono
             if age >= self.hard_timeout_seconds:
                 self._force_ready("hard_timeout_on_query")
                 return False
@@ -135,6 +141,7 @@ class StartupSilenceCoordinator:
         """服务 start() 时武装静默期并注册门闩。"""
         self.enabled = bool(enabled)
         self.started_at = self._now()
+        self.started_mono = self._try_mono()
         self.ready_at = None
         self.ready_reason = ""
         self.absorbed_events = 0
@@ -189,6 +196,7 @@ class StartupSilenceCoordinator:
         self.enabled = False
         self.gates.clear()
         self.ready_reason = "disarmed"
+        self.started_mono = None
 
     def note_connection_established(self, connection_name: str) -> None:
         """WebSocket 建连成功。"""
@@ -256,7 +264,7 @@ class StartupSilenceCoordinator:
             gate = GateState(gate_id=gate_id, kind="poll")
             self.gates[gate_id] = gate
         if not success:
-            # 失败不直接 primed；watchdog/超时会兜底。连续失败由超时处理。
+            # 失败不直接 primed；watchdog 的 first_poll_timeout / 硬超时会兜底。
             return
         self._mark_primed(gate, bootstrap_kind="poll_first_fetch")
 
@@ -322,8 +330,8 @@ class StartupSilenceCoordinator:
             g.gate_id for g in self.gates.values() if g.required and not g.satisfied
         ]
         age = None
-        if self.started_at is not None:
-            age = (self._now() - self.started_at).total_seconds()
+        if self.started_mono is not None:
+            age = self._try_mono() - self.started_mono
         return {
             "enabled": self.enabled,
             "state": self.state.value,
@@ -350,6 +358,8 @@ class StartupSilenceCoordinator:
             "min_silence_seconds": self.min_silence_seconds,
             "settle_seconds": self.settle_seconds,
             "hard_timeout_seconds": self.hard_timeout_seconds,
+            "first_payload_timeout_seconds": self.first_payload_timeout_seconds,
+            "first_poll_timeout_seconds": self.first_poll_timeout_seconds,
         }
 
     # ── 内部 ──────────────────────────────────────────────
@@ -358,7 +368,7 @@ class StartupSilenceCoordinator:
         try:
             return self._mono()
         except RuntimeError:
-            # 无运行中的事件循环时退回 wall clock 相对值
+            # 无运行中的事件循环时退回 wall clock 相对值（仅兜底）
             return self._now().timestamp()
 
     def _ensure_ws_gate(self, connection_name: str) -> GateState | None:
@@ -392,11 +402,9 @@ class StartupSilenceCoordinator:
         return all(g.satisfied for g in self.gates.values() if g.required)
 
     def _min_silence_elapsed(self) -> bool:
-        if self.started_at is None:
+        if self.started_mono is None:
             return True
-        return (
-            self._now() - self.started_at
-        ).total_seconds() >= self.min_silence_seconds
+        return (self._try_mono() - self.started_mono) >= self.min_silence_seconds
 
     def _settle_elapsed(self) -> bool:
         if self.last_bootstrap_at is None:
@@ -495,9 +503,22 @@ class StartupSilenceCoordinator:
                             self._mark_primed(
                                 gate, bootstrap_kind="first_payload_timeout"
                             )
-                    # 硬超时
-                    if self.started_at is not None:
-                        age = (self._now() - self.started_at).total_seconds()
+                        # 轮询门闩：武装后长时间无成功首轮 → 超时放行，避免拖满硬超时
+                        if (
+                            gate.kind == "poll"
+                            and gate.required
+                            and not gate.skipped
+                            and not gate.primed
+                            and self.started_mono is not None
+                            and (now - self.started_mono)
+                            >= self.first_poll_timeout_seconds
+                        ):
+                            self._mark_primed(
+                                gate, bootstrap_kind="poll_first_fetch_timeout"
+                            )
+                    # 硬超时（单调钟）
+                    if self.started_mono is not None:
+                        age = now - self.started_mono
                         if age >= self.hard_timeout_seconds:
                             self._force_ready("hard_timeout")
                             break

--- a/core/app/runtime/startup_silence_coordinator.py
+++ b/core/app/runtime/startup_silence_coordinator.py
@@ -1,0 +1,526 @@
+"""
+启动静默协调器。
+
+用状态机替代固定秒数静默：在建连/首包/首轮轮询完成前吸收 bootstrap 噪音，
+同时播种去重指纹，避免静默结束后整批误报。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from astrbot.api import logger
+
+
+class SilenceState(str, Enum):
+    """启动静默状态。"""
+
+    DISABLED = "disabled"
+    ARMING = "arming"
+    PRIMING = "priming"
+    READY = "ready"
+
+
+@dataclass
+class GateState:
+    """单个就绪门闩状态。"""
+
+    gate_id: str
+    kind: str  # websocket | poll
+    required: bool = True
+    connected: bool = False
+    primed: bool = False
+    skipped: bool = False
+    skip_reason: str = ""
+    connected_at: float | None = None
+    primed_at: float | None = None
+    last_bootstrap_kind: str = ""
+
+    @property
+    def satisfied(self) -> bool:
+        if not self.required or self.skipped:
+            return True
+        if self.kind == "websocket":
+            # 已连接且收到首包/bootstrap，或已显式跳过
+            return self.connected and self.primed
+        # poll：完成至少一次成功抓取即视为 primed
+        return self.primed
+
+
+@dataclass
+class StartupSilenceCoordinator:
+    """启动静默状态机。
+
+    状态流转：
+    - DISABLED：配置关闭
+    - ARMING：start() 后进入，等待注册门闩
+    - PRIMING：建连/首轮轮询中，吸收事件并播种
+    - READY：门闩满足 + settle，或硬超时
+    """
+
+    # 时序参数（秒）
+    min_silence_seconds: float = 0.5
+    settle_seconds: float = 2.0
+    hard_timeout_seconds: float = 60.0
+    first_payload_timeout_seconds: float = 5.0
+
+    state: SilenceState = SilenceState.DISABLED
+    enabled: bool = False
+    started_at: datetime | None = None
+    ready_at: datetime | None = None
+    ready_reason: str = ""
+    absorbed_events: int = 0
+    last_bootstrap_at: float | None = None
+
+    gates: dict[str, GateState] = field(default_factory=dict)
+    _watchdog_task: asyncio.Task | None = field(default=None, repr=False)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+    _service: Any = field(default=None, repr=False)
+
+    def bind_service(self, service: Any) -> None:
+        """绑定主服务，便于读取 running 标志。"""
+        self._service = service
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _mono() -> float:
+        return asyncio.get_running_loop().time()
+
+    def is_silencing(self) -> bool:
+        """是否仍应抑制推送/统计/原始日志。"""
+        if not self.enabled:
+            return False
+        if self.state in {SilenceState.DISABLED, SilenceState.READY}:
+            return False
+        # 硬超时兜底：即使 watchdog 未跑，查询时也强制退出
+        if self.started_at is not None:
+            age = (self._now() - self.started_at).total_seconds()
+            if age >= self.hard_timeout_seconds:
+                self._force_ready("hard_timeout_on_query")
+                return False
+        return self.state in {SilenceState.ARMING, SilenceState.PRIMING}
+
+    # 兼容旧名
+    def is_in_silence_period(self) -> bool:
+        return self.is_silencing()
+
+    def resolve_enabled(self, debug_config: dict[str, Any] | None) -> bool:
+        """从 debug_config 解析是否启用静默启动。
+
+        优先 silent_startup；若缺失则兼容旧 startup_silence_duration：
+        - duration > 0 → True
+        - duration == 0 → False
+        - 都缺失 → 默认 True
+        """
+        cfg = debug_config if isinstance(debug_config, dict) else {}
+        if "silent_startup" in cfg:
+            return bool(cfg.get("silent_startup"))
+        legacy = cfg.get("startup_silence_duration")
+        if isinstance(legacy, bool):
+            return legacy
+        if isinstance(legacy, (int, float)):
+            return float(legacy) > 0
+        return True
+
+    def arm(
+        self, *, enabled: bool, expected_ws: list[str], expected_polls: list[str]
+    ) -> None:
+        """服务 start() 时武装静默期并注册门闩。"""
+        self.enabled = bool(enabled)
+        self.started_at = self._now()
+        self.ready_at = None
+        self.ready_reason = ""
+        self.absorbed_events = 0
+        self.last_bootstrap_at = None
+        self.gates.clear()
+        self._cancel_watchdog()
+
+        if not self.enabled:
+            self.state = SilenceState.DISABLED
+            logger.debug("[灾害预警] 静默启动已关闭，事件将立即进入推送链路")
+            return
+
+        for name in expected_ws:
+            gate_id = str(name or "").strip()
+            if not gate_id:
+                continue
+            self.gates[gate_id] = GateState(gate_id=gate_id, kind="websocket")
+
+        for name in expected_polls:
+            gate_id = str(name or "").strip()
+            if not gate_id:
+                continue
+            self.gates[gate_id] = GateState(gate_id=gate_id, kind="poll")
+
+        self.state = SilenceState.ARMING
+        if not self.gates:
+            # 无任何上游门闩：最短静默后直接就绪
+            self.state = SilenceState.PRIMING
+            self.last_bootstrap_at = self._try_mono()
+            logger.debug("[灾害预警] 静默启动已开启（无待同步数据源）")
+        else:
+            ws_n = sum(1 for g in self.gates.values() if g.kind == "websocket")
+            poll_n = sum(1 for g in self.gates.values() if g.kind == "poll")
+            parts: list[str] = []
+            if ws_n:
+                parts.append(f"{ws_n} 路连接")
+            if poll_n:
+                parts.append(f"{poll_n} 路轮询")
+            scope = "、".join(parts) if parts else f"{len(self.gates)} 路数据源"
+            logger.info(
+                f"[灾害预警] 静默启动已开启，等待 {scope}完成首轮同步"
+                f"（超时时间 {self.hard_timeout_seconds:.0f} 秒）"
+            )
+
+        self._start_watchdog()
+        self._evaluate_ready(reason_hint="arm")
+
+    def disarm(self) -> None:
+        """服务 stop() 时解除静默并清理。"""
+        self._cancel_watchdog()
+        self.state = SilenceState.DISABLED
+        self.enabled = False
+        self.gates.clear()
+        self.ready_reason = "disarmed"
+
+    def note_connection_established(self, connection_name: str) -> None:
+        """WebSocket 建连成功。"""
+        if not self.is_silencing():
+            return
+        gate = self._ensure_ws_gate(connection_name)
+        if gate is None:
+            return
+        if gate.skipped:
+            return
+        now = self._try_mono()
+        gate.connected = True
+        gate.connected_at = now
+        if self.state == SilenceState.ARMING:
+            self.state = SilenceState.PRIMING
+        logger.debug(f"[灾害预警] 静默门闩已建连: {gate.gate_id}")
+        self._evaluate_ready(reason_hint=f"ws_connected:{gate.gate_id}")
+
+    def note_connection_skipped(self, connection_name: str, reason: str = "") -> None:
+        """某连接无法完成（缺鉴权/熔断等），不阻塞全局就绪。"""
+        if not self.enabled or self.state == SilenceState.READY:
+            return
+        gate = self._ensure_ws_gate(connection_name)
+        if gate is None:
+            return
+        gate.skipped = True
+        gate.skip_reason = reason or "skipped"
+        gate.primed = True
+        gate.connected = True
+        logger.debug(
+            f"[灾害预警] 静默门闩已跳过: {gate.gate_id}"
+            + (f" ({gate.skip_reason})" if gate.skip_reason else "")
+        )
+        self._evaluate_ready(reason_hint=f"ws_skipped:{gate.gate_id}")
+
+    def note_bootstrap_payload(
+        self,
+        *,
+        connection_name: str | None = None,
+        gate_id: str | None = None,
+        kind: str = "bootstrap",
+    ) -> None:
+        """标记某连接/门闩收到 bootstrap 或首包。"""
+        if not self.is_silencing():
+            return
+        target = str(gate_id or connection_name or "").strip()
+        if not target:
+            return
+        gate = self.gates.get(target)
+        if gate is None and connection_name:
+            gate = self._ensure_ws_gate(connection_name)
+        if gate is None:
+            return
+        self._mark_primed(gate, bootstrap_kind=kind)
+
+    def note_poll_fetch_completed(self, poll_id: str, *, success: bool = True) -> None:
+        """HTTP 轮询完成首轮（成功或确认可跳过）。"""
+        if not self.enabled or self.state == SilenceState.READY:
+            return
+        gate_id = str(poll_id or "").strip()
+        if not gate_id:
+            return
+        gate = self.gates.get(gate_id)
+        if gate is None:
+            gate = GateState(gate_id=gate_id, kind="poll")
+            self.gates[gate_id] = gate
+        if not success:
+            # 失败不直接 primed；watchdog/超时会兜底。连续失败由超时处理。
+            return
+        self._mark_primed(gate, bootstrap_kind="poll_first_fetch")
+
+    def note_poll_skipped(self, poll_id: str, reason: str = "") -> None:
+        """轮询源未启用或无法运行。"""
+        if not self.enabled or self.state == SilenceState.READY:
+            return
+        gate_id = str(poll_id or "").strip()
+        if not gate_id:
+            return
+        gate = self.gates.get(gate_id)
+        if gate is None:
+            gate = GateState(gate_id=gate_id, kind="poll")
+            self.gates[gate_id] = gate
+        gate.skipped = True
+        gate.skip_reason = reason or "disabled"
+        gate.primed = True
+        self._evaluate_ready(reason_hint=f"poll_skipped:{gate_id}")
+
+    def note_event_absorbed(
+        self,
+        event: Any = None,
+        *,
+        connection_name: str | None = None,
+        bootstrap_kind: str = "",
+    ) -> None:
+        """静默期吸收一条事件（已播种后调用）。"""
+        if not self.is_silencing():
+            return
+        self.absorbed_events += 1
+        self.last_bootstrap_at = self._try_mono()
+        if self.state == SilenceState.ARMING:
+            self.state = SilenceState.PRIMING
+
+        meta = {}
+        if event is not None and isinstance(getattr(event, "metadata", None), dict):
+            meta = event.metadata
+        conn = (
+            connection_name
+            or str(
+                (meta.get("connection_info") or {}).get("connection_name") or ""
+            ).strip()
+            or str(meta.get("connection_name") or "").strip()
+        )
+        kind = (
+            bootstrap_kind
+            or str(meta.get("bootstrap_kind") or "").strip()
+            or ("bootstrap" if meta.get("bootstrap") else "event")
+        )
+        if conn and conn in self.gates:
+            self._mark_primed(self.gates[conn], bootstrap_kind=kind)
+        elif conn:
+            gate = self._ensure_ws_gate(conn)
+            if gate is not None:
+                gate.connected = True
+                self._mark_primed(gate, bootstrap_kind=kind)
+
+        self._evaluate_ready(reason_hint="event_absorbed")
+
+    def get_status(self) -> dict[str, Any]:
+        """供管理端/日志使用的状态快照。"""
+        pending = [
+            g.gate_id for g in self.gates.values() if g.required and not g.satisfied
+        ]
+        age = None
+        if self.started_at is not None:
+            age = (self._now() - self.started_at).total_seconds()
+        return {
+            "enabled": self.enabled,
+            "state": self.state.value,
+            "silencing": self.is_silencing(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "ready_at": self.ready_at.isoformat() if self.ready_at else None,
+            "ready_reason": self.ready_reason,
+            "absorbed_events": self.absorbed_events,
+            "elapsed_seconds": age,
+            "pending_gates": pending,
+            "gates": {
+                gid: {
+                    "kind": g.kind,
+                    "required": g.required,
+                    "connected": g.connected,
+                    "primed": g.primed,
+                    "skipped": g.skipped,
+                    "skip_reason": g.skip_reason,
+                    "satisfied": g.satisfied,
+                    "last_bootstrap_kind": g.last_bootstrap_kind,
+                }
+                for gid, g in self.gates.items()
+            },
+            "min_silence_seconds": self.min_silence_seconds,
+            "settle_seconds": self.settle_seconds,
+            "hard_timeout_seconds": self.hard_timeout_seconds,
+        }
+
+    # ── 内部 ──────────────────────────────────────────────
+
+    def _try_mono(self) -> float:
+        try:
+            return self._mono()
+        except RuntimeError:
+            # 无运行中的事件循环时退回 wall clock 相对值
+            return self._now().timestamp()
+
+    def _ensure_ws_gate(self, connection_name: str) -> GateState | None:
+        gate_id = str(connection_name or "").strip()
+        if not gate_id:
+            return None
+        gate = self.gates.get(gate_id)
+        if gate is None:
+            # 计划外连接（例如运行中热启用）也纳入观察，但不强制 required
+            gate = GateState(gate_id=gate_id, kind="websocket", required=False)
+            self.gates[gate_id] = gate
+        return gate
+
+    def _mark_primed(self, gate: GateState, *, bootstrap_kind: str = "") -> None:
+        now = self._try_mono()
+        if not gate.connected and gate.kind == "websocket":
+            gate.connected = True
+            gate.connected_at = now
+        gate.primed = True
+        gate.primed_at = now
+        if bootstrap_kind:
+            gate.last_bootstrap_kind = bootstrap_kind
+        self.last_bootstrap_at = now
+        if self.state == SilenceState.ARMING:
+            self.state = SilenceState.PRIMING
+        self._evaluate_ready(reason_hint=f"primed:{gate.gate_id}")
+
+    def _all_gates_satisfied(self) -> bool:
+        if not self.gates:
+            return True
+        return all(g.satisfied for g in self.gates.values() if g.required)
+
+    def _min_silence_elapsed(self) -> bool:
+        if self.started_at is None:
+            return True
+        return (
+            self._now() - self.started_at
+        ).total_seconds() >= self.min_silence_seconds
+
+    def _settle_elapsed(self) -> bool:
+        if self.last_bootstrap_at is None:
+            # 尚无任何 bootstrap：若门闩已全满足（例如全 skip），仍要求 min silence
+            return self._all_gates_satisfied()
+        return (self._try_mono() - self.last_bootstrap_at) >= self.settle_seconds
+
+    @staticmethod
+    def _format_ready_reason(reason: str) -> str:
+        """把内部 reason 转成用户可读说明（日志用）。"""
+        text = str(reason or "").strip()
+        if not text:
+            return "数据源已就绪"
+        if text.startswith("gates_ok"):
+            return "数据源已就绪"
+        if text.startswith("hard_timeout"):
+            return "等待超时"
+        if text == "disarmed":
+            return "服务已停止"
+        return text
+
+    def _evaluate_ready(self, *, reason_hint: str = "") -> None:
+        if not self.enabled or self.state == SilenceState.READY:
+            return
+        if not self._min_silence_elapsed():
+            return
+        if not self._all_gates_satisfied():
+            return
+        if not self._settle_elapsed():
+            return
+        # 内部仍保留 hint，便于状态快照排查；日志侧会翻译成可读文案
+        reason = "gates_ok"
+        if reason_hint:
+            reason = f"gates_ok:{reason_hint}"
+        self._force_ready(reason)
+
+    def _force_ready(self, reason: str) -> None:
+        if self.state == SilenceState.READY and self.enabled:
+            return
+        if not self.enabled and self.state == SilenceState.DISABLED:
+            return
+        pending = [
+            g.gate_id for g in self.gates.values() if g.required and not g.satisfied
+        ]
+        self.state = SilenceState.READY
+        self.ready_at = self._now()
+        self.ready_reason = reason
+        self._cancel_watchdog()
+        why = self._format_ready_reason(reason)
+        absorbed = self.absorbed_events
+        if pending:
+            pending_text = "、".join(pending)
+            logger.warning(
+                f"[灾害预警] 静默启动结束（{why}），"
+                f"仍有未就绪：{pending_text}；"
+                f"已忽略启动快照 {absorbed} 条，开始正常推送"
+            )
+        elif absorbed > 0:
+            logger.info(
+                f"[灾害预警] 静默启动结束（{why}），"
+                f"已忽略启动快照 {absorbed} 条，开始正常推送"
+            )
+        else:
+            logger.info(f"[灾害预警] 静默启动结束（{why}），开始正常推送")
+
+    def _start_watchdog(self) -> None:
+        self._cancel_watchdog()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        async def _watch() -> None:
+            try:
+                while self.enabled and self.state not in {
+                    SilenceState.READY,
+                    SilenceState.DISABLED,
+                }:
+                    if self._service is not None and not getattr(
+                        self._service, "running", True
+                    ):
+                        break
+                    now = self._try_mono()
+                    # 建连后长时间无首包 → 视为空闲就绪
+                    for gate in list(self.gates.values()):
+                        if (
+                            gate.kind == "websocket"
+                            and gate.required
+                            and not gate.skipped
+                            and gate.connected
+                            and not gate.primed
+                            and gate.connected_at is not None
+                            and (now - gate.connected_at)
+                            >= self.first_payload_timeout_seconds
+                        ):
+                            self._mark_primed(
+                                gate, bootstrap_kind="first_payload_timeout"
+                            )
+                    # 硬超时
+                    if self.started_at is not None:
+                        age = (self._now() - self.started_at).total_seconds()
+                        if age >= self.hard_timeout_seconds:
+                            self._force_ready("hard_timeout")
+                            break
+                    self._evaluate_ready(reason_hint="watchdog")
+                    await asyncio.sleep(0.5)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug(f"[灾害预警] 静默启动 watchdog 异常: {exc}")
+
+        self._watchdog_task = loop.create_task(
+            _watch(), name="dw_startup_silence_watchdog"
+        )
+        if self._service is not None and hasattr(
+            self._service, "register_background_task"
+        ):
+            self._service.register_background_task(self._watchdog_task)
+
+    def _cancel_watchdog(self) -> None:
+        task = self._watchdog_task
+        self._watchdog_task = None
+        if task is not None and not task.done():
+            task.cancel()
+
+
+__all__ = ["SilenceState", "GateState", "StartupSilenceCoordinator"]

--- a/core/message/logging/stores/raw_message_logging_service.py
+++ b/core/message/logging/stores/raw_message_logging_service.py
@@ -83,10 +83,21 @@ class RawMessageLoggingService:
 
     def _in_startup_silence(self) -> bool:
         """判断是否仍处于启动静默期。"""
-        if self.logger.startup_silence_duration <= 0:
+        checker = getattr(self.logger, "is_in_startup_silence", None)
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:
+                return False
+        # 兼容旧字段：仅当仍配置了正数秒数时按墙钟判断
+        duration = float(getattr(self.logger, "startup_silence_duration", 0) or 0)
+        if duration <= 0:
             return False
-        elapsed = (datetime.now(timezone.utc) - self.logger.start_time).total_seconds()
-        return elapsed < self.logger.startup_silence_duration
+        start = getattr(self.logger, "start_time", None)
+        if start is None:
+            return False
+        elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+        return elapsed < duration
 
     def _try_parse_structured_payload(self, payload_data: Any) -> dict[str, Any] | None:
         """尽量把原始载荷解析为结构化字典。"""

--- a/core/message/message_logger.py
+++ b/core/message/message_logger.py
@@ -69,7 +69,10 @@ class MessageLogger:
             "filter_connection_status", True
         )
         self.wolfx_list_log_max_items = debug_config.get("wolfx_list_log_max_items", 5)
-        self.startup_silence_duration = debug_config.get("startup_silence_duration", 0)
+        # 静默启动由主服务 StartupSilenceCoordinator 统一判定；
+        # 实际日志静默走 silence_checker 回调。
+        self.startup_silence_duration = 0
+        self._silence_checker = None
 
         self.start_time = datetime.now(timezone.utc)
         # 这些内存缓存分别服务于事件级去重与最近日志内容比对。
@@ -138,6 +141,20 @@ class MessageLogger:
             logger.debug(f"[灾害预警] - P2P节点状态过滤: {self.filter_p2p_areas}")
             logger.debug(f"[灾害预警] - 重复事件过滤: {self.filter_duplicate_events}")
             logger.debug(f"[灾害预警] - 连接状态过滤: {self.filter_connection_status}")
+
+    def set_silence_checker(self, checker) -> None:
+        """注入启动静默判定回调（通常绑定主服务 is_silencing）。"""
+        self._silence_checker = checker
+
+    def is_in_startup_silence(self) -> bool:
+        """是否处于启动静默期（委托主服务协调器）。"""
+        checker = self._silence_checker
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:
+                return False
+        return False
 
     def _should_filter_message(self, payload_data: Any, source_id: str = "") -> str:
         """判断是否应该过滤该消息，返回过滤原因，空字符串表示不过滤。"""

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -162,6 +162,11 @@ class SourceMessageRouter:
                 connection_info=connection_info,
                 source_channel=source_channel,
             )
+            if getattr(self.service, "is_silencing", lambda: False)():
+                if hasattr(event, "metadata") and isinstance(event.metadata, dict):
+                    event.metadata.setdefault("bootstrap", True)
+                    if connection_name and not event.metadata.get("bootstrap_kind"):
+                        event.metadata["bootstrap_kind"] = "conn_first_wave"
             log_label = parser_log_label or source_label or source_id
             plugin_logger.debug(f"[灾害预警] {log_label} 解析成功: {event.id}")
 
@@ -307,6 +312,16 @@ class SourceMessageRouter:
                     for item in routed_messages
                 ]
                 msg_type = data.get("type")
+                if msg_type == "initial_all":
+                    coordinator = getattr(self.service, "startup_silence", None)
+                    if coordinator is not None:
+                        try:
+                            coordinator.note_bootstrap_payload(
+                                connection_name=connection_name,
+                                kind="fan_initial_all",
+                            )
+                        except Exception:
+                            pass
                 processed_count = 0
 
                 # 遍历被分配出来的数据源及负载，分别尝试分发

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -320,8 +320,10 @@ class SourceMessageRouter:
                                 connection_name=connection_name,
                                 kind="fan_initial_all",
                             )
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            plugin_logger.debug(
+                                f"[灾害预警] FAN initial_all 通知静默协调器失败: {exc}"
+                            )
                 processed_count = 0
 
                 # 遍历被分配出来的数据源及负载，分别尝试分发

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -167,6 +167,12 @@ class WebSocketManager:
                 self.connection_info[name].pop("quota_hit", None)
                 self.connection_info[name].pop("quota_deferred", None)
                 logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
+                on_established = getattr(self, "on_connection_established", None)
+                if callable(on_established):
+                    try:
+                        on_established(name)
+                    except Exception:
+                        pass
 
                 # FAN Studio：握手成功后立即发送应用层鉴权包。
                 # 仅“缺少凭证”返回 False；网络异常会向上抛出并由下方 except 重试。

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -171,8 +171,10 @@ class WebSocketManager:
                 if callable(on_established):
                     try:
                         on_established(name)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug(
+                            f"[灾害预警] WebSocket 建连回调通知静默协调器失败: {exc}"
+                        )
 
                 # FAN Studio：握手成功后立即发送应用层鉴权包。
                 # 仅“缺少凭证”返回 False；网络异常会向上抛出并由下方 except 重试。

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -879,16 +879,42 @@ class ConfigValidator:
                 )
                 cfg["wolfx_list_log_max_items"] = 50
 
-        # 启动静默期
-        silence = cfg.get("startup_silence_duration")
-        if isinstance(silence, int):
-            if silence < 0:
-                cfg["startup_silence_duration"] = 0
-            elif silence > 3600:
-                logger.warning(
-                    f"[灾害预警] 配置警告: 启动静默期 {silence} 秒 过长，已修正为 3600 秒。"
-                )
-                cfg["startup_silence_duration"] = 3600
+        # 静默启动开关（bool）；兼容旧 startup_silence_duration 秒数配置
+        if "silent_startup" in cfg:
+            raw_silent = cfg.get("silent_startup")
+            if isinstance(raw_silent, bool):
+                cfg["silent_startup"] = raw_silent
+            elif isinstance(raw_silent, (int, float)):
+                cfg["silent_startup"] = bool(raw_silent)
+            elif isinstance(raw_silent, str):
+                cfg["silent_startup"] = raw_silent.strip().lower() in {
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                    "是",
+                }
+            else:
+                cfg["silent_startup"] = True
+        elif "startup_silence_duration" in cfg:
+            legacy = cfg.get("startup_silence_duration")
+            if isinstance(legacy, bool):
+                cfg["silent_startup"] = legacy
+            elif isinstance(legacy, (int, float)):
+                cfg["silent_startup"] = float(legacy) > 0
+            else:
+                cfg["silent_startup"] = True
+            cfg.pop("startup_silence_duration", None)
+            logger.info(
+                f"[灾害预警] 已将旧配置 startup_silence_duration 迁移为 "
+                f"silent_startup={cfg['silent_startup']}"
+            )
+        else:
+            cfg["silent_startup"] = True
+
+        # 已存在 silent_startup 时清理残留旧秒数字段
+        if "startup_silence_duration" in cfg:
+            cfg.pop("startup_silence_duration", None)
 
         # 过滤消息类型列表校验
         if "filtered_message_types" in cfg:

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -207,6 +207,12 @@ class EqscTsunamiPollService:
 
         self._consecutive_failures = 0
         self._last_success_at = time.time()
+        coordinator = getattr(self.service, "startup_silence", None)
+        if coordinator is not None:
+            try:
+                coordinator.note_poll_fetch_completed("eqsc_tsunami", success=True)
+            except Exception:
+                pass
 
         fingerprint = self._build_snapshot_fingerprint(raw)
 

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -211,8 +211,8 @@ class EqscTsunamiPollService:
         if coordinator is not None:
             try:
                 coordinator.note_poll_fetch_completed("eqsc_tsunami", success=True)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(f"[灾害预警] EQSC 海啸轮询通知静默协调器失败: {exc}")
 
         fingerprint = self._build_snapshot_fingerprint(raw)
 

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -266,8 +266,8 @@ class EqscTyphoonPollService:
             if self._last_fingerprints.get(typhoon_id) == fingerprint:
                 continue
 
-            # 启动静默期：不进入推送链路，但仍提交指纹，避免静默结束后整批误报“推送”。
-            is_silence = getattr(self.service, "is_in_silence_period", None)
+            # 启动静默期：不进入推送链路，但仍提交指纹，避免静默结束后整批误报。
+            is_silence = getattr(self.service, "is_silencing", None)
             if callable(is_silence) and is_silence():
                 self._last_fingerprints[typhoon_id] = fingerprint
                 continue
@@ -309,6 +309,12 @@ class EqscTyphoonPollService:
         # 这里仅在拿到可解析对象时记成功。
         self._consecutive_failures = 0
         self._last_success_at = time.time()
+        coordinator = getattr(self.service, "startup_silence", None)
+        if coordinator is not None:
+            try:
+                coordinator.note_poll_fetch_completed("eqsc_typhoon", success=True)
+            except Exception:
+                pass
 
         if not emit_event:
             return active_items

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -313,8 +313,8 @@ class EqscTyphoonPollService:
         if coordinator is not None:
             try:
                 coordinator.note_poll_fetch_completed("eqsc_typhoon", success=True)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(f"[灾害预警] EQSC 台风轮询通知静默协调器失败: {exc}")
 
         if not emit_event:
             return active_items

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -353,6 +353,105 @@ class EventDeduplicationService:
         )
         return True
 
+    def seed_event(self, event: EventEnvelope) -> bool:
+        """静默启动播种：写入去重指纹，不表示允许推送。
+
+        供建连/首轮快照阶段学习当前世界状态，避免静默结束后整批误报。
+        """
+        envelope = event
+        if isinstance(envelope.event, TyphoonEvent):
+            return self._seed_typhoon(envelope)
+        if isinstance(envelope.event, TsunamiEvent):
+            return self._seed_tsunami(envelope)
+        domain_eq = self._get_domain_earthquake(event)
+        if domain_eq is None:
+            return True
+        return self._seed_earthquake(envelope, domain_eq)
+
+    def _seed_typhoon(self, event: EventEnvelope) -> bool:
+        """播种台风核心参数指纹。"""
+        typhoon = event.event
+        if not isinstance(typhoon, TyphoonEvent):
+            return False
+        typhoon_id = normalize_typhoon_id(typhoon.typhoon_id)
+        if not typhoon_id:
+            return False
+        fingerprint = self._generate_typhoon_fingerprint(typhoon)
+        self._typhoon_cache[typhoon_id] = fingerprint
+        plugin_logger.debug(
+            f"[灾害预警] 静默播种台风指纹: {typhoon_id} ({fingerprint})"
+        )
+        return True
+
+    def _seed_tsunami(self, event: EventEnvelope) -> bool:
+        """播种海啸内容指纹。"""
+        if not isinstance(event.event, TsunamiEvent):
+            return False
+        source_id = self._get_source_id(event)
+        fingerprint = self._extract_tsunami_fingerprint(event)
+        if not fingerprint:
+            return False
+        priority = self._resolve_source_priority(source_id)
+        existing = self._tsunami_cache.get(fingerprint)
+        if existing is None or priority >= int(existing.get("priority") or 0):
+            self._remember_tsunami_fingerprint(
+                fingerprint,
+                source_id=source_id,
+                priority=priority,
+                event_id=str(event.id or ""),
+            )
+        plugin_logger.debug(
+            f"[灾害预警] 静默播种海啸指纹: {source_id} 事件 ID {event.id}"
+        )
+        return True
+
+    def _seed_earthquake(
+        self, event: EventEnvelope, domain_eq: EarthquakeEvent
+    ) -> bool:
+        """播种地震滑动窗口指纹。"""
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        source_id = self._get_source_id(event)
+        event_fingerprint = self.generate_event_fingerprint(event, domain_eq, source_id)
+        current_time = self._to_utc(domain_eq.occurred_at, source_id)
+        current_report = self._resolve_report_num(event, metadata)
+        issue_type = self._extract_issue_type_from_earthquake(domain_eq, metadata)
+        record = {
+            "timestamp": current_time,
+            "source": source_id,
+            "latitude": domain_eq.latitude or 0,
+            "longitude": domain_eq.longitude or 0,
+            "magnitude": domain_eq.magnitude or 0,
+            "info_type": metadata.get("info_type")
+            or self._extract_issue_type_from_earthquake(domain_eq, metadata)
+            or "",
+            "issue_type": issue_type,
+            "processed_reports": {current_report},
+            "is_final": bool(metadata.get("is_final", False)),
+        }
+        if event_fingerprint in self.recent_events:
+            source_events = self.recent_events[event_fingerprint]
+            if source_id in source_events:
+                existing = source_events[source_id]
+                processed = existing.get("processed_reports", set())
+                if not isinstance(processed, set):
+                    processed = {existing.get("updates", 1)}
+                processed.add(current_report)
+                existing["processed_reports"] = processed
+                existing["timestamp"] = current_time
+                existing["is_final"] = existing.get("is_final", False) or bool(
+                    metadata.get("is_final", False)
+                )
+                if issue_type:
+                    existing["issue_type"] = issue_type
+            else:
+                source_events[source_id] = record
+        else:
+            self.recent_events[event_fingerprint] = {source_id: record}
+        plugin_logger.debug(
+            f"[灾害预警] 静默播种地震指纹: {source_id} 事件指纹：{event_fingerprint}"
+        )
+        return True
+
     def should_push_event(self, event: EventEnvelope) -> bool:
         """判断是否应该推送事件。
 

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -187,6 +187,13 @@ class SnetPollService:
         if not tiles_payload:
             return None
 
+        coordinator = getattr(self.service, "startup_silence", None)
+        if coordinator is not None:
+            try:
+                coordinator.note_poll_fetch_completed("snet_msil", success=True)
+            except Exception:
+                pass
+
         threshold = (
             self._resolve_min_shindo()
             if min_shindo is None

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -191,8 +191,8 @@ class SnetPollService:
         if coordinator is not None:
             try:
                 coordinator.note_poll_fetch_completed("snet_msil", success=True)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(f"[灾害预警] S-Net 轮询通知静默协调器失败: {exc}")
 
         threshold = (
             self._resolve_min_shindo()


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

引入一个基于状态机的静默启动流程，在正常事件处理开始之前吸收初始连接噪音，同时预先生成去重指纹。

New Features:
- 添加 `StartupSilenceCoordinator`，基于 WebSocket 连接和轮询源而不是固定时间窗口来控制静默启动阶段。
- 在地震、台风和海啸的去重服务中支持静默启动事件预置，这样在静默结束时，初始快照不会生成重复告警。

Enhancements:
- 用 `silent_startup` 开关替代传统的基于时间的 `startup_silence_duration` 配置，并加入相应的校验和迁移逻辑。
- 将灾害服务、消息日志、路由器、轮询器和状态上报接入新的静默启动协调器，确保日志、统计和推送在静默状态下都能一致地遵守静默规则。

Documentation:
- 更新 README，文档化新的 `silent_startup` 调试选项，并阐明静默启动如何影响事件投递和故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a state-machine–based silent startup flow that absorbs initial connection noise while seeding deduplication fingerprints before normal event processing begins.

New Features:
- Add a StartupSilenceCoordinator to control a silent startup phase based on WebSocket connections and polling sources rather than a fixed time window.
- Support silent startup event seeding in the deduplication service for earthquakes, typhoons, and tsunamis so that initial snapshots don’t generate duplicate alerts when silence ends.

Enhancements:
- Replace the legacy time-based startup_silence_duration configuration with a silent_startup switch, including validation and migration logic.
- Wire disaster service, message logging, routers, pollers, and status reporting into the new silent startup coordinator so logging, statistics, and pushes consistently respect the silence state.

Documentation:
- Update README to document the new silent_startup debug option and clarify how silent startup affects event delivery and troubleshooting.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于状态机的静默启动流程，在正常事件处理开始之前吸收初始连接噪音，同时预先生成去重指纹。

New Features:
- 添加 `StartupSilenceCoordinator`，基于 WebSocket 连接和轮询源而不是固定时间窗口来控制静默启动阶段。
- 在地震、台风和海啸的去重服务中支持静默启动事件预置，这样在静默结束时，初始快照不会生成重复告警。

Enhancements:
- 用 `silent_startup` 开关替代传统的基于时间的 `startup_silence_duration` 配置，并加入相应的校验和迁移逻辑。
- 将灾害服务、消息日志、路由器、轮询器和状态上报接入新的静默启动协调器，确保日志、统计和推送在静默状态下都能一致地遵守静默规则。

Documentation:
- 更新 README，文档化新的 `silent_startup` 调试选项，并阐明静默启动如何影响事件投递和故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a state-machine–based silent startup flow that absorbs initial connection noise while seeding deduplication fingerprints before normal event processing begins.

New Features:
- Add a StartupSilenceCoordinator to control a silent startup phase based on WebSocket connections and polling sources rather than a fixed time window.
- Support silent startup event seeding in the deduplication service for earthquakes, typhoons, and tsunamis so that initial snapshots don’t generate duplicate alerts when silence ends.

Enhancements:
- Replace the legacy time-based startup_silence_duration configuration with a silent_startup switch, including validation and migration logic.
- Wire disaster service, message logging, routers, pollers, and status reporting into the new silent startup coordinator so logging, statistics, and pushes consistently respect the silence state.

Documentation:
- Update README to document the new silent_startup debug option and clarify how silent startup affects event delivery and troubleshooting.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于状态机的静默启动流程，在正常事件处理开始之前吸收初始连接噪音，同时预先生成去重指纹。

New Features:
- 添加 `StartupSilenceCoordinator`，基于 WebSocket 连接和轮询源而不是固定时间窗口来控制静默启动阶段。
- 在地震、台风和海啸的去重服务中支持静默启动事件预置，这样在静默结束时，初始快照不会生成重复告警。

Enhancements:
- 用 `silent_startup` 开关替代传统的基于时间的 `startup_silence_duration` 配置，并加入相应的校验和迁移逻辑。
- 将灾害服务、消息日志、路由器、轮询器和状态上报接入新的静默启动协调器，确保日志、统计和推送在静默状态下都能一致地遵守静默规则。

Documentation:
- 更新 README，文档化新的 `silent_startup` 调试选项，并阐明静默启动如何影响事件投递和故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a state-machine–based silent startup flow that absorbs initial connection noise while seeding deduplication fingerprints before normal event processing begins.

New Features:
- Add a StartupSilenceCoordinator to control a silent startup phase based on WebSocket connections and polling sources rather than a fixed time window.
- Support silent startup event seeding in the deduplication service for earthquakes, typhoons, and tsunamis so that initial snapshots don’t generate duplicate alerts when silence ends.

Enhancements:
- Replace the legacy time-based startup_silence_duration configuration with a silent_startup switch, including validation and migration logic.
- Wire disaster service, message logging, routers, pollers, and status reporting into the new silent startup coordinator so logging, statistics, and pushes consistently respect the silence state.

Documentation:
- Update README to document the new silent_startup debug option and clarify how silent startup affects event delivery and troubleshooting.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于状态机的静默启动流程，在正常事件处理开始之前吸收初始连接噪音，同时预先生成去重指纹。

New Features:
- 添加 `StartupSilenceCoordinator`，基于 WebSocket 连接和轮询源而不是固定时间窗口来控制静默启动阶段。
- 在地震、台风和海啸的去重服务中支持静默启动事件预置，这样在静默结束时，初始快照不会生成重复告警。

Enhancements:
- 用 `silent_startup` 开关替代传统的基于时间的 `startup_silence_duration` 配置，并加入相应的校验和迁移逻辑。
- 将灾害服务、消息日志、路由器、轮询器和状态上报接入新的静默启动协调器，确保日志、统计和推送在静默状态下都能一致地遵守静默规则。

Documentation:
- 更新 README，文档化新的 `silent_startup` 调试选项，并阐明静默启动如何影响事件投递和故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a state-machine–based silent startup flow that absorbs initial connection noise while seeding deduplication fingerprints before normal event processing begins.

New Features:
- Add a StartupSilenceCoordinator to control a silent startup phase based on WebSocket connections and polling sources rather than a fixed time window.
- Support silent startup event seeding in the deduplication service for earthquakes, typhoons, and tsunamis so that initial snapshots don’t generate duplicate alerts when silence ends.

Enhancements:
- Replace the legacy time-based startup_silence_duration configuration with a silent_startup switch, including validation and migration logic.
- Wire disaster service, message logging, routers, pollers, and status reporting into the new silent startup coordinator so logging, statistics, and pushes consistently respect the silence state.

Documentation:
- Update README to document the new silent_startup debug option and clarify how silent startup affects event delivery and troubleshooting.

</details>

</details>

</details>