### PR TITLE
feat: 增强事件列表详情展示，并修复 EEW 警报分区与海啸同源去重

### DIFF
--- a/admin/css/views/events.css
+++ b/admin/css/views/events.css
@@ -1291,13 +1291,85 @@ html.theme-dark .event-filter-source-menu {
     opacity: 0.5;
 }
 
-/* 台风 / 海啸卡片第二行参数摘要 */
+/* 台风 / 海啸 / 地震卡片第二行参数摘要 */
 .event-meta-typhoon,
-.event-meta-tsunami {
+.event-meta-tsunami,
+.event-meta-earthquake {
     opacity: 0.72;
     margin-top: 2px;
     font-size: 0.8125rem;
     line-height: 1.35;
+}
+
+.event-meta-earthquake {
+    opacity: 0.88;
+    gap: 8px;
+}
+
+.event-quake-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    background: color-mix(in srgb, var(--md-sys-color-primary) 10%, var(--md-sys-color-surface));
+    color: var(--md-sys-color-on-surface-variant);
+    border: 1px solid color-mix(in srgb, var(--md-sys-color-primary) 16%, transparent);
+}
+
+body.dark-theme .event-quake-chip {
+    background: rgba(103, 80, 164, 0.18);
+    border-color: rgba(103, 80, 164, 0.28);
+}
+
+/* 气象预警 / 地震情报补充正文展开面板 */
+.event-weather-detail-panel {
+    margin-top: 10px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--md-sys-color-tertiary) 8%, var(--md-sys-color-surface));
+    border: 1px solid color-mix(in srgb, var(--md-sys-color-tertiary) 18%, transparent);
+}
+
+.event-weather-detail-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.event-weather-detail-icon {
+    font-size: 13px;
+    line-height: 1;
+}
+
+.event-weather-detail-title {
+    letter-spacing: 0.01em;
+}
+
+.event-weather-detail-body {
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--md-sys-color-on-surface);
+    opacity: 0.92;
+}
+
+.event-weather-detail-body--timeline {
+    margin-top: 4px;
+    font-size: 12px;
+    opacity: 0.88;
+}
+
+body.dark-theme .event-weather-detail-panel {
+    background: rgba(126, 87, 194, 0.12);
+    border-color: rgba(126, 87, 194, 0.22);
 }
 
 /* ---- 海啸结构化面板（对齐推送展示器信息密度） ---- */
