### PR TITLE
fix: 过滤地图瓦片 ERR_ABORTED 误报，渲染成功日志改为具体来源

### DIFF
--- a/core/message/builders/card_message_builder.py
+++ b/core/message/builders/card_message_builder.py
@@ -64,7 +64,10 @@ class CardMessageBuilder:
             image_filename = f"eq_list_{int(time.time())}.png"
             image_path = os.path.join(self.temp_dir, image_filename)
             return await self.browser_manager.render_card(
-                html_content, image_path, selector="#card-wrapper"
+                html_content,
+                image_path,
+                selector="#card-wrapper",
+                render_label="地震列表卡片",
             )
         except Exception as e:
             logger.error(f"[灾害预警] 渲染地震列表卡片失败: {e}")

--- a/core/message/builders/global_quake_card_builder.py
+++ b/core/message/builders/global_quake_card_builder.py
@@ -112,7 +112,10 @@ class GlobalQuakeCardBuilder:
                 )
                 image_path = os.path.join(self.temp_dir, image_filename)
                 return await self.browser_manager.render_card(
-                    html_content, image_path, selector="#card-wrapper"
+                    html_content,
+                    image_path,
+                    selector="#card-wrapper",
+                    render_label="GlobalQuake 卡片",
                 )
 
             result_path = await render_with_cache(card_cache_key, render_gq_card)

--- a/core/message/builders/map_attachment_builder.py
+++ b/core/message/builders/map_attachment_builder.py
@@ -93,7 +93,10 @@ class MapAttachmentBuilder:
             image_filename = f"map_{lat}_{lon}_{int(time.time())}.png"
             image_path = os.path.join(self.temp_dir, image_filename)
             return await self.browser_manager.render_card(
-                html_content, image_path, selector="#card-wrapper"
+                html_content,
+                image_path,
+                selector="#card-wrapper",
+                render_label="地震震中地图",
             )
         except Exception as e:
             logger.error(f"[灾害预警] 渲染地图图片时出错: {e}")

--- a/core/message/render/snet_map_renderer.py
+++ b/core/message/render/snet_map_renderer.py
@@ -336,11 +336,9 @@ class SnetMapRenderer:
                 selector="#card-wrapper",
                 wait_until="networkidle",
                 viewport=SNET_VIEWPORT,
+                render_label="S-Net 测站分布图",
             )
             if result and os.path.exists(output_path):
-                logger.info(
-                    f"[灾害预警] 测站图已生成 ({os.path.getsize(output_path)} bytes): {output_path}"
-                )
                 return output_path
             logger.warning("[灾害预警] 渲染未生成文件")
             return None

--- a/core/message/render/typhoon_map_renderer.py
+++ b/core/message/render/typhoon_map_renderer.py
@@ -513,12 +513,9 @@ class TyphoonMapRenderer:
                 selector="#card-wrapper",
                 wait_until="domcontentloaded",
                 viewport=TYPHOON_VIEWPORT,
+                render_label="台风路径图",
             )
             if result and os.path.exists(output_path):
-                logger.info(
-                    f"[灾害预警] 台风路径图已生成 "
-                    f"({os.path.getsize(output_path)} bytes): {output_path}"
-                )
                 return output_path
             logger.warning("[灾害预警] 台风路径图渲染未生成文件")
             return None

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -125,7 +125,6 @@ class BrowserManager:
         Playwright 常以 net::ERR_ABORTED 上报；出图成功时这些属于噪声。
         """
         failure = str(failure_text or "").lower()
-        resource = str(resource_type or "").lower()
         is_aborted = (
             "err_aborted" in failure
             or "net::err_aborted" in failure
@@ -133,8 +132,6 @@ class BrowserManager:
         )
         if not is_aborted:
             return False
-        if resource in {"image", "imageset", "media"}:
-            return True
         return cls._is_map_tile_url(url)
 
     def _truncate_debug_text(self, value, limit: int = 240) -> str:

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -66,6 +66,12 @@ class BrowserManager:
         return {"width": width, "height": height}
 
     @staticmethod
+    def _normalize_render_label(render_label: str | None) -> str:
+        """规范化渲染来源标签，供成功/失败日志使用。"""
+        text = str(render_label or "").strip()
+        return text or "卡片"
+
+    @staticmethod
     def _is_target_closed_error(error: Exception | str | None) -> bool:
         """判断是否为 Playwright 目标/浏览器已关闭类错误。"""
         message = str(error or "").lower()
@@ -79,6 +85,57 @@ class BrowserManager:
                 "context has been closed",
             )
         )
+
+    @staticmethod
+    def _is_map_tile_url(url: str | None) -> bool:
+        """判断 URL 是否为地图瓦片资源。"""
+        text = str(url or "").lower()
+        if not text:
+            return False
+        if "tilemap.fanstudio.tech" in text:
+            return True
+        if "appmaptile" in text or "webrd0" in text:
+            return True
+        if "/petaldark/" in text or "/petallight/" in text:
+            return True
+        return any(
+            marker in text
+            for marker in (
+                "/arcwi/",
+                "/arcwob/",
+                "/arcwh/",
+                "/geovis/",
+                "tile.openstreetmap",
+                "tiles.",
+                "/tiles/",
+            )
+        )
+
+    @classmethod
+    def _is_benign_request_failure(
+        cls,
+        *,
+        url: str | None,
+        failure_text: str | None,
+        resource_type: str | None = None,
+    ) -> bool:
+        """识别渲染过程中可忽略的资源失败。
+
+        Leaflet 在瓦片重试、视野更新、截图收尾时会主动中止旧请求，
+        Playwright 常以 net::ERR_ABORTED 上报；出图成功时这些属于噪声。
+        """
+        failure = str(failure_text or "").lower()
+        resource = str(resource_type or "").lower()
+        is_aborted = (
+            "err_aborted" in failure
+            or "net::err_aborted" in failure
+            or failure.strip() in {"aborted", "abort", "canceled", "cancelled"}
+        )
+        if not is_aborted:
+            return False
+        if resource in {"image", "imageset", "media"}:
+            return True
+        return cls._is_map_tile_url(url)
 
     def _truncate_debug_text(self, value, limit: int = 240) -> str:
         """截断浏览器侧日志文本，避免单条日志过长。"""
@@ -543,6 +600,7 @@ class BrowserManager:
         selector: str = "#card-wrapper",
         wait_until: str = "domcontentloaded",
         viewport: dict | None = None,
+        render_label: str | None = None,
     ) -> str | None:
         """把 HTML 内容渲染为图片文件。
 
@@ -554,8 +612,10 @@ class BrowserManager:
             viewport: 可选临时视口 {"width": int, "height": int}。
                 用于大尺寸卡片（如 S-Net 1400×1000）；截图后会恢复默认 800×800，
                 避免污染页面池中的其它渲染任务。