@@ -1762,6 +1834,216 @@ body.dark-theme .event-tsunami-section.is-grade {
 .event-group-typhoon-text--strong {
     opacity: 0.9;
     font-weight: 600 !important;
+}
+
+/* 展开壳：顶部摘要 + 下方时间线，视觉上连成一张连续卡片 */
+.event-group-expanded-shell {
+    --hover-lift: 1px;
+    --card-bg: var(--md-sys-color-surface);
+    --card-border-color: var(--glass-border);
+    --card-shadow: var(--glass-shadow);
+    --card-hover-bg: color-mix(in srgb, var(--md-sys-color-surface) 90%, var(--md-sys-color-primary) 10%);
+    --card-hover-border-color: color-mix(in srgb, var(--md-sys-color-primary) 46%, transparent);
+    --card-hover-shadow: 0 8px 22px rgba(103, 80, 164, 0.10);
+    position: relative;
+    isolation: isolate;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border-radius: var(--radius-lg);
+    background: transparent;
+    border: 1px solid transparent;
+    box-shadow: none;
+    overflow: hidden;
+}
+
+.event-group-expanded-shell::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border-color);
+    box-shadow: var(--card-shadow);
+    pointer-events: none;
+    transition:
+        transform 0.18s ease-out,
+        background 0.18s ease-out,
+        border-color 0.18s ease-out,
+        box-shadow 0.18s ease-out;
+}
+
+.event-group-expanded-shell > * {
+    transition: transform 0.18s ease-out;
+}
+
+.event-group-expanded-shell:hover::before,
+.event-group-expanded-shell:hover > * {
+    transform: translateY(calc(-1 * var(--hover-lift)));
+}
+
+.event-group-expanded-shell:hover::before {
+    background: var(--card-hover-bg);
+    border-color: var(--card-hover-border-color);
+    box-shadow: var(--card-hover-shadow);
+}
+
+.event-group-sticky-card {
+    cursor: pointer;
+    position: relative;
+    z-index: 1;
+}
+
+/* 顶部摘要卡：去掉独立卡片外壳，融入展开壳 */
+.event-group-sticky-card .event-card {
+    margin-bottom: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    border: none;
+}
+
+.event-group-sticky-card .event-card::before {
+    display: none;
+}
+
+/* 时间线区：与顶部摘要用细分割线衔接，不再单独成卡 */
+.event-group-timeline-section {
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding: 0 8px 8px;
+}
+
+.event-group-timeline-panel {
+    padding: 8px 16px 16px;
+}
+
+.event-group-timeline-header {
+    display: flex;
+    align-items: center;
+    margin: 0 0 8px 0;
+    padding: 0;
+}
+
+.event-group-timeline-header .event-group-collapse-text {
+    margin: 0 !important;
+    line-height: 1.2 !important;
+}
+
+.event-group-timeline-panel .event-group-collapse-button {
+    margin-bottom: 14px;
+    padding-bottom: 10px;
+}
+
+/* 业务报次提示芯片（与更新序号区分） */
+.event-group-business-chip {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--md-sys-color-tertiary) 12%, var(--md-sys-color-surface));
+    color: var(--md-sys-color-on-surface-variant);
+    border: 1px solid color-mix(in srgb, var(--md-sys-color-tertiary) 22%, transparent);
+    opacity: 0.92;
+}
+
+body.dark-theme .event-group-business-chip {
+    background: rgba(126, 87, 194, 0.16);
+    border-color: rgba(126, 87, 194, 0.28);
+}
+
+/* 时间线历史行：复用 EventCard 主卡片级详情 */
+.event-group-timeline-row--card {
+    align-items: stretch;
+}
+
+.event-group-history-card-wrap {
+    margin-top: 4px;
+    min-width: 0;
+}
+
+.event-group-history-card-wrap .event-card,
+.event-group-history-card-wrap .event-card-history {
+    padding: 10px 12px;
+    margin-bottom: 0;
+    gap: 12px;
+    border-radius: 12px;
+    box-shadow: none;
+    background: color-mix(in srgb, var(--md-sys-color-surface-variant) 28%, transparent);
+    border: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 55%, transparent);
+}
+
+.event-group-history-card-wrap .event-card::before {
+    display: none;
+}
+
+.event-group-history-card-wrap .event-title-text {
+    font-size: 0.95rem !important;
+    font-weight: 700 !important;
+}
+
+.event-group-history-card-wrap .event-tsunami-panel {
+    margin-top: 6px;
+}
+
+.event-group-history-card-wrap .event-tsunami-sections {
+    margin-top: 2px;
+}
+
+.event-group-history-card-wrap .mag-badge,
+.event-group-history-card-wrap .mag-badge-history {
+    width: 44px;
+    height: 44px;
+    font-size: 16px;
+}
+
+body.dark-theme .event-group-history-card-wrap .event-card,
+body.dark-theme .event-group-history-card-wrap .event-card-history {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+/* 海啸时间线详情（兼容旧结构） */
+.event-group-tsunami-details {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 2px;
+    min-width: 0;
+}
+
+.event-group-tsunami-title {
+    font-size: 13px !important;
+    font-weight: 600 !important;
+    opacity: 0.9;
+    line-height: 1.4 !important;
+}
+
+.event-group-tsunami-fallback {
+    font-size: 12px !important;
+    opacity: 0.75;
+    line-height: 1.4 !important;
+}
+
+.event-group-tsunami-details .event-tsunami-panel {
+    margin-top: 2px;
+}
+
+/* 气象时间线 / 展开详情 */
+.event-group-weather-details {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 2px;
+    min-width: 0;
+}
+
+.event-group-weather-title {
+    font-size: 13px !important;
+    font-weight: 600 !important;
+    opacity: 0.9;
 }
 
 /* 速报更新等级芯片(如 "第1报" 芯片) */

--- a/admin/css/views/events.css
+++ b/admin/css/views/events.css
@@ -1354,6 +1354,7 @@ body.dark-theme .event-quake-chip {
 
 .event-weather-detail-body {
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
     word-break: break-word;
     font-size: 13px;
     line-height: 1.55;

--- a/admin/js/components/events/EventCard.jsx
+++ b/admin/js/components/events/EventCard.jsx
@@ -12,6 +12,8 @@ const { Typography } = MaterialUI;
  * @param {boolean} [props.isExpandable=false] 卡片是否包含多报更新并可展开折叠
  * @param {boolean} [props.isExpanded=false] 当前是否处于展开状态
  * @param {number|null} [props.reportIndex=null] 多报更新时的历史期数标签
+ * @param {boolean} [props.hideExpandBadge=false] 隐藏右侧展开/收起控件
+ * @param {boolean} [props.hideReportBadge=false] 隐藏标题旁「第N报」徽章（时间线已有 chip 时使用）
  */
 function EventCard({
     event,
@@ -21,6 +23,7 @@ function EventCard({
     isExpanded = false,
     reportIndex = null,
     hideExpandBadge = false,
+    hideReportBadge = false,
 }) {
     const formatters = window.EventFormatSerialization || window.EventFormatters || {};
     const {
@@ -199,11 +202,14 @@ function EventCard({
 
     // 计算报告第几期 (第几报) 的文案：统一走 resolveEventReportNum，
     // 避免标题内嵌 batch 与 report_num 徽章两套语义打架。
-    const resolvedReportNum = typeof resolveEventReportNum === 'function'
-        ? resolveEventReportNum(evt, reportIndex)
-        : (reportIndex !== null && reportIndex > 0
-            ? reportIndex
-            : (Number(evt.report_num) > 0 ? Number(evt.report_num) : null));
+    // hideReportBadge：时间线历史行上方已有序号 chip，禁止再从 batch 回退画徽章。
+    const resolvedReportNum = hideReportBadge
+        ? null
+        : (typeof resolveEventReportNum === 'function'
+            ? resolveEventReportNum(evt, reportIndex)
+            : (reportIndex !== null && reportIndex > 0
+                ? reportIndex
+                : (Number(evt.report_num) > 0 ? Number(evt.report_num) : null)));
     const reportLabel = typeof formatReportLabel === 'function'
         ? formatReportLabel(resolvedReportNum)
         : (resolvedReportNum ? `第 ${resolvedReportNum} 报` : '');
@@ -220,7 +226,7 @@ function EventCard({
     const earthquakeDepthText = hasValidEarthquakeDepth
         ? (earthquakeDepthNum === 0
             ? '极浅'
-            : `${Number.isInteger(earthquakeDepthNum) ? earthquakeDepthNum : earthquakeDepthNum} km`)
+            : `${Number.isInteger(earthquakeDepthNum) ? earthquakeDepthNum : earthquakeDepthNum}km`)
         : '';
     const earthquakeMagnitudeText = typeof formatMagnitudeBadge === 'function'
         ? formatMagnitudeBadge(evt.magnitude ?? evt._groupMagnitude)

--- a/admin/js/components/events/EventCard.jsx
+++ b/admin/js/components/events/EventCard.jsx
@@ -13,13 +13,14 @@ const { Typography } = MaterialUI;
  * @param {boolean} [props.isExpanded=false] 当前是否处于展开状态
  * @param {number|null} [props.reportIndex=null] 多报更新时的历史期数标签
  */
-function EventCard({ 
-    event, 
-    displayTimezone, 
-    isHistory = false, 
-    isExpandable = false, 
-    isExpanded = false, 
-    reportIndex = null 
+function EventCard({
+    event,
+    displayTimezone,
+    isHistory = false,
+    isExpandable = false,
+    isExpanded = false,
+    reportIndex = null,
+    hideExpandBadge = false,
 }) {
     const formatters = window.EventFormatSerialization || window.EventFormatters || {};
     const {
@@ -30,6 +31,9 @@ function EventCard({
         resolveWeatherFallbackUrl = () => null,
         buildTsunamiTitle = null,
         buildTsunamiMeta = null,
+        resolveEventReportNum = null,
+        formatReportLabel = null,
+        formatMagnitudeBadge = null,
     } = formatters;
     const buildWeatherIconFallbackHandler = _rawBuildHandler || ((_, cb) => (e) => typeof cb === 'function' && cb(e));
     const evt = event || {};
@@ -193,19 +197,61 @@ function EventCard({
         ].filter(Boolean).join(' · ')
         : '';
 
-    // 计算报告第几期 (第几报) 的文案
-    let reportLabel = '';
-    if (reportIndex !== null && reportIndex > 0) {
-        reportLabel = `第 ${reportIndex} 报`;
-    } else if (evt.report_num) {
-        reportLabel = `第 ${evt.report_num} 报`;
-    }
+    // 计算报告第几期 (第几报) 的文案：统一走 resolveEventReportNum，
+    // 避免标题内嵌 batch 与 report_num 徽章两套语义打架。
+    const resolvedReportNum = typeof resolveEventReportNum === 'function'
+        ? resolveEventReportNum(evt, reportIndex)
+        : (reportIndex !== null && reportIndex > 0
+            ? reportIndex
+            : (Number(evt.report_num) > 0 ? Number(evt.report_num) : null));
+    const reportLabel = typeof formatReportLabel === 'function'
+        ? formatReportLabel(resolvedReportNum)
+        : (resolvedReportNum ? `第 ${resolvedReportNum} 报` : '');
+
+    // 地震深度：折叠外也直接可见。
+    // 合法深度 >= 0；缺失/负数不展示；0 km 映射为「极浅」。
+    const earthquakeDepthRaw = evt.depth;
+    const earthquakeDepthNum = Number(earthquakeDepthRaw);
+    const hasValidEarthquakeDepth = earthquakeDepthRaw !== null
+        && earthquakeDepthRaw !== undefined
+        && earthquakeDepthRaw !== ''
+        && Number.isFinite(earthquakeDepthNum)
+        && earthquakeDepthNum >= 0;
+    const earthquakeDepthText = hasValidEarthquakeDepth
+        ? (earthquakeDepthNum === 0
+            ? '极浅'
+            : `${Number.isInteger(earthquakeDepthNum) ? earthquakeDepthNum : earthquakeDepthNum} km`)
+        : '';
+    const earthquakeMagnitudeText = typeof formatMagnitudeBadge === 'function'
+        ? formatMagnitudeBadge(evt.magnitude ?? evt._groupMagnitude)
+        : '';
+
+    // 正文展开语义：
+    // - 气象预警：weather_detail / description
+    // - 地震情报补充正文：weather_detail（P2P 各地震度、CENC 烈度速报、FSSN CMT 等）
+    // 注意：地震标题 description 常是「M x.x 地点」，不能当正文回退，否则会误出展开入口。
+    const detailBodyText = (() => {
+        const weatherDetail = String(evt.weather_detail || '').trim();
+        if (isWeather) {
+            return weatherDetail || String(evt.description || '').trim();
+        }
+        if (isEarthquake) {
+            return weatherDetail;
+        }
+        return '';
+    })();
+    // 列表主卡：可点开展开；时间线历史行：isExpanded 时直接展示正文（无展开控件）
+    const canExpandDetail = !!detailBodyText && !isHistory && (isWeather || isEarthquake);
+    const showDetailPanel = !!detailBodyText && (isWeather || isEarthquake) && isExpanded;
+    const detailPanelTitle = isWeather ? '预警正文' : '情报正文';
+    const showExpandControl = (isExpandable || canExpandDetail) && !hideExpandBadge;
 
     // 拼装卡片的主容器 Class 类名
     const cardClassName = [
         'event-card',
-        isExpandable ? 'clickable' : '',
+        (isExpandable || canExpandDetail) ? 'clickable' : '',
         isHistory ? 'event-card-history' : '',
+        showDetailPanel ? 'is-detail-expanded' : '',
     ].filter(Boolean).join(' ');
 
     // 拼装左侧徽标容器 Class 类名，关联震度警报的危险背景色类
@@ -310,6 +356,20 @@ function EventCard({
                             : formatSourceName(evt.source_id || evt.source || evt._groupSource || 'unknown'))}
                     </span>
                 </div>
+                {isEarthquake && (earthquakeDepthText || (earthquakeMagnitudeText && earthquakeMagnitudeText !== '--')) && (
+                    <div className="event-meta event-meta-earthquake">
+                        {earthquakeMagnitudeText && earthquakeMagnitudeText !== '--' && (
+                            <span className="event-meta-item event-quake-chip">
+                                🧭 M {earthquakeMagnitudeText}
+                            </span>
+                        )}
+                        {earthquakeDepthText && (
+                            <span className="event-meta-item event-quake-chip">
+                                ⬇️ 深度 {earthquakeDepthText}
+                            </span>
+                        )}
+                    </div>
+                )}
                 {typhoonMeta && (
                     <div className="event-meta event-meta-typhoon">
                         <span className="event-meta-item">{typhoonMeta}</span>
@@ -330,7 +390,8 @@ function EventCard({
                                 ))}
                             </div>
                         )}
-                        {Array.isArray(tsunamiMeta.sections) && tsunamiMeta.sections.length > 0 && (
+                        {/* 主卡片与时间线历史行（isExpanded）都展示 sections，信息密度对齐主卡片 */}
+                        {(!isHistory || isExpanded) && Array.isArray(tsunamiMeta.sections) && tsunamiMeta.sections.length > 0 && (
                             <div className="event-tsunami-sections">
                                 {tsunamiMeta.sections.map((section) => (
                                     <div
@@ -365,13 +426,27 @@ function EventCard({
                         ) : null}
                     </div>
                 )}
+                {/* 气象预警 / 地震情报补充正文展开面板（主卡展开或时间线历史行） */}
+                {showDetailPanel && (
+                    <div className="event-weather-detail-panel">
+                        <div className="event-weather-detail-head">
+                            <span className="event-weather-detail-icon">📝</span>
+                            <span className="event-weather-detail-title">{detailPanelTitle}</span>
+                        </div>
+                        <div className="event-weather-detail-body">{detailBodyText}</div>
+                    </div>
+                )}
             </div>
 
-            {/* 极右侧：多更新折叠控制提示（若包含） */}
-            {isExpandable && (
+            {/* 极右侧：多更新折叠 / 正文展开控制提示 */}
+            {showExpandControl && (
                 <div className="update-badge">
                     <span className="update-count">
-                        {isExpanded ? '收起' : `${evt.updateCount || ''} 条更新`}
+                        {isExpanded
+                            ? '收起'
+                            : (isExpandable
+                                ? `${evt.updateCount || ''} 条更新`
+                                : '查看正文')}
                     </span>
                     <span className="update-icon">{isExpanded ? '▲' : '▼'}</span>
                 </div>

--- a/admin/js/components/events/EventGroupTimeline.jsx
+++ b/admin/js/components/events/EventGroupTimeline.jsx
@@ -67,9 +67,10 @@ function EventGroupTimeline({ group, displayTimezone }) {
             weather_detail: hasOwn('weather_detail')
                 ? evt.weather_detail
                 : (isLatestRow ? (latest.weather_detail || '') : ''),
+            // 地点属身份字段：本报优先，缺失时继承主事件，避免历史卡丢地点
             place_name: hasOwn('place_name')
                 ? evt.place_name
-                : (isLatestRow ? latest.place_name : (evt.place_name || '')),
+                : (latest.place_name || evt.place_name || ''),
             max_wave_height: hasOwn('max_wave_height')
                 ? evt.max_wave_height
                 : (isLatestRow ? latest.max_wave_height : null),
@@ -101,6 +102,26 @@ function EventGroupTimeline({ group, displayTimezone }) {
         };
     };
 
+    // 预计算组内业务报次：若多行撞同一业务号，时间线统一改用组内序号，
+    // 避免地震/气象多报共用同一 report_num 时全部显示成「第 N 报」。
+    const businessReportNums = (group.events || []).map((evt, idx) => {
+        const merged = mergeTimelineEvent(evt, idx === 0);
+        const num = typeof resolveEventReportNum === 'function'
+            ? resolveEventReportNum(merged)
+            : Number(merged?.report_num);
+        return (Number.isInteger(num) && num > 0) ? num : null;
+    });
+    const seenBusinessNums = new Set();
+    let hasDuplicateBusinessReportNum = false;
+    for (const num of businessReportNums) {
+        if (num == null) continue;
+        if (seenBusinessNums.has(num)) {
+            hasDuplicateBusinessReportNum = true;
+            break;
+        }
+        seenBusinessNums.add(num);
+    }
+
     return (
         <div className="event-group-timeline-panel">
             {/* 收起由顶部主卡片统一提供，这里只保留轻量统计标题，避免重复「收起」 */}
@@ -115,22 +136,18 @@ function EventGroupTimeline({ group, displayTimezone }) {
                 <div className="event-group-timeline-line"></div>
 
                 {group.events.map((evt, idx) => {
-                    // 时间线芯片一律按「组内更新序号」编号（最新=N … 最旧=1），
-                    // 避免海啸业务 batch 长期停在「第3报」时，9 次系统更新全部显示成同一个号。
-                    // 业务报次（batch）仍由主卡片徽章展示，语义分离。
+                    // 时间线芯片：默认可用业务报次；台风/海啸、无业务号、或组内业务号撞车时用序号。
+                    // 业务报次（batch）仍可由主卡片徽章 / 业务 chip 展示，语义分离。
                     const sequenceNum = totalReports - idx;
                     const isLatest = idx === 0;
                     const mergedEvt = mergeTimelineEvent(evt, isLatest);
 
-                    const businessReportNum = typeof resolveEventReportNum === 'function'
-                        ? resolveEventReportNum(mergedEvt)
-                        : Number(mergedEvt?.report_num);
-                    const hasBusinessReportNum = Number.isInteger(businessReportNum) && businessReportNum > 0;
-                    // 台风 / 海啸多报：用序号；地震等业务报次若与序号一致或每报不同，仍可用业务号，
-                    // 但当多行业务号撞车时强制回退序号。
+                    const businessReportNum = businessReportNums[idx];
+                    const hasBusinessReportNum = businessReportNum != null;
                     const useSequenceLabel = isTyphoonGroup
                         || groupType === 'tsunami'
-                        || !hasBusinessReportNum;
+                        || !hasBusinessReportNum
+                        || hasDuplicateBusinessReportNum;
                     const displayReportNum = useSequenceLabel ? sequenceNum : businessReportNum;
                     // 统一写「第 X 报」；海啸业务号不同时另注业务报数
                     const reportLabelText = typeof formatReportLabel === 'function'

--- a/admin/js/components/events/EventGroupTimeline.jsx
+++ b/admin/js/components/events/EventGroupTimeline.jsx
@@ -3,8 +3,10 @@ const { Typography } = MaterialUI;
 /**
  * 地震或灾害事件多报更新时间轴面板组件 (EventGroupTimeline)
  * 当某次地震存在多次修正速报或更新时，用户点击卡片会展开此组件。
- * 该组件以垂直时间线形式，由新到旧列出该事件组名下接收到的所有历史报告，
- * 并展示各期报告中的详细震级、震源深度以及对应的地震烈度/震度标志。
+ * 该组件以垂直时间线形式，由新到旧列出该事件组名下接收到的所有历史报告。
+ *
+ * 海啸/气象/地震/台风统一复用 EventCard 渲染各报详情，
+ * 使历史报与主卡片信息密度一致（chips / sections / 深度等）。
  *
  * @param {Object} props
  * @param {Object} props.group 包含同一事件关联的 events 列表与最新一条 event 记录的分组数据
@@ -12,167 +14,193 @@ const { Typography } = MaterialUI;
  * @param {Function} props.onCollapse 折叠收起该面板的回调函数
  */
 function EventGroupTimeline({ group, displayTimezone, onCollapse }) {
-    const { getDisplayTimeValue, formatMagnitudeBadge, getEarthquakeBadgeContent } = window.EventFormatters;
-    const typhoonFormatters = window.DisasterTyphoonFormatters;
+    const formatters = window.EventFormatters || {};
+    const {
+        getDisplayTimeValue,
+        resolveEventReportNum,
+        formatReportLabel,
+    } = formatters;
     const totalReports = group.events.length;
     const groupType = group.latestEvent.type || '';
     const isTyphoonGroup = groupType === 'typhoon';
 
+    /**
+     * 将历史快照与最新主事件合并。
+     * 身份字段（source/type/place）可继承；状态字段（weather_detail/is_cancelled 等）
+     * 仅在本报有值或最新行时继承，避免解除报覆盖历史报。
+     */
+    const mergeTimelineEvent = (evt, isLatestRow = false) => {
+        const latest = group.latestEvent || {};
+        const hasOwn = (key) => (
+            evt[key] !== undefined && evt[key] !== null && evt[key] !== ''
+        );
+
+        // 历史快照若无 weather_detail，尽量从 description 推断取消态，避免误继承最新解除
+        const ownCancelled = hasOwn('is_cancelled')
+            ? Boolean(evt.is_cancelled)
+            : (hasOwn('cancelled')
+                ? Boolean(evt.cancelled)
+                : (String(evt.level || '').includes('解除')
+                    || String(evt.description || '').includes('解除')
+                    || null));
+
+        return {
+            // 先铺父级身份字段，再覆盖本报快照
+            source: evt.source || latest.source,
+            source_id: evt.source_id || latest.source_id || latest.source,
+            type: evt.type || latest.type,
+            info_type: evt.info_type || latest.info_type,
+            weather_type_code: evt.weather_type_code || latest.weather_type_code,
+            icon_url: evt.icon_url || latest.icon_url,
+            // 本报快照字段优先
+            ...evt,
+            description: hasOwn('description') ? evt.description : (isLatestRow ? latest.description : (evt.description || '')),
+            subtitle: hasOwn('subtitle') ? evt.subtitle : (isLatestRow ? latest.subtitle : (evt.subtitle || '')),
+            level: hasOwn('level') ? evt.level : (isLatestRow ? latest.level : (evt.level || '')),
+            magnitude: hasOwn('magnitude') ? evt.magnitude : (isLatestRow ? latest.magnitude : evt.magnitude),
+            depth: hasOwn('depth') ? evt.depth : (isLatestRow ? latest.depth : evt.depth),
+            report_num: hasOwn('report_num') ? evt.report_num : (isLatestRow ? latest.report_num : evt.report_num),
+            time: evt.time || evt.timestamp || (isLatestRow ? latest.time : ''),
+            timestamp: evt.timestamp || evt.time || (isLatestRow ? latest.timestamp : ''),
+            recorded_at: evt.recorded_at || (isLatestRow ? latest.recorded_at : evt.recorded_at),
+            // 详情摘要：有则用本报；最新行可回退主表；历史行不继承最新解除摘要
+            weather_detail: hasOwn('weather_detail')
+                ? evt.weather_detail
+                : (isLatestRow ? (latest.weather_detail || '') : ''),
+            place_name: hasOwn('place_name')
+                ? evt.place_name
+                : (isLatestRow ? latest.place_name : (evt.place_name || '')),
+            max_wave_height: hasOwn('max_wave_height')
+                ? evt.max_wave_height
+                : (isLatestRow ? latest.max_wave_height : null),
+            area_count: hasOwn('area_count')
+                ? evt.area_count
+                : (isLatestRow ? latest.area_count : null),
+            immediate_area_count: hasOwn('immediate_area_count')
+                ? evt.immediate_area_count
+                : (isLatestRow ? latest.immediate_area_count : null),
+            is_cancelled: ownCancelled !== null
+                ? ownCancelled
+                : (isLatestRow ? Boolean(latest.is_cancelled) : false),
+            is_training: hasOwn('is_training')
+                ? Boolean(evt.is_training)
+                : (hasOwn('isTraining')
+                    ? Boolean(evt.isTraining)
+                    : (isLatestRow ? Boolean(latest.is_training) : false)),
+            latitude: hasOwn('latitude') ? evt.latitude : (isLatestRow ? latest.latitude : evt.latitude),
+            longitude: hasOwn('longitude') ? evt.longitude : (isLatestRow ? latest.longitude : evt.longitude),
+            // 台风快照字段
+            _snapshot_level: evt._snapshot_level || evt.level,
+            _snapshot_wind_speed: evt._snapshot_wind_speed ?? evt.wind_speed,
+            _snapshot_pressure: evt._snapshot_pressure ?? evt.pressure,
+            _snapshot_latitude: evt._snapshot_latitude ?? evt.latitude,
+            _snapshot_longitude: evt._snapshot_longitude ?? evt.longitude,
+            wind_speed: evt.wind_speed ?? (isLatestRow ? latest.wind_speed : evt.wind_speed),
+            pressure: evt.pressure ?? (isLatestRow ? latest.pressure : evt.pressure),
+            batch: evt.batch ?? (isLatestRow ? latest.batch : evt.batch),
+        };
+    };
+
     return (
-        <div className="event-group-expanded event-group-expanded-panel">
-            {/* 收起控制条 */}
-            <button
-                onClick={onCollapse}
-                onKeyDown={(e) => { 
-                    if (e.key === 'Enter' || e.key === ' ') { 
-                        e.preventDefault(); 
-                        onCollapse(); 
-                    } 
-                }}
-                aria-expanded={true}
-                className="event-group-collapse-button"
-            >
+        <div className="event-group-timeline-panel">
+            {/* 收起由顶部主卡片统一提供，这里只保留轻量统计标题，避免重复「收起」 */}
+            <div className="event-group-timeline-header">
                 <Typography variant="body2" className="event-group-collapse-text">
                     共 {totalReports} 次更新
                 </Typography>
-                <div className="update-badge">
-                    <span>收起</span>
-                    <span className="update-icon">▲</span>
-                </div>
-            </button>
+            </div>
 
             {/* 垂直时间线容器 */}
             <div className="event-group-timeline">
-                {/* 垂直中心轴线 */}
                 <div className="event-group-timeline-line"></div>
-                
-                {/* 遍历输出每一报的历史明细 */}
-                {group.events.map((evt, idx) => {
-                    // 台风路径点统一按时间线位置编号：主表最新状态没有 report_num，
-                    // 若混用历史快照的 report_num，会把最新点错误显示为“第1报”。
-                    const reportIndex = totalReports - idx;
-                    const actualReportNum = Number(evt?.report_num);
-                    const hasValidReportNum = Number.isInteger(actualReportNum) && actualReportNum > 0;
-                    const displayReportNum = isTyphoonGroup
-                        ? reportIndex
-                        : (hasValidReportNum ? actualReportNum : reportIndex);
-                    
-                    // 标识最新的这一期（第0项）
-                    const isLatest = idx === 0;
-                    const rowType = evt.type || group.latestEvent.type || '';
-                    const isEarthquake = rowType === 'earthquake' || rowType === 'earthquake_warning';
-                    const isTyphoon = rowType === 'typhoon';
-                    
-                    // 获取报告中的地震参数
-                    const rowDepth = evt.depth ?? group.latestEvent.depth;
-                    const rowMagnitude = evt.magnitude ?? group.latestEvent.magnitude;
-                    const rowMagnitudeText = formatMagnitudeBadge(rowMagnitude);
-                    
-                    // 提取此报对应的地震烈度徽标元数据
-                    const rowBadgeMeta = getEarthquakeBadgeContent({
-                        ...group.latestEvent,
-                        ...evt,
-                        _groupMagnitude: group.latestEvent.magnitude
-                    });
 
-                    // 台风路径点参数：优先使用当前快照字段，回退到主字段峰值。
-                    const typhoonLevel = evt._snapshot_level || evt.level || '';
-                    const typhoonWind = Number(evt._snapshot_wind_speed ?? evt.wind_speed);
-                    const typhoonPressure = evt._snapshot_pressure != null
-                        ? Number(evt._snapshot_pressure)
-                        : (evt.pressure != null ? Number(evt.pressure) : null);
-                    const typhoonLat = evt._snapshot_latitude != null
-                        ? Number(evt._snapshot_latitude)
-                        : (evt.latitude != null ? Number(evt.latitude) : null);
-                    const typhoonLon = evt._snapshot_longitude != null
-                        ? Number(evt._snapshot_longitude)
-                        : (evt.longitude != null ? Number(evt.longitude) : null);
-                    const typhoonLevelEmoji = typhoonFormatters?.getTyphoonLevelEmoji(typhoonLevel) || '🌀';
-                    const typhoonLevelColor = typhoonFormatters?.getTyphoonLevelColor(typhoonLevel) || '';
-                    const typhoonCoords = typhoonFormatters?.formatTyphoonCoords(typhoonLat, typhoonLon) || '';
+                {group.events.map((evt, idx) => {
+                    // 时间线芯片一律按「组内更新序号」编号（最新=N … 最旧=1），
+                    // 避免海啸业务 batch 长期停在「第3报」时，9 次系统更新全部显示成同一个号。
+                    // 业务报次（batch）仍由主卡片徽章展示，语义分离。
+                    const sequenceNum = totalReports - idx;
+                    const isLatest = idx === 0;
+                    const mergedEvt = mergeTimelineEvent(evt, isLatest);
+
+                    const businessReportNum = typeof resolveEventReportNum === 'function'
+                        ? resolveEventReportNum(mergedEvt)
+                        : Number(mergedEvt?.report_num);
+                    const hasBusinessReportNum = Number.isInteger(businessReportNum) && businessReportNum > 0;
+                    // 台风 / 海啸多报：用序号；地震等业务报次若与序号一致或每报不同，仍可用业务号，
+                    // 但当多行业务号撞车时强制回退序号。
+                    const useSequenceLabel = isTyphoonGroup
+                        || groupType === 'tsunami'
+                        || !hasBusinessReportNum;
+                    const displayReportNum = useSequenceLabel ? sequenceNum : businessReportNum;
+                    // 统一写「第 X 报」；海啸业务号不同时另注业务报数
+                    const reportLabelText = typeof formatReportLabel === 'function'
+                        ? formatReportLabel(displayReportNum)
+                        : `第 ${displayReportNum} 报`;
+                    const businessHint = (groupType === 'tsunami'
+                        && hasBusinessReportNum
+                        && businessReportNum !== sequenceNum)
+                        ? (typeof formatReportLabel === 'function'
+                            ? formatReportLabel(businessReportNum)
+                            : `第 ${businessReportNum} 报`)
+                        : '';
+
+                    // 展示时间：优先本报更新时间
+                    const displayTime = typeof getDisplayTimeValue === 'function'
+                        ? getDisplayTimeValue(mergedEvt, true)
+                        : (mergedEvt.time || mergedEvt.timestamp || '');
 
                     return (
                         <div
                             key={idx}
                             className={`event-group-timeline-item ${idx === group.events.length - 1 ? 'is-last' : ''}`}
                         >
-                            {/* 时间线节点小圆点 */}
                             <div className={`event-group-timeline-dot ${isLatest ? 'is-latest' : ''}`}></div>
-                            
-                            {/* 单期报告内容排版行 */}
-                            <div className="event-group-timeline-row">
-                                {/* 若是地震类型，渲染对应的烈度徽标 */}
-                                {isEarthquake && <IntensityBadge meta={rowBadgeMeta} />}
-                                
+
+                            <div className="event-group-timeline-row event-group-timeline-row--card">
                                 <div className="event-group-timeline-main">
-                                    {/* 报告数、最新标及发生时间 */}
+                                    {/* 更新序号 + 业务报次提示 + 最新标 + 时间 */}
                                     <div className="event-group-timeline-meta-row">
                                         <span className={`event-group-report-chip ${isLatest ? 'is-latest' : ''}`}>
-                                            第 {displayReportNum} 报
+                                            {reportLabelText}
                                         </span>
+                                        {businessHint ? (
+                                            <span className="event-group-business-chip" title="源站业务报次">
+                                                业务报数 {businessHint}
+                                            </span>
+                                        ) : null}
                                         {isLatest && <span className="event-group-latest-chip">最新</span>}
                                         <Typography variant="body2" className="event-group-time-text">
-                                            🕒 {formatTimeFriendly(getDisplayTimeValue(evt, true), displayTimezone, evt.source || group.latestEvent.source || '')}
+                                            🕒 {formatTimeFriendly(
+                                                displayTime,
+                                                displayTimezone,
+                                                mergedEvt.source || group.latestEvent.source || ''
+                                            )}
                                         </Typography>
                                     </div>
-                                    
-                                    {/* 地震专用数值参数区（震级、深度） */}
-                                    {isEarthquake && (
-                                        <div className="event-group-quake-details">
-                                            <Typography variant="body2" className="event-group-quake-text event-group-quake-text--strong">
-                                                震级: {rowMagnitudeText !== '--' ? `M ${rowMagnitudeText}` : '调查中'}
-                                            </Typography>
-                                            <Typography variant="body2" className="event-group-quake-text">
-                                                深度: {(rowDepth !== undefined && rowDepth !== null) ? `${rowDepth} km` : '未知'}
-                                            </Typography>
-                                        </div>
-                                    )}
 
-                                    {/* 台风专用路径点参数区（强度、位置、最大风速、气压） */}
-                                    {isTyphoon && (
-                                        <div className="event-group-typhoon-details">
-                                            <Typography variant="body2" className="event-group-typhoon-text event-group-typhoon-text--strong" style={typhoonLevelColor ? { color: typhoonLevelColor } : undefined}>
-                                                {typhoonLevelEmoji} {typhoonLevel || '未知等级'}
-                                            </Typography>
-                                            {typhoonCoords && (
-                                                <Typography variant="body2" className="event-group-typhoon-text">
-                                                    中心位置: ({typhoonCoords})
-                                                </Typography>
-                                            )}
-                                            {Number.isFinite(typhoonWind) && typhoonWind > 0 && (
-                                                <Typography variant="body2" className="event-group-typhoon-text">
-                                                    最大风速: {typhoonWind.toFixed(1)} m/s
-                                                </Typography>
-                                            )}
-                                            {typhoonPressure != null && typhoonPressure > 0 && (
-                                                <Typography variant="body2" className="event-group-typhoon-text">
-                                                    中心气压: {typhoonPressure} hPa
-                                                </Typography>
-                                            )}
-                                        </div>
-                                    )}
+                                    {/* 复用主卡片同款 EventCard，展示完整 chips / sections / 深度等。
+                                        报次已在上方 chip 展示，这里不再重复 reportIndex。 */}
+                                    <div className="event-group-history-card-wrap">
+                                        <EventCard
+                                            event={{
+                                                ...mergedEvt,
+                                                // 避免 EventCard 再读 report_num 重复画「第N报」
+                                                report_num: null,
+                                            }}
+                                            displayTimezone={displayTimezone}
+                                            isHistory={true}
+                                            isExpandable={false}
+                                            isExpanded={true}
+                                            reportIndex={null}
+                                            hideExpandBadge={true}
+                                        />
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     );
                 })}
             </div>
-        </div>
-    );
-}
-
-/**
- * 局部时序烈度徽标子组件 (IntensityBadge)
- *
- * @param {Object} props
- * @param {Object} props.meta 包含 label (机构) 与 text (烈度数值/符号) 的配置
- */
-function IntensityBadge({ meta }) {
-    const toneClass = meta?.toneClass ? `event-badge-tone-${meta.toneClass}` : 'event-badge-tone-unknown';
-    return (
-        <div className={`event-group-intensity-badge ${toneClass}`}>
-            <span className="event-group-intensity-label">{meta.label}</span>
-            <span className="event-group-intensity-value">{meta.text}</span>
         </div>
     );
 }

--- a/admin/js/components/events/EventGroupTimeline.jsx
+++ b/admin/js/components/events/EventGroupTimeline.jsx
@@ -7,13 +7,13 @@ const { Typography } = MaterialUI;
  *
  * 海啸/气象/地震/台风统一复用 EventCard 渲染各报详情，
  * 使历史报与主卡片信息密度一致（chips / sections / 深度等）。
+ * 收起由顶部主卡片统一提供，本组件不再接收 onCollapse。
  *
  * @param {Object} props
  * @param {Object} props.group 包含同一事件关联的 events 列表与最新一条 event 记录的分组数据
  * @param {string} props.displayTimezone 全局配置的时区，如 'UTC+8'
- * @param {Function} props.onCollapse 折叠收起该面板的回调函数
  */
-function EventGroupTimeline({ group, displayTimezone, onCollapse }) {
+function EventGroupTimeline({ group, displayTimezone }) {
     const formatters = window.EventFormatters || {};
     const {
         getDisplayTimeValue,
@@ -45,15 +45,15 @@ function EventGroupTimeline({ group, displayTimezone, onCollapse }) {
                     || null));
 
         return {
-            // 先铺父级身份字段，再覆盖本报快照
+            // 先铺本报快照，再显式写身份/状态字段，避免 ...evt 中的 null/'' 冲掉父级身份
+            ...evt,
+            // 身份字段：本报有值用本报，否则继承最新主事件
             source: evt.source || latest.source,
             source_id: evt.source_id || latest.source_id || latest.source,
             type: evt.type || latest.type,
             info_type: evt.info_type || latest.info_type,
             weather_type_code: evt.weather_type_code || latest.weather_type_code,
             icon_url: evt.icon_url || latest.icon_url,
-            // 本报快照字段优先
-            ...evt,
             description: hasOwn('description') ? evt.description : (isLatestRow ? latest.description : (evt.description || '')),
             subtitle: hasOwn('subtitle') ? evt.subtitle : (isLatestRow ? latest.subtitle : (evt.subtitle || '')),
             level: hasOwn('level') ? evt.level : (isLatestRow ? latest.level : (evt.level || '')),
@@ -179,20 +179,17 @@ function EventGroupTimeline({ group, displayTimezone, onCollapse }) {
                                     </div>
 
                                     {/* 复用主卡片同款 EventCard，展示完整 chips / sections / 深度等。
-                                        报次已在上方 chip 展示，这里不再重复 reportIndex。 */}
+                                        报次已在上方 chip 展示；hideReportBadge 禁止 batch 回退再画徽章。 */}
                                     <div className="event-group-history-card-wrap">
                                         <EventCard
-                                            event={{
-                                                ...mergedEvt,
-                                                // 避免 EventCard 再读 report_num 重复画「第N报」
-                                                report_num: null,
-                                            }}
+                                            event={mergedEvt}
                                             displayTimezone={displayTimezone}
                                             isHistory={true}
                                             isExpandable={false}
                                             isExpanded={true}
                                             reportIndex={null}
                                             hideExpandBadge={true}
+                                            hideReportBadge={true}
                                         />
                                     </div>
                                 </div>

--- a/admin/js/components/events/EventsList.jsx
+++ b/admin/js/components/events/EventsList.jsx
@@ -226,15 +226,18 @@ function EventsList() {
                                 const isExpanded = expandedEvents.has(group.id);
                                 const latestType = String(group.latestEvent?.type || '').toLowerCase();
                                 const weatherDetail = String(group.latestEvent?.weather_detail || '').trim();
+                                // 与 EventCard 对齐：earthquake / earthquake_warning 均可展开情报正文
+                                const isEarthquakeType = latestType === 'earthquake'
+                                    || latestType === 'earthquake_warning';
                                 // 气象可回退 description；地震仅认 weather_detail，避免标题误当正文
                                 const detailBody = latestType === 'weather_alarm'
                                     ? (weatherDetail || String(group.latestEvent?.description || '').trim())
-                                    : weatherDetail;
+                                    : (isEarthquakeType ? weatherDetail : '');
                                 // 多报更新：真正的同源折叠
                                 // 气象预警 / 地震情报补充正文：额外提供正文展开语义
                                 const hasMultiReport = group.updateCount > 1;
                                 const canExpandDetail = (
-                                    (latestType === 'weather_alarm' || latestType === 'earthquake')
+                                    (latestType === 'weather_alarm' || isEarthquakeType)
                                     && !!detailBody
                                     && !hasMultiReport
                                 );
@@ -245,12 +248,26 @@ function EventsList() {
                                     _groupType: group.latestEvent.type,
                                     _groupMagnitude: group.latestEvent.magnitude,
                                 };
+                                const toggleGroup = () => toggleEventGroup(group.id);
+                                const onExpandKeyDown = (e) => {
+                                    if (!isExpandable) return;
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        toggleGroup();
+                                    }
+                                };
 
                                 return (
                                     <div key={group.id} className="event-group">
                                         {/* 折叠收起形态：展示带有多报更新数量 / 正文入口的事件概要卡片 */}
                                         <Collapse in={!isExpanded} timeout={220} unmountOnExit>
-                                            <div onClick={() => isExpandable && toggleEventGroup(group.id)}>
+                                            <div
+                                                role={isExpandable ? 'button' : undefined}
+                                                tabIndex={isExpandable ? 0 : undefined}
+                                                aria-expanded={isExpandable ? false : undefined}
+                                                onClick={() => isExpandable && toggleGroup()}
+                                                onKeyDown={onExpandKeyDown}
+                                            >
                                                 <EventCard
                                                     event={cardEvent}
                                                     displayTimezone={displayTimezone}
@@ -265,7 +282,16 @@ function EventsList() {
                                             <div className={`event-group-expanded-shell ${hasMultiReport ? 'has-timeline' : 'is-detail-only'}`}>
                                                 <div
                                                     className="event-group-sticky-card"
-                                                    onClick={() => toggleEventGroup(group.id)}
+                                                    role="button"
+                                                    tabIndex={0}
+                                                    aria-expanded={true}
+                                                    onClick={toggleGroup}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter' || e.key === ' ') {
+                                                            e.preventDefault();
+                                                            toggleGroup();
+                                                        }
+                                                    }}
                                                 >
                                                     <EventCard
                                                         event={cardEvent}
@@ -280,7 +306,6 @@ function EventsList() {
                                                         <EventGroupTimeline
                                                             group={group}
                                                             displayTimezone={displayTimezone}
-                                                            onCollapse={() => toggleEventGroup(group.id)}
                                                         />
                                                     </div>
                                                 )}

--- a/admin/js/components/events/EventsList.jsx
+++ b/admin/js/components/events/EventsList.jsx
@@ -224,32 +224,67 @@ function EventsList() {
                         <div className="events-list">
                             {groupedEvents.map((group) => {
                                 const isExpanded = expandedEvents.has(group.id);
+                                const latestType = String(group.latestEvent?.type || '').toLowerCase();
+                                const weatherDetail = String(group.latestEvent?.weather_detail || '').trim();
+                                // 气象可回退 description；地震仅认 weather_detail，避免标题误当正文
+                                const detailBody = latestType === 'weather_alarm'
+                                    ? (weatherDetail || String(group.latestEvent?.description || '').trim())
+                                    : weatherDetail;
+                                // 多报更新：真正的同源折叠
+                                // 气象预警 / 地震情报补充正文：额外提供正文展开语义
+                                const hasMultiReport = group.updateCount > 1;
+                                const canExpandDetail = (
+                                    (latestType === 'weather_alarm' || latestType === 'earthquake')
+                                    && !!detailBody
+                                    && !hasMultiReport
+                                );
+                                const isExpandable = hasMultiReport || canExpandDetail;
+                                const cardEvent = {
+                                    ...group.latestEvent,
+                                    updateCount: group.updateCount,
+                                    _groupType: group.latestEvent.type,
+                                    _groupMagnitude: group.latestEvent.magnitude,
+                                };
+
                                 return (
                                     <div key={group.id} className="event-group">
-                                        {/* 折叠收起形态：展示带有多报更新数量的事件概要卡片 */}
+                                        {/* 折叠收起形态：展示带有多报更新数量 / 正文入口的事件概要卡片 */}
                                         <Collapse in={!isExpanded} timeout={220} unmountOnExit>
-                                            <div onClick={() => group.updateCount > 1 && toggleEventGroup(group.id)}>
+                                            <div onClick={() => isExpandable && toggleEventGroup(group.id)}>
                                                 <EventCard
-                                                    event={{
-                                                        ...group.latestEvent,
-                                                        updateCount: group.updateCount,
-                                                        _groupType: group.latestEvent.type,
-                                                        _groupMagnitude: group.latestEvent.magnitude,
-                                                    }}
+                                                    event={cardEvent}
                                                     displayTimezone={displayTimezone}
-                                                    isExpandable={group.updateCount > 1}
+                                                    isExpandable={hasMultiReport}
                                                     isExpanded={false}
                                                 />
                                             </div>
                                         </Collapse>
 
-                                        {/* 展开形态：展示垂直时间线历史追踪面板 */}
+                                        {/* 展开形态：单一连续卡片壳 = 顶部事件摘要 + 下方时间线 / 正文 */}
                                         <Collapse in={isExpanded} timeout={260} unmountOnExit>
-                                            <EventGroupTimeline
-                                                group={group}
-                                                displayTimezone={displayTimezone}
-                                                onCollapse={() => toggleEventGroup(group.id)}
-                                            />
+                                            <div className={`event-group-expanded-shell ${hasMultiReport ? 'has-timeline' : 'is-detail-only'}`}>
+                                                <div
+                                                    className="event-group-sticky-card"
+                                                    onClick={() => toggleEventGroup(group.id)}
+                                                >
+                                                    <EventCard
+                                                        event={cardEvent}
+                                                        displayTimezone={displayTimezone}
+                                                        isExpandable={hasMultiReport}
+                                                        isExpanded={true}
+                                                        hideExpandBadge={false}
+                                                    />
+                                                </div>
+                                                {hasMultiReport && (
+                                                    <div className="event-group-timeline-section">
+                                                        <EventGroupTimeline
+                                                            group={group}
+                                                            displayTimezone={displayTimezone}
+                                                            onCollapse={() => toggleEventGroup(group.id)}
+                                                        />
+                                                    </div>
+                                                )}
+                                            </div>
                                         </Collapse>
                                     </div>
                                 );

--- a/admin/js/utils/eventFormatters.js
+++ b/admin/js/utils/eventFormatters.js
@@ -386,13 +386,110 @@
     }
 
     /**
+     * 从文本中剥离内嵌报数标记，例如「（第3报）」「(第 3 报)」。
+     * 列表标题旁已有独立报数徽章，避免标题与徽章两套语义打架。
+     */
+    function stripEmbeddedReportToken(text) {
+        const raw = String(text || '').trim();
+        if (!raw) return '';
+        return raw
+            .replace(/[（(]\s*第\s*\d+\s*报\s*[）)]/g, '')
+            .replace(/\s{2,}/g, ' ')
+            .replace(/\s*·\s*$/g, '')
+            .trim();
+    }
+
+    /**
+     * 从 description / weather_detail / batch 字段尽力解析业务报次。
+     */
+    function extractReportNumFromText(text) {
+        const raw = String(text || '').trim();
+        if (!raw) return null;
+        const match = raw.match(/第\s*(\d+)\s*[报批]/)
+            || raw.match(/批次\s*(\d+)/)
+            || raw.match(/(?:^|[^\d])(\d+)\s*报/);
+        if (!match) return null;
+        const num = Number(match[1]);
+        return Number.isInteger(num) && num > 0 ? num : null;
+    }
+
+    /**
+     * 从事件对象提取业务 batch 报次（不含系统 update_count）。
+     */
+    function resolveBusinessBatchNum(evt) {
+        if (!evt || typeof evt !== 'object') return null;
+        const batchCandidates = [
+            evt.batch,
+            evt.Batch,
+            evt.weather_detail,
+            // 旧 description 可能内嵌「（第3报）」；新标题已剥离，但仍兼容历史数据
+            evt.description,
+            evt.subtitle,
+        ];
+        for (const candidate of batchCandidates) {
+            if (candidate === null || candidate === undefined || candidate === '') continue;
+            const asNum = Number(candidate);
+            if (Number.isInteger(asNum) && asNum > 0) return asNum;
+            const parsed = extractReportNumFromText(candidate);
+            if (parsed) return parsed;
+        }
+        return null;
+    }
+
+    /**
+     * 统一解析事件展示用报次。
+     *
+     * 语义：
+     * - 地震等：report_num 即业务报次
+     * - 海啸：report_num 应为业务 batch；旧数据可能被错误写成 update_count，
+     *   因此海啸优先读 batch / weather_detail 中的业务报次，再回退 report_num
+     * - update_count 只表示系统合并次数，用于「N 条更新」，不进徽章
+     *
+     * 优先级：显式 override >（海啸业务 batch）> report_num > 文本回退
+     */
+    function resolveEventReportNum(evt, override = null) {
+        if (override !== null && override !== undefined && override !== '') {
+            const forced = Number(override);
+            if (Number.isInteger(forced) && forced > 0) return forced;
+        }
+        if (!evt || typeof evt !== 'object') return null;
+
+        const eventType = String(evt.type || evt._groupType || '').toLowerCase();
+        const isTsunami = eventType === 'tsunami';
+
+        if (isTsunami) {
+            const businessBatch = resolveBusinessBatchNum(evt);
+            if (businessBatch) return businessBatch;
+        }
+
+        const direct = Number(evt.report_num);
+        if (Number.isInteger(direct) && direct > 0) return direct;
+
+        if (!isTsunami) {
+            const fallbackBatch = resolveBusinessBatchNum(evt);
+            if (fallbackBatch) return fallbackBatch;
+        }
+        return null;
+    }
+
+    /**
+     * 格式化「第 N 报」展示文案。
+     */
+    function formatReportLabel(reportNum) {
+        const num = Number(reportNum);
+        if (!Number.isInteger(num) || num <= 0) return '';
+        return `第 ${num} 报`;
+    }
+
+    /**
      * 构建海啸列表主标题。
      * 优先用后端新 description；若是旧「海啸信息 (信息)」则用结构化字段重拼。
+     * 注意：标题内不再附带「（第N报）」，报次统一由卡片徽章展示，避免与 report_num 冲突。
      */
     function buildTsunamiTitle(evt) {
         if (!evt || typeof evt !== 'object') return '海啸情报';
 
-        const description = cleanTsunamiText(evt.description);
+        const description = stripEmbeddedReportToken(cleanTsunamiText(evt.description));
         const level = cleanTsunamiText(evt.level);
         const place = resolveTsunamiPlaceName(evt);
         const magToken = formatTsunamiMagnitudeToken(evt);
@@ -571,12 +668,23 @@
         const depthRaw = evt.depth;
         if (depthRaw !== null && depthRaw !== undefined && depthRaw !== '') {
             const depthNum = Number(depthRaw);
-            if (Number.isFinite(depthNum)) {
-                const depthText = Number.isInteger(depthNum) ? `${depthNum}` : String(depthNum);
-                pushChip('depth', '⬇️', `深度 ${depthText}km`, 'default');
+            // 合法深度 >= 0；负数（调查中占位）不展示；0 映射为极浅
+            if (Number.isFinite(depthNum) && depthNum >= 0) {
+                const depthText = depthNum === 0
+                    ? '极浅'
+                    : `${Number.isInteger(depthNum) ? depthNum : depthNum}km`;
+                pushChip('depth', '⬇️', `深度 ${depthText}`, 'default');
             }
         } else if (parsed.depthText) {
-            pushChip('depth', '⬇️', `深度 ${parsed.depthText}`, 'default');
+            const parsedDepthNum = Number(String(parsed.depthText).replace(/km/i, ''));
+            if (Number.isFinite(parsedDepthNum) && parsedDepthNum >= 0) {
+                pushChip(
+                    'depth',
+                    '⬇️',
+                    parsedDepthNum === 0 ? '深度 极浅' : `深度 ${parsed.depthText}`,
+                    'default',
+                );
+            }
         }
 
         // 波高：结构化字段优先，再回退 weather_detail
@@ -617,9 +725,7 @@
             pushChip('stations', '📡', `监测站 ${parsed.stationCount}`, 'station');
         }
 
-        if (parsed.batchText) {
-            pushChip('batch', '#️⃣', `第${parsed.batchText}报`.replace(/^第第/, '第'), 'default');
-        }
+        // 报次统一由卡片标题旁徽章展示，chip 区不再重复「第N报」，避免与 report_num 冲突。
 
         if (evt.is_cancelled || evt.cancelled || cleanTsunamiText(evt.level) === '解除') {
             pushChip('cancelled', '✅', '已解除', 'cancel');
@@ -852,6 +958,11 @@
         normalizeBadgeToneToken,
         getEarthquakeBadgeContent,
         buildEarthquakeTitle,
+        stripEmbeddedReportToken,
+        extractReportNumFromText,
+        resolveBusinessBatchNum,
+        resolveEventReportNum,
+        formatReportLabel,
         isGenericTsunamiTitle,
         isLegacyTsunamiDescription,
         resolveTsunamiRegion,

--- a/admin/js/utils/eventFormatters.js
+++ b/admin/js/utils/eventFormatters.js
@@ -415,9 +415,11 @@
 
     /**
      * 从事件对象提取业务 batch 报次（不含系统 update_count）。
+     * 纯数字限制 1～999，避免时间戳/事件 ID 被误当成报次。
      */
     function resolveBusinessBatchNum(evt) {
         if (!evt || typeof evt !== 'object') return null;
+        const MAX_BUSINESS_BATCH = 999;
         const batchCandidates = [
             evt.batch,
             evt.Batch,
@@ -429,9 +431,11 @@
         for (const candidate of batchCandidates) {
             if (candidate === null || candidate === undefined || candidate === '') continue;
             const asNum = Number(candidate);
-            if (Number.isInteger(asNum) && asNum > 0) return asNum;
+            if (Number.isInteger(asNum) && asNum >= 1 && asNum <= MAX_BUSINESS_BATCH) {
+                return asNum;
+            }
             const parsed = extractReportNumFromText(candidate);
-            if (parsed) return parsed;
+            if (parsed && parsed >= 1 && parsed <= MAX_BUSINESS_BATCH) return parsed;
         }
         return null;
     }
@@ -669,6 +673,7 @@
         if (depthRaw !== null && depthRaw !== undefined && depthRaw !== '') {
             const depthNum = Number(depthRaw);
             // 合法深度 >= 0；负数（调查中占位）不展示；0 映射为极浅
+            // 文案与 EventCard 地震芯片统一为「Nkm / 极浅」
             if (Number.isFinite(depthNum) && depthNum >= 0) {
                 const depthText = depthNum === 0
                     ? '极浅'
@@ -678,12 +683,10 @@
         } else if (parsed.depthText) {
             const parsedDepthNum = Number(String(parsed.depthText).replace(/km/i, ''));
             if (Number.isFinite(parsedDepthNum) && parsedDepthNum >= 0) {
-                pushChip(
-                    'depth',
-                    '⬇️',
-                    parsedDepthNum === 0 ? '深度 极浅' : `深度 ${parsed.depthText}`,
-                    'default',
-                );
+                const depthText = parsedDepthNum === 0
+                    ? '极浅'
+                    : `${Number.isInteger(parsedDepthNum) ? parsedDepthNum : parsedDepthNum}km`;
+                pushChip('depth', '⬇️', `深度 ${depthText}`, 'default');
             }
         }
 

--- a/core/domain/event_context.py
+++ b/core/domain/event_context.py
@@ -65,6 +65,8 @@ class EarthquakeDisplayContext:
     jma_comment: str | None = None
     jma_warning_areas: list[str] = field(default_factory=list)
     jma_warning_area_ranges: list[str] = field(default_factory=list)
+    # 按震度档汇总的警报区域：[{range_text, scale_from, emoji, areas:[...]}, ...]
+    jma_warning_area_groups: list[dict[str, Any]] = field(default_factory=list)
     # display_model 是已经进一步整理好的展示结果，可供下游直接使用。
     display_model: EarthquakeDisplayModel | None = None
     # metadata 放补充信息，options 放展示阶段的可选控制参数。

--- a/core/domain/tsunami/__init__.py
+++ b/core/domain/tsunami/__init__.py
@@ -29,6 +29,7 @@ from .tsunami_title import (
     format_tsunami_magnitude_token,
     is_generic_tsunami_title,
     is_legacy_tsunami_description,
+    parse_tsunami_batch_num,
 )
 
 __all__ = [
@@ -49,6 +50,7 @@ __all__ = [
     "is_generic_tsunami_title",
     "is_legacy_tsunami_description",
     "jp_tsunami_level_weight",
+    "parse_tsunami_batch_num",
     "normalize_cn_tsunami_level",
     "normalize_jp_tsunami_level",
     "normalize_jma_tsunami_areas",

--- a/core/domain/tsunami/jma_tsunami_normalize.py
+++ b/core/domain/tsunami/jma_tsunami_normalize.py
@@ -190,13 +190,14 @@ def build_jma_tsunami_content_fingerprint(
     areas: list[dict[str, Any]] | None = None,
     is_training: bool = False,
 ) -> str:
-    """构建跨源内容指纹（等级 + 区域核心字段）。
+    """构建同源内容指纹（事件身份 + 等级 + 区域核心字段）。
 
-    注意：P2P 与 EQSC 的 event_id 生成策略不同（回退组合键 vs 官方 eventID），
-    因此跨源去重指纹**故意不纳入 event_id**，避免同内容被拆成两条独立事件。
-    event_id 参数保留仅为兼容旧调用方，不参与哈希。
+    用于同源去重：同一数据源内，内容未变化时过滤重复推送。
+    P2P 与 EQSC 各自独立推送，不再做跨源去重。
+
+    event_id 必须参与指纹：解除报 areas 通常为空，若不含事件身份，
+    不同事件的解除会撞成同一指纹，导致后续解除通知被误杀。
     """
-    del event_id  # 跨源一致性：不参与指纹
     area_rows: list[dict[str, Any]] = []
     for area in areas or []:
         if not isinstance(area, dict):
@@ -217,6 +218,7 @@ def build_jma_tsunami_content_fingerprint(
         key=lambda row: (row["name"], row["grade"], row["condition"], row["height"])
     )
     payload = {
+        "event_id": _clean_text(event_id),
         "cancelled": bool(cancelled),
         "max_grade": _normalize_grade(max_grade, cancelled=cancelled),
         "is_training": bool(is_training),

--- a/core/domain/tsunami/tsunami_title.py
+++ b/core/domain/tsunami/tsunami_title.py
@@ -170,12 +170,15 @@ def parse_tsunami_batch_num(batch: Any) -> int | None:
     """解析海啸业务报次为整数。
 
     支持：
-    - 纯数字：3 / "3" / 3.0
+    - 纯数字：3 / "3" / 3.0（限制 1～999，避免时间戳/事件 ID 误当报次）
     - 中文报次：第3报 / 第 3 报 / 第3批
     - 摘要片段：批次 3
 
     无法解析时返回 None（不是系统 update_count）。
     """
+    # 业务报次合理上限：超过则视为非报次标识（时间戳、事件 ID 等）
+    _MAX_BUSINESS_BATCH = 999
+
     if batch is None:
         return None
     if isinstance(batch, bool):
@@ -185,15 +188,15 @@ def parse_tsunami_batch_num(batch: Any) -> int | None:
             number = int(batch)
         except (TypeError, ValueError):
             return None
-        return number if number > 0 else None
+        return number if 1 <= number <= _MAX_BUSINESS_BATCH else None
 
     text = _clean_text(batch)
     if not text:
         return None
-    # 纯数字
+    # 纯数字：同样限制上限
     try:
         number = int(float(text))
-        if number > 0:
+        if 1 <= number <= _MAX_BUSINESS_BATCH:
             return number
     except (TypeError, ValueError):
         pass
@@ -205,7 +208,7 @@ def parse_tsunami_batch_num(batch: Any) -> int | None:
         number = int(match.group(1))
     except (TypeError, ValueError):
         return None
-    return number if number > 0 else None
+    return number if 1 <= number <= _MAX_BUSINESS_BATCH else None
 
 
 def format_tsunami_batch_token(batch: Any) -> str:

--- a/core/domain/tsunami/tsunami_title.py
+++ b/core/domain/tsunami/tsunami_title.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from .tsunami_levels import (
@@ -165,21 +166,59 @@ def format_tsunami_magnitude_token(
     return f"{prefix}{mag_text}"
 
 
+def parse_tsunami_batch_num(batch: Any) -> int | None:
+    """解析海啸业务报次为整数。
+
+    支持：
+    - 纯数字：3 / "3" / 3.0
+    - 中文报次：第3报 / 第 3 报 / 第3批
+    - 摘要片段：批次 3
+
+    无法解析时返回 None（不是系统 update_count）。
+    """
+    if batch is None:
+        return None
+    if isinstance(batch, bool):
+        return None
+    if isinstance(batch, (int, float)):
+        try:
+            number = int(batch)
+        except (TypeError, ValueError):
+            return None
+        return number if number > 0 else None
+
+    text = _clean_text(batch)
+    if not text:
+        return None
+    # 纯数字
+    try:
+        number = int(float(text))
+        if number > 0:
+            return number
+    except (TypeError, ValueError):
+        pass
+
+    match = re.search(r"第\s*(\d+)\s*[报批]", text) or re.search(r"批次\s*(\d+)", text)
+    if not match:
+        return None
+    try:
+        number = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
 def format_tsunami_batch_token(batch: Any) -> str:
     """格式化批次/报次：第3报。"""
+    parsed = parse_tsunami_batch_num(batch)
+    if parsed is not None:
+        return f"第{parsed}报"
     text = _clean_text(batch)
     if not text:
         return ""
     # 已是“第n报/批”
     if text.startswith("第") and ("报" in text or "批" in text):
         return text
-    # 纯数字
-    try:
-        number = int(float(text))
-        if number > 0:
-            return f"第{number}报"
-    except (TypeError, ValueError):
-        pass
     return f"第{text}报"
 
 
@@ -222,7 +261,8 @@ def build_tsunami_list_title(
         place = ""
 
     mag_token = format_tsunami_magnitude_token(magnitude, region=region_key)
-    batch_token = format_tsunami_batch_token(batch) if region_key == "china" else ""
+    # 业务报次统一由卡片徽章展示，标题内不再内嵌「（第N报）」，避免与徽章语义打架。
+    batch_token = ""
 
     # 主段：级别
     head = level_label
@@ -377,4 +417,5 @@ __all__ = [
     "format_tsunami_magnitude_token",
     "is_generic_tsunami_title",
     "is_legacy_tsunami_description",
+    "parse_tsunami_batch_num",
 ]

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -466,7 +466,21 @@ class JmaEewPresenter(BasePresenter):
             coords = _format_coordinates(data.latitude, data.longitude)
             lines.append(f"📍震中：{data.title} ({coords})")
 
-        if data.magnitude is not None:
+        # PLUM/假定震源下 M1.0 为占位震级：优先读 metadata 标记，再兜底 is_assumption+≈1.0
+        magnitude_is_placeholder = bool(
+            (data.metadata or {}).get("magnitude_is_placeholder")
+        )
+        if (
+            not magnitude_is_placeholder
+            and data.is_assumption
+            and data.magnitude is not None
+            and abs(float(data.magnitude) - 1.0) < 0.05
+        ):
+            magnitude_is_placeholder = True
+
+        if magnitude_is_placeholder or (data.is_assumption and data.magnitude is None):
+            lines.append("📊震级：不明（PLUM法）")
+        elif data.magnitude is not None:
             lines.append(f"📊震级：M {data.magnitude:.1f}")
 
         if data.depth is not None:
@@ -491,7 +505,7 @@ class JmaEewPresenter(BasePresenter):
         display_context: EarthquakeDisplayContext,
         options: dict | None = None,
     ) -> str:
-        """展示速报，并拼装细分的警报覆盖县市与预估范围。"""
+        """展示速报，并按震度档汇总警报区域（方案 C）。"""
         rendered = cls.format_message(
             display_context, _resolve_options(display_context, options)
         )
@@ -500,45 +514,63 @@ class JmaEewPresenter(BasePresenter):
 
         lines = rendered.split("\n") if rendered else []
 
-        jma_warning_areas = display_context.jma_warning_areas
-        if (
-            isinstance(jma_warning_areas, list)
-            and jma_warning_areas
-            and not any(line.startswith("⚠️警报区域：") for line in lines)
-        ):
-            lines.append("⚠️警报区域：")
-            # 多区域场景按固定数量分行，避免单行过长影响阅读。
-            chunk_size = 3
-            for i in range(0, len(jma_warning_areas), chunk_size):
-                chunk = [
-                    str(item).strip()
-                    for item in jma_warning_areas[i : i + chunk_size]
-                    if str(item).strip()
+        # 按震度档汇总区域，替代旧的「预估震度范围」逐条输出
+        area_groups = getattr(display_context, "jma_warning_area_groups", None)
+        if not isinstance(area_groups, list) or not area_groups:
+            # 兼容旧 metadata / 未透传字段的路径
+            raw_groups = (display_context.metadata or {}).get("jma_warning_area_groups")
+            area_groups = raw_groups if isinstance(raw_groups, list) else []
+
+        has_group_block = False
+        if isinstance(area_groups, list) and area_groups:
+            group_lines: list[str] = []
+            for group in area_groups:
+                if not isinstance(group, dict):
+                    continue
+                range_text = str(group.get("range_text") or "").strip()
+                if not range_text:
+                    continue
+                emoji = str(group.get("emoji") or "").strip() or "⚪"
+                areas = [
+                    str(name).strip()
+                    for name in list(group.get("areas") or [])
+                    if str(name).strip()
                 ]
-                if chunk:
-                    lines.append("  " + "、".join(chunk))
+                if not areas:
+                    continue
+                group_lines.append(f"  {emoji} {range_text}：{'、'.join(areas)}")
 
-        jma_warn_area = display_context.jma_warn_area
-        if (
-            isinstance(jma_warn_area, str)
-            and jma_warn_area.strip()
-            and not any(line.startswith("⚠️警报区域：") for line in lines)
-        ):
-            lines.append(f"⚠️警报区域：{jma_warn_area.strip()}")
+            if group_lines:
+                lines.append("💥预估震度分布：")
+                lines.extend(group_lines)
+                has_group_block = True
 
-        jma_warning_area_ranges = display_context.jma_warning_area_ranges
-        if isinstance(jma_warning_area_ranges, list):
-            for shindo_range in jma_warning_area_ranges:
-                if (
-                    isinstance(shindo_range, str)
-                    and shindo_range.strip()
-                    and not any(
-                        line.startswith("💥预估震度范围：")
-                        and shindo_range.strip() in line
-                        for line in lines
-                    )
-                ):
-                    lines.append(f"💥预估震度范围：{shindo_range.strip()}")
+        # 无分组数据时回退到旧的警报区域列表展示
+        if not has_group_block:
+            jma_warning_areas = display_context.jma_warning_areas
+            if (
+                isinstance(jma_warning_areas, list)
+                and jma_warning_areas
+                and not any(line.startswith("⚠️警报区域：") for line in lines)
+            ):
+                lines.append("⚠️警报区域：")
+                chunk_size = 3
+                for i in range(0, len(jma_warning_areas), chunk_size):
+                    chunk = [
+                        str(item).strip()
+                        for item in jma_warning_areas[i : i + chunk_size]
+                        if str(item).strip()
+                    ]
+                    if chunk:
+                        lines.append("  " + "、".join(chunk))
+
+            jma_warn_area = display_context.jma_warn_area
+            if (
+                isinstance(jma_warn_area, str)
+                and jma_warn_area.strip()
+                and not any(line.startswith("⚠️警报区域：") for line in lines)
+            ):
+                lines.append(f"⚠️警报区域：{jma_warn_area.strip()}")
 
         _append_local_estimation(lines, display_context)
         return "\n".join(lines)

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -215,13 +215,14 @@ def _append_cn_district_estimation(
     lon = display_context.longitude
     mag = display_context.magnitude
     depth = display_context.depth
-    # 缺少必要参数时跳过
-    if lat is None or lon is None or mag is None or depth is None:
+    # 缺少位置或震级时无法估算；深度缺失时按 10 km 兜底
+    if lat is None or lon is None or mag is None:
         return
+    depth_km = float(depth) if depth is not None else 10.0
 
     try:
         estimates = CnDistrictIntensityService.estimate_affected_districts(
-            float(lat), float(lon), float(mag), float(depth)
+            float(lat), float(lon), float(mag), depth_km
         )
     except Exception:
         return

--- a/core/message/runtime/local_monitor.py
+++ b/core/message/runtime/local_monitor.py
@@ -77,13 +77,15 @@ class LocalMonitor:
 
         is_allowed, distance, intensity = self.check_event(earthquake)
 
-        # 基于震源深度与震中距估算 P/S 波预计到达时间
+        # 基于震源深度与震中距估算 P/S 波预计到达时间。
+        # 缺 depth时与本地烈度一致，按 10 km 兜底估算。
         depth = getattr(earthquake, "depth", None)
+        depth_km = float(depth) if depth is not None else 10.0
         p_travel_sec: float | None = None
         s_travel_sec: float | None = None
-        if depth is not None and distance > 0:
+        if distance > 0:
             try:
-                travel_result = TravelTimeService.lookup(float(depth), float(distance))
+                travel_result = TravelTimeService.lookup(depth_km, float(distance))
                 p_travel_sec = travel_result.p_travel_sec
                 s_travel_sec = travel_result.s_travel_sec
             except Exception as exc:

--- a/core/parsers/china_intensity_report_eqsc_parser.py
+++ b/core/parsers/china_intensity_report_eqsc_parser.py
@@ -8,6 +8,7 @@ EQSC CENC 烈度速报解析器。
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from typing import Any
 
 from ...utils.converters import safe_float_convert
@@ -254,15 +255,21 @@ class CencIntensityReportEqscParser(CencIntensityReportParser):
             )
             attrs.update(metadata)
             envelope.payload.attributes = attrs
-            # provider_family 以 catalog 为准
+            # provider_family / source_id 以 catalog 与本解析器为准
+            envelope.payload.source_id = self.source_id
             if self.source_entry is not None:
                 envelope.payload.provider_family = (
                     self.source_entry.provider_family.value
                 )
-        if envelope.identity is not None and self.source_entry is not None:
-            envelope.identity.source_id = self.source_id
-            envelope.identity.provider_family = self.source_entry.provider_family.value
-            envelope.identity.source_enum = self.source_entry.source_enum
+        # EventIdentity 为 frozen dataclass，必须用 replace 重建，不能原地赋值
+        if envelope.identity is not None:
+            identity_kwargs: dict[str, Any] = {"source_id": self.source_id}
+            if self.source_entry is not None:
+                identity_kwargs["provider_family"] = (
+                    self.source_entry.provider_family.value
+                )
+                identity_kwargs["source_enum"] = self.source_entry.source_enum
+            envelope.identity = replace(envelope.identity, **identity_kwargs)
         return envelope
 
     def _parse_data(self, data: dict[str, Any]):

--- a/core/parsers/japan_eew_parser.py
+++ b/core/parsers/japan_eew_parser.py
@@ -188,6 +188,17 @@ class JmaEewP2PParser(BaseParser):
             plugin_logger.error(f"[灾害预警] {self.source_id} 消息处理失败: {exc}")
             return None
 
+    @staticmethod
+    def _collect_p2p_area_scale_candidates(area: dict[str, Any]) -> list[int]:
+        """收集区域可用的 P2P 震度业务值，忽略占位值 99（以上）。"""
+        candidates: list[int] = []
+        for key in ("scaleFrom", "scaleTo"):
+            raw = ScaleConverter.normalize_p2p_scale_value(area.get(key))
+            if raw is None or raw <= 0 or raw == 99:
+                continue
+            candidates.append(raw)
+        return candidates
+
     def _parse_eew_data(self, data: dict[str, Any]) -> EventEnvelope | None:
         """解析紧急地震速报数据。"""
         try:
@@ -195,6 +206,8 @@ class JmaEewP2PParser(BaseParser):
             hypocenter = earthquake_info.get("hypocenter", {})
             issue_info = data.get("issue", {})
             areas = data.get("areas", [])
+            if not isinstance(areas, list):
+                areas = []
 
             # 最大震度可能直接给出，也可能需要从区域列表中推导
             max_scale_raw = -1
@@ -203,29 +216,24 @@ class JmaEewP2PParser(BaseParser):
             elif "max_scale" in earthquake_info:
                 max_scale_raw = earthquake_info.get("max_scale", -1)
             else:
-                raw_scales = []
+                raw_scales: list[int] = []
                 for area in areas:
                     if not isinstance(area, dict):
                         continue
-                    scale = (
-                        ScaleConverter.normalize_p2p_scale_value(area.get("scaleFrom"))
-                        or 0
-                    )
-                    if scale <= 0:
-                        scale = (
-                            ScaleConverter.normalize_p2p_scale_value(
-                                area.get("scaleTo")
-                            )
-                            or 0
-                        )
-                    if scale > 0:
-                        raw_scales.append(scale)
+                    candidates = self._collect_p2p_area_scale_candidates(area)
+                    if candidates:
+                        raw_scales.append(max(candidates))
 
                 max_scale_raw = max(raw_scales) if raw_scales else -1
                 if max_scale_raw > 0:
                     plugin_logger.warning(
                         f"[灾害预警] {self.source_id} 使用areas计算maxScale: {max_scale_raw}"
                     )
+
+            try:
+                max_scale_raw = int(max_scale_raw)
+            except (TypeError, ValueError):
+                max_scale_raw = -1
 
             scale = (
                 ScaleConverter.convert_p2p_scale(max_scale_raw)
@@ -276,6 +284,14 @@ class JmaEewP2PParser(BaseParser):
                         is_plum = True
                         break
 
+            # PLUM/假定震源下 M1.0 通常是占位震级，不应作为真实震级展示或参与过滤。
+            magnitude = safe_float_convert(hypocenter.get("magnitude"))
+            magnitude_is_placeholder = bool(
+                is_plum and magnitude is not None and abs(magnitude - 1.0) < 0.05
+            )
+            if magnitude_is_placeholder:
+                magnitude = None
+
             report_num = (
                 issue_info.get("serial", 1)
                 if isinstance(issue_info.get("serial"), int)
@@ -283,6 +299,9 @@ class JmaEewP2PParser(BaseParser):
             )
             warning_areas: list[str] = []
             warning_area_ranges: list[str] = []
+            # range_text -> 分组信息，用于「按震度档汇总区域」展示
+            area_groups: dict[str, dict[str, Any]] = {}
+
             # 日本预警区域列表会同时用于文本展示与影响范围提示，这里先归一化整理
             for area in areas:
                 if not isinstance(area, dict):
@@ -295,23 +314,42 @@ class JmaEewP2PParser(BaseParser):
                 range_text = ScaleConverter.format_p2p_scale_range(scale_from, scale_to)
                 emoji = ScaleConverter.get_p2p_scale_emoji(scale_from, scale_to)
 
-                max_area_scale = (
-                    max(value for value in (scale_from, scale_to) if value is not None)
-                    if scale_from is not None or scale_to is not None
-                    else None
-                )
+                scale_candidates = self._collect_p2p_area_scale_candidates(area)
+                max_area_scale = max(scale_candidates) if scale_candidates else None
+                # 若仅有 from + 99(以上)，仍按 from 作为档位键
+                if max_area_scale is None and scale_from is not None and scale_from > 0:
+                    max_area_scale = scale_from
 
                 # 震度在 4.5 (5弱) 及以上的警报区域需要保留进警报范围中
                 if area_name and max_area_scale is not None and max_area_scale >= 45:
                     kind = str(area.get("kindCode", "") or "").strip()
                     status = "已到达" if kind == "11" else "未到达"
-                    area_parts = [status]
+                    area_label = f"{area_name}({status})"
+                    warning_areas.append(f"{emoji}{area_label}")
+
                     if range_text:
-                        area_parts.append(f"震度{range_text}")
-                    warning_areas.append(f"{emoji}{area_name}({'・'.join(area_parts)})")
+                        group = area_groups.get(range_text)
+                        if group is None:
+                            group = {
+                                "range_text": range_text,
+                                "scale_from": scale_from
+                                if scale_from is not None
+                                else max_area_scale,
+                                "emoji": emoji,
+                                "areas": [],
+                            }
+                            area_groups[range_text] = group
+                        if area_label not in group["areas"]:
+                            group["areas"].append(area_label)
 
                 if range_text and range_text not in warning_area_ranges:
                     warning_area_ranges.append(range_text)
+
+            warning_area_groups = sorted(
+                area_groups.values(),
+                key=lambda item: int(item.get("scale_from") or 0),
+                reverse=True,
+            )
 
             source_entry = get_source_entry(self.source_id)
             metadata = {
@@ -327,8 +365,10 @@ class JmaEewP2PParser(BaseParser):
                 "info_type": "警报",
                 "is_training": bool(is_test),
                 "is_assumption": bool(is_plum),
+                "magnitude_is_placeholder": magnitude_is_placeholder,
                 "jma_warning_areas": warning_areas,
                 "jma_warning_area_ranges": warning_area_ranges,
+                "jma_warning_area_groups": warning_area_groups,
             }
 
             # 实例化地震预警领域模型
@@ -337,7 +377,7 @@ class JmaEewP2PParser(BaseParser):
                 latitude=safe_float_convert(hypocenter.get("latitude")),
                 longitude=safe_float_convert(hypocenter.get("longitude")),
                 depth=safe_float_convert(hypocenter.get("depth")),
-                magnitude=safe_float_convert(hypocenter.get("magnitude")),
+                magnitude=magnitude,
                 place_name=str(hypocenter.get("name", "未知地点") or "未知地点"),
                 scale=scale,
                 metadata=dict(metadata),
@@ -401,6 +441,38 @@ class JmaEewWolfxParser(BaseParser):
         """初始化 Wolfx 日本预警解析器。"""
         super().__init__("jma_wolfx", message_logger)
 
+    @staticmethod
+    def _normalize_wolfx_warn_areas(warn_area: Any) -> list[dict[str, Any]]:
+        """把 Wolfx WarnArea 统一规整为 dict 列表（兼容单对象与数组）。"""
+        if isinstance(warn_area, list):
+            return [item for item in warn_area if isinstance(item, dict)]
+        if isinstance(warn_area, dict):
+            return [warn_area]
+        return []
+
+    @staticmethod
+    def _format_wolfx_shindo_range(shindo1: Any, shindo2: Any) -> str:
+        """格式化 Wolfx 区域震度范围文本。"""
+        left = ScaleConverter.format_jma_cwa_scale_display(shindo1) if shindo1 else ""
+        right = ScaleConverter.format_jma_cwa_scale_display(shindo2) if shindo2 else ""
+        if left and right and left != right:
+            return f"{left} ～ {right}"
+        return left or right
+
+    @staticmethod
+    def _wolfx_area_sort_key(shindo1: Any, shindo2: Any) -> float:
+        """按区域震度高低排序，优先取较大档。"""
+        values: list[float] = []
+        for raw in (shindo1, shindo2):
+            parsed = (
+                ScaleConverter.parse_jma_cwa_scale(raw)
+                if raw not in (None, "")
+                else None
+            )
+            if parsed is not None:
+                values.append(parsed)
+        return max(values) if values else -1.0
+
     def _parse_data(self, data: dict[str, Any]) -> EventEnvelope | None:
         """解析 Wolfx 日本地震预警数据。"""
         try:
@@ -414,18 +486,104 @@ class JmaEewWolfxParser(BaseParser):
             report_num = (
                 data.get("Serial", 1) if isinstance(data.get("Serial"), int) else 1
             )
-            warn_area = data.get("WarnArea", {})
-            jma_warn_area = ""
+            warn_area_items = self._normalize_wolfx_warn_areas(data.get("WarnArea"))
+            warning_areas: list[str] = []
             warning_area_ranges: list[str] = []
-            if isinstance(warn_area, dict):
-                jma_warn_area = str(warn_area.get("Chiiki", "") or "").strip()
-                shindo1 = warn_area.get("Shindo1")
-                shindo2 = warn_area.get("Shindo2")
-                if shindo1:
-                    range_text = f"{shindo1}"
-                    if shindo2 and shindo2 != shindo1:
-                        range_text += f" ～ {shindo2}"
+            area_groups: dict[str, dict[str, Any]] = {}
+            info_type = ""
+            jma_warn_area = ""
+
+            for item in warn_area_items:
+                area_name = str(item.get("Chiiki", "") or "").strip()
+                area_type = str(item.get("Type", "") or "").strip()
+                shindo1 = item.get("Shindo1")
+                shindo2 = item.get("Shindo2")
+                range_text = self._format_wolfx_shindo_range(shindo1, shindo2)
+                scale_value = self._wolfx_area_sort_key(shindo1, shindo2)
+                emoji = "⚪"
+                if scale_value >= 0:
+                    # 复用 P2P emoji 阈值：把规范浮点值映射到相近业务档
+                    if scale_value >= 6.5:
+                        emoji = "🟣"
+                    elif scale_value >= 5.5:
+                        emoji = "🔴"
+                    elif scale_value >= 4.5:
+                        emoji = "🟠"
+                    elif scale_value >= 3.5:
+                        emoji = "🟡"
+                    elif scale_value >= 2.5:
+                        emoji = "🟢"
+                    elif scale_value >= 1.5:
+                        emoji = "🔵"
+
+                # 警报区域优先；无 Type 时按震度档兜底；≥5弱 的预报区也纳入分布
+                is_warning_type = area_type in {"警報", "警报"}
+                if is_warning_type:
+                    info_type = "警报"
+                elif not info_type and area_type:
+                    info_type = area_type
+
+                if area_name and (is_warning_type or scale_value >= 4.5):
+                    arrive_raw = item.get("Arrive")
+                    if isinstance(arrive_raw, bool):
+                        status = "已到达" if arrive_raw else "未到达"
+                    else:
+                        arrive_text = str(arrive_raw or "").strip()
+                        # Wolfx 常给 PLUM 说明字符串，无法判断到达时不硬编码
+                        if "到達" in arrive_text and "予測なし" not in arrive_text:
+                            status = "已到达"
+                        elif arrive_text:
+                            status = "未到达"
+                        else:
+                            status = ""
+                    area_label = f"{area_name}({status})" if status else area_name
+                    warning_areas.append(f"{emoji}{area_label}")
+
+                    if range_text:
+                        group = area_groups.get(range_text)
+                        if group is None:
+                            group = {
+                                "range_text": range_text,
+                                "scale_from": scale_value,
+                                "emoji": emoji,
+                                "areas": [],
+                            }
+                            area_groups[range_text] = group
+                        if area_label not in group["areas"]:
+                            group["areas"].append(area_label)
+
+                if range_text and range_text not in warning_area_ranges:
                     warning_area_ranges.append(range_text)
+
+            warning_area_groups = sorted(
+                area_groups.values(),
+                key=lambda item: float(item.get("scale_from") or 0),
+                reverse=True,
+            )
+            if warning_areas:
+                # 兼容旧字段：拼接区域名摘要
+                jma_warn_area = "、".join(
+                    str(item.get("Chiiki", "") or "").strip()
+                    for item in warn_area_items
+                    if str(item.get("Chiiki", "") or "").strip()
+                    and (
+                        str(item.get("Type", "") or "").strip() in {"警報", "警报"}
+                        or self._wolfx_area_sort_key(
+                            item.get("Shindo1"), item.get("Shindo2")
+                        )
+                        >= 4.5
+                    )
+                )
+
+            is_assumption = bool(data.get("isAssumption", False))
+            magnitude = safe_float_convert(
+                data.get("Magunitude") or data.get("Magnitude")
+            )
+            magnitude_is_placeholder = bool(
+                is_assumption and magnitude is not None and abs(magnitude - 1.0) < 0.05
+            )
+            if magnitude_is_placeholder:
+                magnitude = None
 
             source_entry = get_source_entry(self.source_id)
             metadata = {
@@ -437,15 +595,15 @@ class JmaEewWolfxParser(BaseParser):
                 "report_num": report_num,
                 "is_final": bool(data.get("isFinal", False)),
                 "is_cancel": bool(data.get("isCancel", False)),
-                "info_type": data.get("WarnArea", {}).get("Type", "")
-                if isinstance(data.get("WarnArea"), dict)
-                else "",
+                "info_type": info_type,
                 "is_training": bool(data.get("isTraining", False)),
-                "is_assumption": bool(data.get("isAssumption", False)),
+                "is_assumption": is_assumption,
+                "magnitude_is_placeholder": magnitude_is_placeholder,
                 "is_sea": bool(data.get("isSea", False)),
                 "jma_warn_area": jma_warn_area,
-                "jma_warning_areas": [jma_warn_area] if jma_warn_area else [],
+                "jma_warning_areas": warning_areas,
                 "jma_warning_area_ranges": warning_area_ranges,
+                "jma_warning_area_groups": warning_area_groups,
             }
 
             # 实例化地震领域模型
@@ -454,9 +612,7 @@ class JmaEewWolfxParser(BaseParser):
                 latitude=safe_float_convert(data.get("Latitude")),
                 longitude=safe_float_convert(data.get("Longitude")),
                 depth=safe_float_convert(data.get("Depth")),
-                magnitude=safe_float_convert(
-                    data.get("Magunitude") or data.get("Magnitude")
-                ),
+                magnitude=magnitude,
                 place_name=str(data.get("Hypocenter", "") or ""),
                 scale=ScaleConverter.parse_jma_cwa_scale(data.get("MaxIntensity", "")),
                 metadata=dict(metadata),

--- a/core/parsers/tsunami_parser.py
+++ b/core/parsers/tsunami_parser.py
@@ -423,7 +423,7 @@ class JmaTsunamiEqscParser(BaseParser):
     - 区域级 firstHeight.condition、maxHeight.description/value、immediate
     - isTraining / expiresAt / cancelled 状态位
 
-    解析目标：把上述字段完整落入 metadata / forecasts，供展示器与跨源去重复用。
+    解析目标：把上述字段完整落入 metadata / forecasts，供展示器与同源去重复用。
     """
 
     def __init__(self, message_logger=None):
@@ -584,7 +584,7 @@ class JmaTsunamiEqscParser(BaseParser):
             is_training = coerce_bool(data.get("isTraining"), default=False)
 
             # ---- 区域预报 ----
-            # 归一化后 forecasts 供展示器与跨源内容指纹共用
+            # 归一化后 forecasts 供展示器与同源内容指纹共用
             forecasts = normalize_jma_tsunami_areas(
                 data.get("areas", []), cancelled=cancelled
             )

--- a/core/rules/time_rule.py
+++ b/core/rules/time_rule.py
@@ -17,8 +17,9 @@ class EventTimeRule(BaseRule):
 
     rule_name = "time_rule"
 
-    def __init__(self, max_age_hours: float = 1.0):
-        # 默认限制历史事件时间距今不得超过 1 小时
+    def __init__(self, max_age_hours: float = 3.0):
+        # 默认限制历史事件时间距今不得超过 3 小时
+        # （CMT 等补充产品可能在发震后 1～2 小时才产出，1 小时阈值会误拦）
         self.max_age_hours = max_age_hours
 
     def evaluate(self, context: RuleContext) -> RuleDecision:

--- a/core/services/display/builders/earthquake_context_builder.py
+++ b/core/services/display/builders/earthquake_context_builder.py
@@ -103,6 +103,11 @@ def _extract_earthquake_projection_details(
         for area_range in list(metadata.get("jma_warning_area_ranges") or [])
         if str(area_range).strip()
     ]
+    jma_warning_area_groups = [
+        dict(group)
+        for group in list(metadata.get("jma_warning_area_groups") or [])
+        if isinstance(group, dict) and str(group.get("range_text") or "").strip()
+    ]
 
     return {
         "impact_area": impact_area,
@@ -112,6 +117,7 @@ def _extract_earthquake_projection_details(
         "jma_comment": jma_comment,
         "jma_warning_areas": jma_warning_areas,
         "jma_warning_area_ranges": jma_warning_area_ranges,
+        "jma_warning_area_groups": jma_warning_area_groups,
         # 预存的本地/网络 URI 地址
         "image_uri": str(metadata.get("image_uri") or "").strip(),
         "shakemap_uri": str(metadata.get("shakemap_uri") or "").strip(),
@@ -196,6 +202,9 @@ def build_earthquake_display_context(projection: dict, options: dict | None = No
         "jma_comment": jma_comment,
         "jma_warning_areas": list(payload_details["jma_warning_areas"]),
         "jma_warning_area_ranges": list(payload_details["jma_warning_area_ranges"]),
+        "jma_warning_area_groups": list(
+            payload_details.get("jma_warning_area_groups") or []
+        ),
     }
     if local_estimation is not None:
         # 本地烈度估算仅在存在时写入，避免污染不相关事件的展示元数据。
@@ -236,6 +245,9 @@ def build_earthquake_display_context(projection: dict, options: dict | None = No
         jma_comment=jma_comment,
         jma_warning_areas=list(payload_details["jma_warning_areas"]),
         jma_warning_area_ranges=list(payload_details["jma_warning_area_ranges"]),
+        jma_warning_area_groups=list(
+            payload_details.get("jma_warning_area_groups") or []
+        ),
         display_model=EarthquakeDisplayModel(
             title=title,
             extras=dict(display_metadata),

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -2,7 +2,8 @@
 EQSC JMA 海啸情报轮询服务。
 
 独立于 WebSocket 接入：周期性拉取 /jma_tsunami.json，
-经内容指纹去重后进入统一事件流水线，作为 P2P 津波予報的高优先级补充源。
+经同源内容指纹去重后进入统一事件流水线，作为 P2P 津波予報的高优先级补充源。
+各源独立推送，不再与 P2P 做跨源互斥。
 """
 
 from __future__ import annotations

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -47,10 +47,10 @@ class EventDeduplicationService:
         # 当同一台风的核心参数（等级、位置、风速、气压、移向移速、风圈半径）
         # 与上次推送完全一致时直接过滤，避免数据源刷屏。
         self._typhoon_cache: dict[str, str] = {}
-        # JMA 海啸跨源去重缓存：
-        # key = content_fingerprint
+        # JMA 海啸同源去重缓存：
+        # key = source_id|content_fingerprint
         # value = {"source_id", "priority", "event_id", "ts"}
-        # EQSC 优先级更高：同内容后到的低优先级源会被吞掉。
+        # 各源独立推送，不再跨源互斥；priority 仅作语义记录保留。
         # 带容量上限，防止长跑进程内存无限增长。
         self._tsunami_cache: dict[str, dict[str, Any]] = {}
         self._tsunami_cache_max_size = 512
@@ -324,9 +324,9 @@ class EventDeduplicationService:
         """跨源优先级去重公共实现。
 
         Args:
-            kind: 业务类别文案，如「海啸」「烈度速报」，用于日志前缀。
-            filter_same_source: 为 True 时，同优先级同源也过滤（适合内容指纹，
-                如海啸）。为 False 时同源放行给下游更新链路（适合粗软指纹，
+            kind: 业务类别文案，如「烈度速报」，用于日志前缀。
+            filter_same_source: 为 True 时，同优先级同源也过滤。
+                为 False 时同源放行给下游更新链路（适合粗软指纹，
                 如 CENC 烈度速报仅做跨源去重）。
 
         规则：
@@ -398,21 +398,19 @@ class EventDeduplicationService:
         return True
 
     def _should_push_tsunami(self, event: EventEnvelope) -> bool:
-        """JMA 海啸跨源去重：同内容指纹只推一次，EQSC 优先。
+        """JMA 海啸同源内容去重：各源独立推送，同内容只推一次。
 
-        规则：
-        1. 指纹未见过 → 放行并记录
-        2. 指纹相同且来源优先级 <= 已记录 → 过滤
-        3. 指纹相同但来源优先级更高（如 EQSC 后到）→ 放行并升级缓存
-           （用于 P2P 先到简报、EQSC 后到完整报的升级场景；
-            若内容完全一致，EQSC 后到仍会因指纹相同且 priority 更高而放行一次，
-            但解析器指纹已含区域细节，EQSC 通常会因更丰富字段产生不同指纹从而放行更新）
+        设计取舍：
+        - 不再做 P2P / EQSC 跨源互斥，便于双源互补与测试数据积累。
+        - catalog 中的 priority 语义仍保留并写入缓存，但不参与过滤决策。
+        - 同源同内容（含 event_id）未变化时过滤，避免轮询/重放刷屏。
+        - 解除报 areas 为空时依赖 event_id 区分不同事件，避免误杀后续解除。
         """
         if not isinstance(event.event, TsunamiEvent):
             return True
 
         source_id = self._get_source_id(event)
-        # 仅对日本海啸双源做跨源去重；中国海啸等保持放行
+        # 仅对日本海啸双源做同源内容去重；中国海啸等保持放行
         if source_id not in {"jma_tsunami_p2p", "jma_tsunami_eqsc"}:
             return True
 
@@ -420,15 +418,27 @@ class EventDeduplicationService:
         if not fingerprint:
             return True
 
-        return self._should_push_by_priority_fingerprint(
-            cache=self._tsunami_cache,
-            max_size=self._tsunami_cache_max_size,
-            fingerprint=fingerprint,
+        event_id = str(event.id or "")
+        # 同源隔离：不同源即使内容相同也各自放行
+        cache_key = f"{source_id}|{fingerprint}"
+        existing = self._tsunami_cache.get(cache_key)
+        if existing is not None:
+            plugin_logger.info(
+                f"[灾害预警] 海啸内容未变化，过滤重复推送: {source_id} "
+                f"(event={event_id})",
+                is_event_linked=True,
+            )
+            return False
+
+        # priority 仅作语义记录，不参与跨源过滤
+        priority = self._resolve_source_priority(source_id)
+        self._remember_tsunami_fingerprint(
+            cache_key,
             source_id=source_id,
-            event_id=str(event.id or ""),
-            kind="海啸",
-            log_level="info",
+            priority=priority,
+            event_id=event_id,
         )
+        return True
 
     @classmethod
     def _is_cenc_intensity_report_source(cls, source_id: str) -> bool:
@@ -553,22 +563,22 @@ class EventDeduplicationService:
         return True
 
     def _seed_tsunami(self, event: EventEnvelope) -> bool:
-        """播种海啸内容指纹。"""
+        """播种海啸同源内容指纹。"""
         if not isinstance(event.event, TsunamiEvent):
             return False
         source_id = self._get_source_id(event)
         fingerprint = self._extract_tsunami_fingerprint(event)
         if not fingerprint:
             return False
+        # 与推送路径一致：按源隔离，避免静默播种时跨源互相覆盖
+        cache_key = f"{source_id}|{fingerprint}"
         priority = self._resolve_source_priority(source_id)
-        existing = self._tsunami_cache.get(fingerprint)
-        if existing is None or priority >= int(existing.get("priority") or 0):
-            self._remember_tsunami_fingerprint(
-                fingerprint,
-                source_id=source_id,
-                priority=priority,
-                event_id=str(event.id or ""),
-            )
+        self._remember_tsunami_fingerprint(
+            cache_key,
+            source_id=source_id,
+            priority=priority,
+            event_id=str(event.id or ""),
+        )
         plugin_logger.debug(
             f"[灾害预警] 静默播种海啸指纹: {source_id} 事件 ID {event.id}"
         )
@@ -625,7 +635,7 @@ class EventDeduplicationService:
         """判断是否应该推送事件。
 
         台风事件走专用核心参数指纹去重链路，
-        海啸事件走 JMA 跨源内容指纹去重（EQSC 优先），
+        海啸事件走 JMA 同源内容指纹去重（各源独立推送），
         地震事件进入指纹与报次更新判定链路，
         其余非地震事件直接放行。
         """
@@ -636,7 +646,7 @@ class EventDeduplicationService:
         if isinstance(envelope.event, TyphoonEvent):
             return self._should_push_typhoon(envelope)
 
-        # 海啸事件：P2P / EQSC 跨源内容去重
+        # 海啸事件：P2P / EQSC 同源内容去重（不再跨源互斥）
         if isinstance(envelope.event, TsunamiEvent):
             return self._should_push_tsunami(envelope)
 

--- a/core/sources/source_catalog.py
+++ b/core/sources/source_catalog.py
@@ -711,7 +711,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         text_presenter_key="tsunami_jma",
         report_policy="none",
         intensity_mode="none",
-        # EQSC 字段更完整，优先级低于 EQSC（数值越大越优先）
+        # 字段完整度语义：低于 EQSC（数值越大越优先）；当前不做跨源互斥
         priority=1,
         display_name="日本气象厅",
         description="日本气象厅：津波予報 - P2P地震情报 WebSocket",
@@ -741,7 +741,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         text_presenter_key="tsunami_jma",
         report_policy="none",
         intensity_mode="none",
-        # 高于 P2P：字段更完整，跨源去重时优先保留 EQSC
+        # 高于 P2P：字段更完整；priority 语义保留，当前不做跨源互斥
         priority=3,
         display_name="日本气象厅",
         description="日本气象厅：津波予報 - EQSC HTTP 轮询（P2P 高优先级补充）",

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -575,25 +575,53 @@ class DatabaseManager:
         magnitude: Any = None,
         depth: Any = None,
         description: Any = None,
+        subtitle: Any = None,
+        weather_detail: Any = None,
+        place_name: Any = None,
         level: Any = None,
         wind_speed: Any = None,
         pressure: Any = None,
         latitude: Any = None,
         longitude: Any = None,
+        max_wave_height: Any = None,
+        area_count: Any = None,
+        immediate_area_count: Any = None,
+        is_cancelled: Any = None,
+        is_training: Any = None,
         time_value: Any = None,
     ) -> str:
-        """构建 event_updates 内容指纹，用于识别同内容重复写入。"""
+        """构建 event_updates 内容指纹，用于识别同内容重复写入。
+
+        除震级/深度/坐标等基础字段外，还需覆盖海啸/气象历史报详情字段，
+        避免仅 weather_detail / 波高 / 解除态变化时被误判为内容未变。
+        """
         return "|".join(
             [
                 cls._normalize_snapshot_value(report_num),
                 cls._normalize_snapshot_value(magnitude),
                 cls._normalize_snapshot_value(depth),
                 cls._normalize_snapshot_value(description),
+                cls._normalize_snapshot_value(subtitle),
+                cls._normalize_snapshot_value(weather_detail),
+                cls._normalize_snapshot_value(place_name),
                 cls._normalize_snapshot_value(level),
                 cls._normalize_snapshot_value(wind_speed),
                 cls._normalize_snapshot_value(pressure),
                 cls._normalize_snapshot_value(latitude),
                 cls._normalize_snapshot_value(longitude),
+                cls._normalize_snapshot_value(max_wave_height),
+                cls._normalize_snapshot_value(area_count),
+                cls._normalize_snapshot_value(immediate_area_count),
+                cls._normalize_snapshot_value(
+                    1
+                    if is_cancelled in (True, 1, "1")
+                    else (0 if is_cancelled in (False, 0, "0") else is_cancelled)
+                ),
+                cls._normalize_snapshot_value(
+                    1
+                    if is_training in (True, 1, "1")
+                    else (0 if is_training in (False, 0, "0") else is_training)
+                ),
                 cls._normalize_snapshot_value(time_value),
             ]
         )
@@ -755,7 +783,7 @@ class DatabaseManager:
                 update_snapshot_wind = event_data["_snapshot_wind_speed"]
                 update_snapshot_pressure = event_data["_snapshot_pressure"]
 
-            # Wolfx 列表轮询：与最近一条 updates 内容完全一致时不追加、不抬升 update_count
+            # 列表轮询 / 海啸重连补发：与最近一条 updates 内容完全一致时不追加、不抬升
             content_unchanged = False
             if self._should_dedupe_list_poll_update(source, event_data):
                 incoming_fp = self._build_update_content_fingerprint(
@@ -763,17 +791,27 @@ class DatabaseManager:
                     magnitude=event_data.get("magnitude"),
                     depth=event_data.get("depth"),
                     description=event_data.get("description"),
+                    subtitle=event_data.get("subtitle"),
+                    weather_detail=event_data.get("weather_detail"),
+                    place_name=event_data.get("place_name"),
                     level=update_snapshot_level,
                     wind_speed=update_snapshot_wind,
                     pressure=update_snapshot_pressure,
                     latitude=event_data.get("latitude"),
                     longitude=event_data.get("longitude"),
+                    max_wave_height=event_data.get("max_wave_height"),
+                    area_count=event_data.get("area_count"),
+                    immediate_area_count=event_data.get("immediate_area_count"),
+                    is_cancelled=event_data.get("is_cancelled"),
+                    is_training=event_data.get("is_training"),
                     time_value=event_data.get("time"),
                 )
                 await cursor.execute(
                     """
-                    SELECT report_num, magnitude, depth, description, level, wind_speed,
-                           pressure, latitude, longitude, time
+                    SELECT report_num, magnitude, depth, description, subtitle,
+                           weather_detail, place_name, level, wind_speed, pressure,
+                           latitude, longitude, max_wave_height, area_count,
+                           immediate_area_count, is_cancelled, is_training, time
                     FROM event_updates
                     WHERE event_id=?
                     ORDER BY id DESC
@@ -788,12 +826,20 @@ class DatabaseManager:
                         magnitude=last_update[1],
                         depth=last_update[2],
                         description=last_update[3],
-                        level=last_update[4],
-                        wind_speed=last_update[5],
-                        pressure=last_update[6],
-                        latitude=last_update[7],
-                        longitude=last_update[8],
-                        time_value=last_update[9],
+                        subtitle=last_update[4],
+                        weather_detail=last_update[5],
+                        place_name=last_update[6],
+                        level=last_update[7],
+                        wind_speed=last_update[8],
+                        pressure=last_update[9],
+                        latitude=last_update[10],
+                        longitude=last_update[11],
+                        max_wave_height=last_update[12],
+                        area_count=last_update[13],
+                        immediate_area_count=last_update[14],
+                        is_cancelled=last_update[15],
+                        is_training=last_update[16],
+                        time_value=last_update[17],
                     )
                     content_unchanged = last_fp == incoming_fp
 

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -174,6 +174,39 @@ class DatabaseManager:
                 await cursor.execute(
                     "ALTER TABLE event_updates ADD COLUMN longitude REAL"
                 )
+            # 海啸/气象历史报详情：与主卡片同级展示所需的摘要字段
+            if "subtitle" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN subtitle TEXT"
+                )
+            if "weather_detail" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN weather_detail TEXT"
+                )
+            if "place_name" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN place_name TEXT"
+                )
+            if "max_wave_height" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN max_wave_height REAL"
+                )
+            if "area_count" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN area_count INTEGER"
+                )
+            if "immediate_area_count" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN immediate_area_count INTEGER"
+                )
+            if "is_cancelled" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN is_cancelled INTEGER DEFAULT 0"
+                )
+            if "is_training" not in updates_columns:
+                await cursor.execute(
+                    "ALTER TABLE event_updates ADD COLUMN is_training INTEGER DEFAULT 0"
+                )
 
         # 创建不存在的表
         await self._create_tables(cursor)
@@ -218,6 +251,7 @@ class DatabaseManager:
             """
         )
         # 事件更新表：保存每次历史报次的详细快照，用于重建更新轨迹
+        # 海啸/气象额外保留 weather_detail 等，使时间线历史报可与主卡片同级展示
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS event_updates (
@@ -228,11 +262,19 @@ class DatabaseManager:
                 magnitude       REAL,
                 depth           REAL,
                 description     TEXT,
+                subtitle        TEXT,
+                weather_detail  TEXT,
+                place_name      TEXT,
                 level           TEXT,
                 wind_speed      REAL,
                 pressure        REAL,
                 latitude        REAL,
                 longitude       REAL,
+                max_wave_height REAL,
+                area_count      INTEGER,
+                immediate_area_count INTEGER,
+                is_cancelled    INTEGER DEFAULT 0,
+                is_training     INTEGER DEFAULT 0,
                 time            TEXT,
                 recorded_at     TEXT DEFAULT CURRENT_TIMESTAMP
             )
@@ -413,6 +455,7 @@ class DatabaseManager:
 
             # 首次写入主事件表后，同步写入一条更新记录，保证历史链条从首报开始完整。
             # 台风快照优先使用当次观测值，避免与主表峰值语义混淆。
+            # 海啸/气象同步写入 weather_detail 等，使历史报可与主卡片同级展示。
             snapshot_level = event_data.get("_snapshot_level", event_data.get("level"))
             snapshot_wind = event_data.get(
                 "_snapshot_wind_speed", event_data.get("wind_speed")
@@ -423,8 +466,12 @@ class DatabaseManager:
             await cursor.execute(
                 """
                 INSERT INTO event_updates
-                    (event_id, source_event_id, report_num, magnitude, depth, description, level, wind_speed, pressure, latitude, longitude, time)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                    (event_id, source_event_id, report_num, magnitude, depth,
+                     description, subtitle, weather_detail, place_name, level,
+                     wind_speed, pressure, latitude, longitude,
+                     max_wave_height, area_count, immediate_area_count,
+                     is_cancelled, is_training, time)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     new_id,
@@ -433,11 +480,19 @@ class DatabaseManager:
                     event_data.get("magnitude"),
                     event_data.get("depth"),
                     event_data.get("description"),
+                    event_data.get("subtitle"),
+                    event_data.get("weather_detail"),
+                    event_data.get("place_name"),
                     snapshot_level,
                     snapshot_wind,
                     snapshot_pressure,
                     event_data.get("latitude"),
                     event_data.get("longitude"),
+                    event_data.get("max_wave_height"),
+                    event_data.get("area_count"),
+                    event_data.get("immediate_area_count"),
+                    1 if event_data.get("is_cancelled") else 0,
+                    1 if event_data.get("is_training") else 0,
                     event_data.get("time"),
                 ),
             )
@@ -554,11 +609,33 @@ class DatabaseManager:
         }
     )
 
+    # 海啸源：WebSocket 重连/多通道补发可能导致同内容重复入库。
+    # 内容指纹一致时不抬升 update_count、不追加 event_updates。
+    _TSUNAMI_DEDUPE_SOURCES = frozenset(
+        {
+            "fan_studio_tsunami",
+            "china_tsunami_fanstudio",
+            "china_tsunami",
+            "jma_tsunami_p2p",
+            "jma_tsunami",
+            "japan_jma_tsunami",
+            "p2p_tsunami",
+            "jma_tsunami_eqsc",
+            "eqsc_tsunami",
+        }
+    )
+
     @classmethod
     def _should_dedupe_list_poll_update(
         cls, source: str, event_data: dict[str, Any]
     ) -> bool:
-        """判断本次 update 是否属于 Wolfx 列表轮询去重范围。"""
+        """判断本次 update 是否应做内容指纹去重。
+
+        覆盖：
+        1. Wolfx 列表轮询源（定时重复拉取）
+        2. 海啸源（重连补发 / 多通道同内容）
+        3. 显式 type=tsunami 的记录（兜底）
+        """
         candidates = (
             source,
             event_data.get("source"),
@@ -568,6 +645,12 @@ class DatabaseManager:
             key = str(raw or "").strip().lower()
             if key in cls._LIST_POLL_DEDUPE_SOURCES:
                 return True
+            if key in cls._TSUNAMI_DEDUPE_SOURCES:
+                return True
+
+        event_type = str(event_data.get("type") or "").strip().lower()
+        if event_type == "tsunami":
+            return True
         return False
 
     async def update_event(self, source: str, event_data: dict[str, Any]) -> bool:
@@ -786,12 +869,17 @@ class DatabaseManager:
 
             # 主事件表字段更新后，仅在内容变化时追加报次快照。
             # 台风快照写入本次观测值，避免把“已抬升的峰值”误记成当前观测。
+            # 海啸/气象同步写入 weather_detail 等详情，供时间线历史报复用主卡片展示。
             if not content_unchanged:
                 await cursor.execute(
                     """
                     INSERT INTO event_updates
-                        (event_id, source_event_id, report_num, magnitude, depth, description, level, wind_speed, pressure, latitude, longitude, time)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                        (event_id, source_event_id, report_num, magnitude, depth,
+                         description, subtitle, weather_detail, place_name, level,
+                         wind_speed, pressure, latitude, longitude,
+                         max_wave_height, area_count, immediate_area_count,
+                         is_cancelled, is_training, time)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     (
                         db_id,
@@ -800,11 +888,19 @@ class DatabaseManager:
                         event_data.get("magnitude"),
                         event_data.get("depth"),
                         event_data.get("description"),
+                        event_data.get("subtitle"),
+                        event_data.get("weather_detail"),
+                        event_data.get("place_name"),
                         update_snapshot_level,
                         update_snapshot_wind,
                         update_snapshot_pressure,
                         event_data.get("latitude"),
                         event_data.get("longitude"),
+                        event_data.get("max_wave_height"),
+                        event_data.get("area_count"),
+                        event_data.get("immediate_area_count"),
+                        1 if event_data.get("is_cancelled") else 0,
+                        1 if event_data.get("is_training") else 0,
                         event_data.get("time"),
                     ),
                 )

--- a/core/storage/stats/earthquake_detail_record_fields.py
+++ b/core/storage/stats/earthquake_detail_record_fields.py
@@ -21,8 +21,14 @@ from ...domain.event_models import EventEnvelope
 from ...domain.event_payload import SourcePayload
 from ..source_compat import is_cenc_intensity_report, is_fssn_cmt_report
 
+# weather_detail 文本长度上限（命名常量，便于统一调整）
+DEFAULT_DETAIL_LIMIT = 2048
+JMA_COMMENT_LIMIT = 256
+JMA_DETAIL_LIMIT = 4096
+FSSN_CMT_DETAIL_LIMIT = 1024
 
-def truncate_text(text: str, *, limit: int = 900) -> str:
+
+def truncate_text(text: str, *, limit: int = DEFAULT_DETAIL_LIMIT) -> str:
     """截断长文本，避免 weather_detail 过大。"""
     content = str(text or "").strip()
     if not content or len(content) <= limit:
@@ -235,10 +241,10 @@ def _build_jma_earthquake_detail(
             parts.append(points_summary)
 
     if comment:
-        parts.append("备注：" + truncate_text(comment, limit=280))
+        parts.append("备注：" + truncate_text(comment, limit=JMA_COMMENT_LIMIT))
 
     # 用换行拼接多段，前端 pre-wrap 可直接展开阅读
-    return truncate_text("\n".join(parts), limit=1200)
+    return truncate_text("\n".join(parts), limit=JMA_DETAIL_LIMIT)
 
 
 def _format_mag_token(mag_type: str, value: Any) -> str:
@@ -390,7 +396,7 @@ def _build_fssn_cmt_detail(
         lines.append("标识：" + " · ".join(id_parts))
 
     lines.append("备注：左/右旋最终确定需依赖实际发震断层面")
-    return truncate_text("\n".join(lines), limit=1000)
+    return truncate_text("\n".join(lines), limit=FSSN_CMT_DETAIL_LIMIT)
 
 
 def apply_earthquake_detail_record_fields(
@@ -415,17 +421,31 @@ def apply_earthquake_detail_record_fields(
     if is_cenc_intensity_report(source_id, info_type=info_type):
         return
 
-    payload = (
-        event.payload.to_dict() if isinstance(event.payload, SourcePayload) else {}
-    )
-    if not isinstance(payload, dict):
+    # SourcePayload.to_dict() 仅返回 raw 浅拷贝，不含 attributes。
+    # 这里直接读 payload 对象字段，避免 attributes 丢失导致写不出正文。
+    if isinstance(event.payload, SourcePayload):
+        payload_raw = (
+            dict(event.payload.raw) if isinstance(event.payload.raw, dict) else {}
+        )
+        payload_attributes = (
+            dict(event.payload.attributes)
+            if isinstance(event.payload.attributes, dict)
+            else {}
+        )
+        # 兼容旧调用方：部分字段可能直接挂在 raw 顶层
+        payload = payload_raw
+    elif isinstance(event.payload, dict):
+        payload = dict(event.payload)
+        raw_candidate = payload.get("raw")
+        payload_raw = raw_candidate if isinstance(raw_candidate, dict) else payload
+        attrs_candidate = payload.get("attributes")
+        payload_attributes = (
+            attrs_candidate if isinstance(attrs_candidate, dict) else {}
+        )
+    else:
         payload = {}
-    payload_attributes = payload.get("attributes")
-    if not isinstance(payload_attributes, dict):
-        payload_attributes = {}
-    payload_raw = payload.get("raw")
-    if not isinstance(payload_raw, dict):
         payload_raw = {}
+        payload_attributes = {}
 
     detail = ""
     if is_fssn_cmt_report(source_id, info_type=info_type) or is_fssn_cmt_source(

--- a/core/storage/stats/earthquake_detail_record_fields.py
+++ b/core/storage/stats/earthquake_detail_record_fields.py
@@ -1,0 +1,460 @@
+"""
+地震情报类事件的 weather_detail 落库辅助。
+
+把可能含大量补充信息的地震情报摘要写入 weather_detail，
+便于管理端事件列表像气象预警一样展开查看正文：
+- P2P / Wolfx 各地震度相关情报（jma_points）
+- FSSN 矩心矩张量解（CMT 节面 / 多震级）
+- CENC 烈度速报仍由 cenc_intensity_record_fields 负责
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ....utils.converters import ScaleConverter
+from ...domain.earthquake.cmt_normalize import (
+    format_fault_type_label,
+    is_fssn_cmt_source,
+)
+from ...domain.event_models import EventEnvelope
+from ...domain.event_payload import SourcePayload
+from ..source_compat import is_cenc_intensity_report, is_fssn_cmt_report
+
+
+def truncate_text(text: str, *, limit: int = 900) -> str:
+    """截断长文本，避免 weather_detail 过大。"""
+    content = str(text or "").strip()
+    if not content or len(content) <= limit:
+        return content
+    if limit <= 1:
+        return content[:limit]
+    return content[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _pick_from_sources(*sources: Any, keys: tuple[str, ...]) -> Any:
+    """从多层字典中按候选键取值。"""
+    for key in keys:
+        for source in sources:
+            if not isinstance(source, dict) or key not in source:
+                continue
+            value = source.get(key)
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            return value
+    return None
+
+
+def _format_scale_display(scale: Any) -> str:
+    """统一震度展示文本。"""
+    if scale is None or scale == "":
+        return ""
+    # P2P 业务整数优先走专用格式化
+    raw_int = ScaleConverter.normalize_p2p_scale_value(scale)
+    if raw_int is not None and raw_int >= 10:
+        text = ScaleConverter.format_p2p_scale_display(raw_int)
+        if text:
+            return text
+    text = ScaleConverter.format_jma_cwa_scale_display(scale)
+    if text:
+        return text
+    return str(scale).strip()
+
+
+def _scale_sort_key(scale: Any) -> float:
+    """震度排序键：数值越大越靠前。"""
+    raw_int = ScaleConverter.normalize_p2p_scale_value(scale)
+    if raw_int is not None and raw_int >= 0:
+        converted = ScaleConverter.convert_p2p_scale(raw_int)
+        if converted is not None:
+            return float(converted)
+        return float(raw_int)
+    try:
+        return float(scale)
+    except (TypeError, ValueError):
+        parsed = ScaleConverter.parse_jma_cwa_scale(scale)
+        if parsed is not None:
+            return float(parsed)
+        return -1.0
+
+
+def _format_jma_info_type_label(info_type: str) -> str:
+    """日本情报类型中文标签。"""
+    mapping = {
+        "ScalePrompt": "震度速报",
+        "Destination": "震源相关情报",
+        "ScaleAndDestination": "震度・震源相关情报",
+        "DetailScale": "各地震度相关情报",
+        "Foreign": "远地地震相关情报",
+        "Other": "其他情报",
+    }
+    text = str(info_type or "").strip()
+    if not text:
+        return ""
+    if text in mapping:
+        return mapping[text]
+    # 已是中文标题时直接返回
+    if any("\u4e00" <= ch <= "\u9fff" for ch in text):
+        return text
+    return text
+
+
+def _collect_jma_points(*sources: Any) -> list[dict[str, Any]]:
+    """从 metadata / payload 提取 jma_points。"""
+    raw = _pick_from_sources(
+        *sources,
+        keys=("jma_points", "points", "Points"),
+    )
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _build_jma_points_summary(
+    points: list[dict[str, Any]],
+    *,
+    max_scales: int = 6,
+    max_addrs_per_scale: int = 8,
+    max_total_addrs: int = 36,
+) -> str:
+    """把观测点按震度分组压成可读摘要。"""
+    if not points:
+        return ""
+
+    scale_groups: dict[Any, list[str]] = {}
+    for point in points:
+        addr = str(
+            point.get("addr")
+            or point.get("Addr")
+            or point.get("name")
+            or point.get("Name")
+            or point.get("location")
+            or ""
+        ).strip()
+        if not addr:
+            continue
+        scale = point.get("scale")
+        if scale is None:
+            scale = point.get("Scale") or point.get("shindo") or point.get("intensity")
+        scale_groups.setdefault(scale, []).append(addr)
+
+    if not scale_groups:
+        return ""
+
+    sorted_scales = sorted(scale_groups.keys(), key=_scale_sort_key, reverse=True)
+    lines: list[str] = []
+    used_addrs = 0
+    for scale in sorted_scales[:max_scales]:
+        addrs = scale_groups.get(scale) or []
+        if not addrs:
+            continue
+        remaining = max(0, max_total_addrs - used_addrs)
+        if remaining <= 0:
+            extra_scales = len(sorted_scales) - len(lines)
+            if extra_scales > 0:
+                lines.append(f"…另有 {extra_scales} 档震度")
+            break
+        show_n = min(max_addrs_per_scale, remaining, len(addrs))
+        shown = addrs[:show_n]
+        used_addrs += show_n
+        scale_text = _format_scale_display(scale) or str(scale)
+        loc_str = "、".join(shown)
+        if len(addrs) > show_n:
+            loc_str += f" 等{len(addrs)}处"
+        lines.append(f"[震度{scale_text}] {loc_str}")
+
+    if not lines:
+        return ""
+    return "各地震度详情：\n" + "\n".join(f"  {line}" for line in lines)
+
+
+def _build_jma_earthquake_detail(
+    *,
+    info_type: str,
+    event_metadata: dict[str, Any],
+    envelope_metadata: dict[str, Any],
+    payload_attributes: dict[str, Any],
+    payload_raw: dict[str, Any],
+    payload: dict[str, Any],
+) -> str:
+    """构建日本地震情报（含各地震度）正文摘要。"""
+    sources = (
+        event_metadata,
+        envelope_metadata,
+        payload_attributes,
+        payload_raw,
+        payload,
+    )
+    points = _collect_jma_points(*sources)
+    comment = str(
+        _pick_from_sources(*sources, keys=("jma_comment", "freeFormComment", "comment"))
+        or ""
+    ).strip()
+    domestic_tsunami = str(
+        _pick_from_sources(
+            *sources,
+            keys=("domestic_tsunami", "domesticTsunami", "info"),
+        )
+        or ""
+    ).strip()
+    revision = str(
+        _pick_from_sources(*sources, keys=("revision", "correct")) or ""
+    ).strip()
+    if revision.lower() in {"none", "null"}:
+        revision = ""
+
+    # 无观测点、无备注时不写 weather_detail，避免普通测定误出展开入口
+    if not points and not comment:
+        return ""
+
+    parts: list[str] = []
+    type_label = _format_jma_info_type_label(info_type)
+    if type_label:
+        parts.append(type_label)
+    if revision:
+        parts.append(f"订正：{revision}")
+
+    tsunami_mapping = {
+        "None": "无需担心海啸",
+        "Unknown": "不明",
+        "Checking": "调查中",
+        "NonEffective": "预计会有若干海面变动，无须担心受害",
+        "Watch": "正在/已经发布津波注意报",
+        "Warning": "正在/已经发布津波警报/大津波警报",
+    }
+    if domestic_tsunami:
+        tsunami_text = tsunami_mapping.get(domestic_tsunami, domestic_tsunami)
+        parts.append(f"津波：{tsunami_text}")
+
+    if points:
+        parts.append(f"观测点 {len(points)}")
+        points_summary = _build_jma_points_summary(points)
+        if points_summary:
+            parts.append(points_summary)
+
+    if comment:
+        parts.append("备注：" + truncate_text(comment, limit=280))
+
+    # 用换行拼接多段，前端 pre-wrap 可直接展开阅读
+    return truncate_text("\n".join(parts), limit=1200)
+
+
+def _format_mag_token(mag_type: str, value: Any) -> str:
+    """格式化震级片段。"""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        text = str(value or "").strip()
+        return f"{mag_type} {text}" if text else ""
+    return f"{mag_type} {number:.1f}"
+
+
+def _format_plane_line(label: str, plane: Any) -> str:
+    """格式化节面一行。"""
+    if not isinstance(plane, dict):
+        return ""
+    strike = plane.get("strike")
+    dip = plane.get("dip")
+    rake = plane.get("rake")
+    if strike is None or dip is None or rake is None:
+        raw = str(plane.get("raw") or "").strip()
+        if raw:
+            fault = format_fault_type_label(plane)
+            return f"{label}：{raw}（{fault}）" if fault else f"{label}：{raw}"
+        return ""
+    fault = format_fault_type_label(plane)
+    base = f"{label}：走向 {strike}° / 倾角 {dip}° / 滑动角 {rake}°"
+    return f"{base}（{fault}）" if fault else base
+
+
+def _build_fssn_cmt_detail(
+    *,
+    event_metadata: dict[str, Any],
+    envelope_metadata: dict[str, Any],
+    payload_attributes: dict[str, Any],
+    payload_raw: dict[str, Any],
+    payload: dict[str, Any],
+    domain_event: Any,
+) -> str:
+    """构建 FSSN CMT 正文摘要。"""
+    sources = (
+        event_metadata,
+        envelope_metadata,
+        payload_attributes,
+        payload_raw,
+        payload,
+    )
+    all_mags = _pick_from_sources(*sources, keys=("all_magnitudes", "allMagnitudes"))
+    if not isinstance(all_mags, dict):
+        all_mags = {}
+
+    display_mag = _pick_from_sources(
+        *sources,
+        keys=("display_magnitude", "displayMagnitude"),
+    )
+    if display_mag is None and domain_event is not None:
+        display_mag = getattr(domain_event, "magnitude", None)
+    display_mag_type = (
+        str(
+            _pick_from_sources(
+                *sources,
+                keys=("display_magnitude_type", "displayMagnitudeType"),
+            )
+            or "M"
+        ).strip()
+        or "M"
+    )
+
+    depth = _pick_from_sources(*sources, keys=("depth",))
+    if depth is None and domain_event is not None:
+        depth = getattr(domain_event, "depth", None)
+    depth_error = _pick_from_sources(*sources, keys=("depth_error", "depthError"))
+    centroid_depth = _pick_from_sources(
+        *sources,
+        keys=("centroid_depth", "centroidDepth"),
+    )
+    plane1 = _pick_from_sources(
+        *sources,
+        keys=("nodal_plane1", "nodalPlane1"),
+    )
+    plane2 = _pick_from_sources(
+        *sources,
+        keys=("nodal_plane2", "nodalPlane2"),
+    )
+    cmt_id = str(_pick_from_sources(*sources, keys=("cmt_id", "id")) or "").strip()
+    fssn_event_id = str(
+        _pick_from_sources(*sources, keys=("fssn_event_id", "eventId")) or ""
+    ).strip()
+
+    # 至少要有节面 / 多震级 / 矩心深度之一，才值得展开
+    if not plane1 and not plane2 and not all_mags and centroid_depth is None:
+        return ""
+
+    lines: list[str] = ["CMT 矩心矩张量解"]
+
+    mag_tokens: list[str] = []
+    if display_mag is not None:
+        mag_tokens.append(_format_mag_token(display_mag_type, display_mag))
+    for key in ("Mww", "mB", "mb", "MLv", "Mwp", "M", "Mw(Mwp)", "Mw(mB)"):
+        if key == display_mag_type:
+            continue
+        if key not in all_mags:
+            continue
+        token = _format_mag_token(key, all_mags.get(key))
+        if token and token not in mag_tokens:
+            mag_tokens.append(token)
+    if mag_tokens:
+        lines.append("震级：" + " / ".join(mag_tokens[:6]))
+
+    depth_parts: list[str] = []
+    if depth is not None and depth != "":
+        try:
+            depth_num = float(depth)
+            if depth_num == 0:
+                depth_text = "极浅"
+            else:
+                depth_text = f"{depth_num:g} km"
+        except (TypeError, ValueError):
+            depth_text = str(depth).strip()
+        if depth_error is not None and depth_error != "":
+            try:
+                err_num = float(depth_error)
+                depth_text = f"{depth_text} (±{err_num:g})"
+            except (TypeError, ValueError):
+                depth_text = f"{depth_text} (±{depth_error})"
+        depth_parts.append(f"震源深度 {depth_text}")
+    if centroid_depth is not None and centroid_depth != "":
+        try:
+            centroid_num = float(centroid_depth)
+            depth_parts.append(f"矩心深度 {centroid_num:g} km")
+        except (TypeError, ValueError):
+            depth_parts.append(f"矩心深度 {centroid_depth}")
+    if depth_parts:
+        lines.append("深度：" + "｜".join(depth_parts))
+
+    plane1_line = _format_plane_line("节面1", plane1)
+    plane2_line = _format_plane_line("节面2", plane2)
+    if plane1_line:
+        lines.append(plane1_line)
+    if plane2_line:
+        lines.append(plane2_line)
+
+    id_parts: list[str] = []
+    if cmt_id:
+        id_parts.append(f"CMT ID {cmt_id}")
+    if fssn_event_id and fssn_event_id != cmt_id:
+        id_parts.append(f"事件 {fssn_event_id}")
+    if id_parts:
+        lines.append("标识：" + " · ".join(id_parts))
+
+    lines.append("备注：左/右旋最终确定需依赖实际发震断层面")
+    return truncate_text("\n".join(lines), limit=1000)
+
+
+def apply_earthquake_detail_record_fields(
+    record: dict[str, Any],
+    event: EventEnvelope,
+    *,
+    info_type: str,
+    event_metadata: dict[str, Any],
+    envelope_metadata: dict[str, Any],
+) -> None:
+    """为含大量补充信息的地震情报写入 weather_detail。
+
+    注意：CENC 烈度速报由 apply_cenc_intensity_report_fields 单独处理，这里跳过。
+    若记录已有 weather_detail（例如 CENC 已写入），也不覆盖。
+    """
+    if str(record.get("weather_detail") or "").strip():
+        return
+
+    source_id = str(
+        event.source_id or record.get("source_id") or record.get("source") or ""
+    ).strip()
+    if is_cenc_intensity_report(source_id, info_type=info_type):
+        return
+
+    payload = (
+        event.payload.to_dict() if isinstance(event.payload, SourcePayload) else {}
+    )
+    if not isinstance(payload, dict):
+        payload = {}
+    payload_attributes = payload.get("attributes")
+    if not isinstance(payload_attributes, dict):
+        payload_attributes = {}
+    payload_raw = payload.get("raw")
+    if not isinstance(payload_raw, dict):
+        payload_raw = {}
+
+    detail = ""
+    if is_fssn_cmt_report(source_id, info_type=info_type) or is_fssn_cmt_source(
+        source_id, info_type=info_type
+    ):
+        detail = _build_fssn_cmt_detail(
+            event_metadata=event_metadata,
+            envelope_metadata=envelope_metadata,
+            payload_attributes=payload_attributes,
+            payload_raw=payload_raw,
+            payload=payload,
+            domain_event=getattr(event, "event", None),
+        )
+    else:
+        # 日本地震情报：有 jma_points / 备注时写入
+        detail = _build_jma_earthquake_detail(
+            info_type=info_type,
+            event_metadata=event_metadata,
+            envelope_metadata=envelope_metadata,
+            payload_attributes=payload_attributes,
+            payload_raw=payload_raw,
+            payload=payload,
+        )
+
+    if detail:
+        record["weather_detail"] = detail
+
+
+__all__ = [
+    "apply_earthquake_detail_record_fields",
+    "truncate_text",
+]

--- a/core/storage/stats/event_record_factory.py
+++ b/core/storage/stats/event_record_factory.py
@@ -25,6 +25,7 @@ from ...domain.tsunami.tsunami_levels import (
 from ...domain.tsunami.tsunami_title import (
     build_tsunami_list_title,
     is_generic_tsunami_title,
+    parse_tsunami_batch_num,
 )
 from ...domain.typhoon import (
     format_display_name,
@@ -34,6 +35,7 @@ from ...domain.typhoon import (
 )
 from ...services.identity.event_identity import resolve_report_num, resolve_source_id
 from .cenc_intensity_record_fields import apply_cenc_intensity_report_fields
+from .earthquake_detail_record_fields import apply_earthquake_detail_record_fields
 
 
 def _adapt_event_envelope(event: EventEnvelope) -> EventEnvelope:
@@ -161,6 +163,14 @@ class EventRecordFactory:
             record,
             event,
             earthquake_level=earthquake_level,
+            info_type=info_type,
+            event_metadata=event_metadata,
+            envelope_metadata=envelope_metadata,
+        )
+        # P2P 各地震度 / FSSN CMT 等补充正文：写入 weather_detail 供管理端展开
+        apply_earthquake_detail_record_fields(
+            record,
+            event,
             info_type=info_type,
             event_metadata=event_metadata,
             envelope_metadata=envelope_metadata,
@@ -660,6 +670,14 @@ class EventRecordFactory:
             area_count=area_count_int,
         )
 
+        batch_raw = merged.get("batch")
+        business_report_num = parse_tsunami_batch_num(batch_raw)
+        if business_report_num is None:
+            # 兼容：从 weather_detail / description 回退解析业务报次
+            business_report_num = parse_tsunami_batch_num(
+                weather_detail
+            ) or parse_tsunami_batch_num(record.get("description"))
+
         record.update(
             {
                 "time": data.issued_at.isoformat() if data.issued_at else None,
@@ -678,11 +696,15 @@ class EventRecordFactory:
                 "immediate_area_count": immediate_count_int,
                 "is_cancelled": bool(cancelled or level == "解除"),
                 "is_training": bool(is_training),
+                # 业务 batch 原文保留，便于前端/调试对照
+                "batch": batch_raw if batch_raw not in (None, "") else None,
             }
         )
-        # 首报默认 report_num=1；后续合并会在 merger 中递增
-        if record.get("report_num") in (None, "", 0):
-            record["report_num"] = 1
+        # 海啸 report_num = 业务报次（batch），不是系统 update_count。
+        # 有 batch 才写入；无 batch 时留给 merger / insert 用 update 序号或默认 1 兜底，
+        # 避免日本海啸无 batch 时每报都被写死成 1。
+        if business_report_num is not None:
+            record["report_num"] = business_report_num
         return record
 
     @staticmethod

--- a/core/storage/stats/event_record_merger.py
+++ b/core/storage/stats/event_record_merger.py
@@ -187,10 +187,16 @@ class EventRecordMerger:
                 source_id=source_id,
                 update_count=next_count,
             )
+            # 先清掉旧 report_num，避免无 batch 的日本海啸沿用上一报业务号。
+            # apply_tsunami_fields 仅在解析到业务 batch 时写入 report_num。
+            previous_report_num = record.get("report_num")
+            record.pop("report_num", None)
             EventRecordFactory.apply_tsunami_fields(record, event)
             if real_event_id:
                 record["real_event_id"] = real_event_id
-            record["report_num"] = next_count
+            # 无业务 batch：用系统更新序号区分各报（日本海啸常见）
+            if record.get("report_num") in (None, "", 0):
+                record["report_num"] = next_count or previous_report_num or 1
 
             updated_record = target_list.pop(i)
             target_list.insert(0, updated_record)

--- a/core/storage/stats/event_record_merger.py
+++ b/core/storage/stats/event_record_merger.py
@@ -189,14 +189,13 @@ class EventRecordMerger:
             )
             # 先清掉旧 report_num，避免无 batch 的日本海啸沿用上一报业务号。
             # apply_tsunami_fields 仅在解析到业务 batch 时写入 report_num。
-            previous_report_num = record.get("report_num")
             record.pop("report_num", None)
             EventRecordFactory.apply_tsunami_fields(record, event)
             if real_event_id:
                 record["real_event_id"] = real_event_id
             # 无业务 batch：用系统更新序号区分各报（日本海啸常见）
             if record.get("report_num") in (None, "", 0):
-                record["report_num"] = next_count or previous_report_num or 1
+                record["report_num"] = next_count or 1
 
             updated_record = target_list.pop(i)
             target_list.insert(0, updated_record)

--- a/core/storage/stats/stats_record_service.py
+++ b/core/storage/stats/stats_record_service.py
@@ -105,13 +105,15 @@ class StatsRecordService:
                         existing_real = str(existing.get("real_event_id") or "").strip()
                         if existing_real:
                             push_record["real_event_id"] = existing_real
-                        # 海啸多报：用 update_count 作为报次，便于前端时间线展示
+                        # 海啸：report_num 优先业务 batch；无 batch 时用 update 序号兜底。
+                        # 不再无条件地 report_num = update_count。
                         if isinstance(event.event, TsunamiEvent):
-                            push_record["report_num"] = next_count
                             if not push_record.get("real_event_id"):
                                 push_record["real_event_id"] = (
                                     existing_real or push_record.get("event_id")
                                 )
+                            if push_record.get("report_num") in (None, "", 0):
+                                push_record["report_num"] = next_count
                         await self.manager.db.update_event(
                             existing_source or source_id,
                             push_record,

--- a/utils/converters.py
+++ b/utils/converters.py
@@ -45,16 +45,18 @@ class ScaleConverter:
     def parse_jma_cwa_scale(scale_str: str | int | float) -> float | None:
         """
         解析日本或台湾震度字符串。
-        支持格式：'5-'、'5+'、'5弱'、'5強'、'5'、'6.5' 等。
+        支持格式：'5-'、'5+'、'5弱'、'5強'、'5强'、'5' 等。
 
-        映射规则如下：
+        映射规则与项目内 P2P/展示层规范值对齐：
         X弱 / X- -> X - 0.5
-        X強 / X+ -> X + 0.5
+        X強 / X强 / X+ -> X
         X        -> X.0
 
         例如：
         5弱 -> 4.5
-        5強 -> 5.5
+        5強 -> 5.0
+        6弱 -> 5.5
+        6強 -> 6.0
         """
         if scale_str is None:
             return None
@@ -67,18 +69,39 @@ class ScaleConverter:
         if not scale_str:
             return None
 
-        # 支持 5+、5-、5弱、5強 等多种格式。
-        match = re.search(r"(\d+)(弱|強|\+|\-)?", scale_str)
+        # 先走显式字典，避免简繁体与符号写法产生歧义。
+        normalized = scale_str.replace("強", "强").replace("＋", "+").replace("－", "-")
+        explicit_mapping = {
+            "5-": 4.5,
+            "5弱": 4.5,
+            "5+": 5.0,
+            "5强": 5.0,
+            "6-": 5.5,
+            "6弱": 5.5,
+            "6+": 6.0,
+            "6强": 6.0,
+            "7": 7.0,
+            "4": 4.0,
+            "3": 3.0,
+            "2": 2.0,
+            "1": 1.0,
+            "0": 0.0,
+        }
+        if normalized in explicit_mapping:
+            return explicit_mapping[normalized]
+
+        # 支持 5+、5-、5弱、5強/5强 等多种格式。
+        # 「強/强/+」映射为整数档（5.0/6.0），与 convert_p2p_scale 及展示层一致。
+        match = re.search(r"(\d+)(弱|強|强|\+|\-)?", normalized)
         if match:
             base = int(match.group(1))
             suffix = match.group(2)
 
             if suffix in ["弱", "-"]:
                 return base - 0.5
-            elif suffix in ["強", "+"]:
-                return base + 0.5
-            else:
+            if suffix in ["強", "强", "+"]:
                 return float(base)
+            return float(base)
 
         return None
 

--- a/utils/time_converter.py
+++ b/utils/time_converter.py
@@ -90,6 +90,10 @@ class TimeConverter:
             "%Y-%m-%dT%H:%M:%S",  # 无时区 ISO
             "%Y/%m/%d %H:%M",
             "%Y-%m-%d %H:%M",
+            # EQSC 等源常见：紧凑日期 + 空格时间，如 20260728 16:04:08
+            "%Y%m%d %H:%M:%S",
+            "%Y%m%d %H:%M:%S.%f",
+            "%Y%m%d %H:%M",
             "%Y%m%d%H%M%S",
             "%Y%m%d%H%M",
         ]


### PR DESCRIPTION
## 📝 描述 / Description

一场地震震出了无数个bug...

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Sourcery 提要

在改进 EEW 解析、震级/深度处理、海啸报告编号以及海啸 EEW 去重行为的同时，增强地震、气象预警与海啸事件的详情展示能力。

新增功能：
- 在管理端事件列表和时间线中，为地震事件显示震级/深度标签，并为气象和地震事件提供可展开的详情面板。
- 为事件更新保留更丰富的快照字段，使历史海啸/气象报告能够以与最新卡片相同的细节层级进行渲染。
- 存储并提供按强度区间分组的 JMA EEW 预警区域，用于更清晰的消息展示。

缺陷修复：
- 规范 JMA EEW 和 Wolfx 预警区域的解析：忽略占位强度等级、正确处理非列表类型负载，并避免最大震度计算错误。
- 将 PLUM M1.0 震级视为占位值，不再作为真实震级显示，也不影响筛选与本地震度估计。
- 通过将业务批次号与系统更新计数分离，并从标题中移除嵌入式报告标记，修正海啸报告编号。
- 修正 CENC 震度报告的标识归属，改为使用解析器的源配置进行填充。
- 将 JMA 海啸内容的指纹和去重逻辑改为仅在同一来源内生效，避免跨来源抑制，并改善 EQSC/P2P 之间的共存。
- 扩展时间解析和基于时间的过滤窗口，避免丢弃诸如 CMT 解等有效但略有延迟的产品。

改进优化：
- 重构事件组时间线，使其复用主 `EventCard` 来呈现所有灾种，统一最新与历史报告之间的信息密度。
- 引入结构化的地震详情存储字段（`weather_detail`），用于保存 JMA 震度信息与 FSSN CMT 解，并在展示层与 UI 中予以体现。
- 通过按震度区间对区域进行分组，并在消息中以概览形式呈现，改进 JMA EEW 和 Wolfx 预警区域输出，而非简单平铺列表。
- 优化 JMA/台湾震度解析规则，使其更契合项目范围内对弱/强等级的统一语义。
- 当深度缺失时，允许本地震度估计与 P/S 走时计算回退到默认深度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance event detail presentation for earthquakes, weather alerts, and tsunamis while improving EEW parsing, magnitude/depth handling, tsunami report numbering, and tsunami EEW deduplication behavior.

New Features:
- Display earthquake magnitude/depth chips and expandable detail panels for weather and earthquake events in the admin event list and timeline.
- Persist richer snapshot fields for event updates so historical tsunami/weather reports can be rendered with the same detail as the latest card.
- Store and expose grouped JMA EEW warning areas by intensity band for clearer message presentation.

Bug Fixes:
- Normalize JMA EEW and Wolfx warning area parsing to ignore placeholder scales, handle non-list payloads, and avoid miscomputed max intensity.
- Treat PLUM M1.0 magnitudes as placeholders so they no longer show as real magnitudes or affect filtering and local estimation.
- Fix tsunami report numbering by separating business batch numbers from system update counts and removing embedded report markers from titles.
- Correct CENC intensity report identity population to use the parser’s source configuration.
- Change JMA tsunami content fingerprinting and deduplication to be same-source only, preventing cross-source suppression and improving EQSC/P2P coexistence.
- Extend time parsing and time-based filtering windows to avoid dropping valid but slightly delayed products like CMT solutions.

Enhancements:
- Refactor the event group timeline to reuse the main EventCard for all disaster types, unifying information density between latest and historical reports.
- Introduce structured earthquake detail storage (weather_detail) for JMA intensity info and FSSN CMT solutions and surface it in presenters and UI.
- Improve JMA EEW and Wolfx warning-area outputs by grouping regions by intensity band and summarizing them in messages instead of flat lists.
- Refine JMA/Taiwan intensity parsing rules to better match project-wide scale semantics for weak/strong levels.
- Allow local intensity estimation and P/S travel time computation to fall back to a default depth when missing.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 事件卡片支持按需展开气象预警与地震情报补充正文；历史模式更清晰地展示更新时间线。
  * “第 N 报/批次”解析与徽章统一展示，并补齐地震震级/深度、海啸深度（含“极浅”）等展示。
* **改进**
  * 日本地震预警改为按震度档汇总展示；缺失深度时仍可继续计算展示结果。
  * 历史事件时间筛选窗口更长，整体去重更稳定，重复更少。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->