+            render_label: 渲染来源标签，用于成功日志区分场景。
         """
         resolved_viewport = self._normalize_viewport(viewport)
+        label = self._normalize_render_label(render_label)
         # 远程模式直接走 HTTP 渲染接口，本地模式则复用页面池执行截图。
         if self._mode == "remote":
             if not self._initialized:
@@ -566,11 +626,12 @@ class BrowserManager:
                 output_path,
                 selector,
                 viewport=resolved_viewport,
+                render_label=label,
             )
 
         # 本地模式：使用 Playwright
         if not await self._ensure_local_browser_ready():
-            logger.error("[灾害预警] 浏览器不可用，无法渲染")
+            logger.error(f"[灾害预警] 浏览器不可用，无法渲染{label}")
             return None
 
         page: Page | None = None
@@ -582,6 +643,11 @@ class BrowserManager:
         console_messages: list[str] = []
         page_errors: list[str] = []
         request_failures: list[str] = []
+        benign_request_failures: list[str] = []
+        listeners_attached = False
+        _record_console = None
+        _record_page_error = None
+        _record_request_failed = None
         try:
             # 并发控制 - 限制同时渲染的数量
             try:
@@ -630,7 +696,28 @@ class BrowserManager:
                                     failure_text = failure.get("errorText", "")
                                 else:
                                     failure_text = str(failure)
-                            entry = f"{req.method} {req.url} -> {self._truncate_debug_text(failure_text or 'unknown failure')}"
+                            resource_type = ""
+                            try:
+                                resource_type = str(
+                                    getattr(req, "resource_type", "") or ""
+                                )
+                            except Exception:
+                                resource_type = ""
+                            entry = (
+                                f"{req.method} {req.url} -> "
+                                f"{self._truncate_debug_text(failure_text or 'unknown failure')}"
+                            )
+                            if self._is_benign_request_failure(
+                                url=getattr(req, "url", None),
+                                failure_text=failure_text,
+                                resource_type=resource_type,
+                            ):
+                                # 瓦片重试/视野更新导致的中止请求：仅 debug，避免刷屏。
+                                benign_request_failures.append(entry)
+                                logger.debug(
+                                    f"[灾害预警] 忽略可预期的资源中止: {entry}"
+                                )
+                                return
                             request_failures.append(entry)
                             logger.warning(f"[灾害预警] 页面资源请求失败: {entry}")
                         except Exception as hook_err:
@@ -639,6 +726,7 @@ class BrowserManager:
                     page.on("console", _record_console)
                     page.on("pageerror", _record_page_error)
                     page.on("requestfailed", _record_request_failed)
+                    listeners_attached = True
 
                     # 大尺寸卡片（如 S-Net）临时放大视口，截图后在 finally 中恢复默认
                     if resolved_viewport:
@@ -696,15 +784,17 @@ class BrowserManager:
                             logger.debug("[灾害预警] 地图渲染标记已就绪")
                         except Exception:
                             logger.warning(
-                                "[灾害预警] 等待 .map-ready 标记超时，地图可能未完全加载"
+                                f"[灾害预警] {label}等待 .map-ready 标记超时，地图可能未完全加载"
                             )
                             if request_failures:
                                 logger.warning(
-                                    f"[灾害预警] 地图等待超时期间捕获到资源失败: {' | '.join(request_failures[-5:])}"
+                                    f"[灾害预警] {label}地图等待超时期间捕获到资源失败: "
+                                    f"{' | '.join(request_failures[-5:])}"
                                 )
                             if page_errors:
                                 logger.warning(
-                                    f"[灾害预警] 地图等待超时期间捕获到脚本异常: {' | '.join(page_errors[-3:])}"
+                                    f"[灾害预警] {label}地图等待超时期间捕获到脚本异常: "
+                                    f"{' | '.join(page_errors[-3:])}"
                                 )
                             await self._log_page_diagnostics(
                                 page, reason="map-ready-timeout"
@@ -740,26 +830,51 @@ class BrowserManager:
                     if os.path.exists(output_path):
                         if request_failures:
                             logger.warning(
-                                f"[灾害预警] 卡片渲染虽成功，但捕获到资源请求失败: {' | '.join(request_failures[-5:])}"
+                                f"[灾害预警] {label}渲染虽成功，但捕获到资源请求失败: "
+                                f"{' | '.join(request_failures[-5:])}"
+                            )
+                        elif benign_request_failures:
+                            logger.debug(
+                                f"[灾害预警] {label}渲染成功，已忽略 "
+                                f"{len(benign_request_failures)} 条可预期资源中止"
                             )
                         if page_errors:
                             logger.warning(
-                                f"[灾害预警] 卡片渲染虽成功，但捕获到页面脚本异常: {' | '.join(page_errors[-3:])}"
+                                f"[灾害预警] {label}渲染虽成功，但捕获到页面脚本异常: "
+                                f"{' | '.join(page_errors[-3:])}"
                             )
                         plugin_logger.info(
-                            f"[灾害预警] 卡片渲染成功，耗时 {elapsed:.3f}秒",
+                            f"[灾害预警] {label}渲染成功，耗时 {elapsed:.3f}秒",
                             is_event_linked=True,
                         )
                         render_succeeded = True
                         return output_path
                     else:
-                        logger.warning("[灾害预警] 截图未生成文件")
+                        logger.warning(f"[灾害预警] {label}截图未生成文件")
                         await self._log_page_diagnostics(
                             page, reason="screenshot-missing"
                         )
                         return None
 
                 finally:
+                    # 页面池复用前必须卸掉本次监听器，否则 requestfailed 会随复用次数叠加刷屏。
+                    if page and listeners_attached:
+                        for event_name, handler in (
+                            ("console", _record_console),
+                            ("pageerror", _record_page_error),
+                            ("requestfailed", _record_request_failed),
+                        ):
+                            if handler is None:
+                                continue
+                            try:
+                                page.remove_listener(event_name, handler)
+                            except Exception:
+                                try:
+                                    page.off(event_name, handler)
+                                except Exception:
+                                    pass
+                        listeners_attached = False
+
                     # 成功：恢复视口后归还；失败：直接丢弃坏页并补池，避免污染后续渲染。
                     if page and not page_returned:
                         if render_succeeded:
@@ -789,7 +904,7 @@ class BrowserManager:
                     self._semaphore.release()
 
         except Exception as e:
-            logger.error(f"[灾害预警] 卡片渲染失败: {e}")
+            logger.error(f"[灾害预警] {label}渲染失败: {e}")
             # 上报卡片渲染错误到遥测
             if self._telemetry and self._telemetry.enabled:
                 await self._telemetry.track_error(
@@ -819,11 +934,13 @@ class BrowserManager:
         output_path: str,
         selector: str,
         viewport: dict[str, int] | None = None,
+        render_label: str | None = None,
     ) -> str | None:
         """使用 browserless HTTP API 渲染卡片。
 
         viewport 可选；未提供时使用默认 800×800。
         """
+        label = self._normalize_render_label(render_label)
         start_time = time.time()
 
         # 对注入的 selector 进行 JSON 编码，规避转义和 JS 语法截断安全风险。
@@ -944,7 +1061,7 @@ class BrowserManager:
 
                         elapsed = time.time() - start_time
                         logger.info(
-                            f"[灾害预警] 卡片渲染成功（HTTP API），耗时 {elapsed:.3f}秒"
+                            f"[灾害预警] {label}渲染成功（HTTP API），耗时 {elapsed:.3f}秒"
                         )
                         return output_path
                     else:
@@ -978,7 +1095,7 @@ class BrowserManager:
                                             f.write(image_data)
                                         elapsed = time.time() - start_time
                                         logger.info(
-                                            f"[灾害预警] 卡片渲染通过降级重试成功（HTTP API），耗时 {elapsed:.3f}秒"
+                                            f"[灾害预警] {label}渲染通过降级重试成功（HTTP API），耗时 {elapsed:.3f}秒"
                                         )
                                         return output_path
                                     else:
@@ -993,10 +1110,10 @@ class BrowserManager:
                         return None
 
         except asyncio.TimeoutError:
-            logger.error("[灾害预警] browserless API 请求超时")
+            logger.error(f"[灾害预警] {label} browserless API 请求超时")
             return None
         except Exception as e:
-            logger.error(f"[灾害预警] browserless API 请求失败: {e}")
+            logger.error(f"[灾害预警] {label} browserless API 请求失败: {e}")
             if self._telemetry and self._telemetry.enabled:
                 await self._telemetry.track_error(
                     e, module="core.browser_manager._render_card_via_http"


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

通过区分良性的地图瓦片中止与真正的失败，并为特定卡片类型添加渲染日志标签，改进基于浏览器的卡片渲染日志记录与健壮性。

Bug Fixes（缺陷修复）:
- 防止在 Leaflet 重试或视口更新过程中被中止的地图瓦片请求被错误地报告为渲染失败。
- 避免在页面重复复用过程中累积 Playwright 事件监听器，从而减少冗余的重复请求失败日志噪音。

Enhancements（功能增强）:
- 为卡片渲染添加渲染标签，使成功、超时和错误日志能够清晰标明所属的卡片或地图类型。
- 优化资源失败处理逻辑，将预期的图像/媒体中止视为可忽略噪音，同时仍能暴露有意义的失败。
- 更新地震列表、全球地震、震中地图、台风路径以及 S-Net 观测站渲染器，以提供描述性标签并依赖集中化的渲染成功日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve browser-based card rendering logging and robustness by distinguishing benign map tile aborts from real failures and tagging render logs with specific card types.

Bug Fixes:
- Prevent map tile requests aborted during Leaflet retries or viewport updates from being reported as rendering failures.
- Avoid accumulation of Playwright event listeners across page reuse to reduce noisy repeated request failure logs.

Enhancements:
- Add a render label to card rendering so success, timeout, and error logs clearly indicate the originating card or map type.
- Refine resource failure handling to treat expected image/media aborts as ignorable noise while still surfacing meaningful failures.
- Update earthquake list, global quake, epicenter map, typhoon path, and S-Net station renderers to supply descriptive labels and rely on centralized render success logging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化地震、全球地震、台风及地图卡片的渲染日志标识与诊断信息，便于区分不同渲染场景。
  * 对地图瓦片这类可预期的资源中止失败进行弱告警处理，减少无效告警。
  * 改善页面事件监听器的清理，降低重复渲染时的触发异常。
  * 在渲染超时、失败及脚本异常场景提供更详细的补充日志摘要。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->