### PR TITLE
fix: 修复原始消息日志记录器误过滤 OpenQuakeAPI 数据的问题

### DIFF
--- a/core/message/logging/filters/event_hash_builder.py
+++ b/core/message/logging/filters/event_hash_builder.py
@@ -86,14 +86,23 @@ class EventHashBuilder:
             hash_parts.append(f"eid:{event_id}")
 
             # OpenQuake/GQ 使用 revisionId；其他 EEW 使用 updates/ReportNum/Serial。
-            report_num = (
-                data.get("updates")
-                or data.get("ReportNum")
-                or data.get("Serial")
-                or data.get("revisionId")
-                or data.get("revision_id")
+            # 严格查找第一个非 None 且非空字符串的字段，确保 0 (如第 0 报或 revisionId 0) 作为有效标识被保留
+            report_num_keys = [
+                "updates",
+                "ReportNum",
+                "Serial",
+                "revisionId",
+                "revision_id",
+            ]
+            report_num = next(
+                (
+                    data[k]
+                    for k in report_num_keys
+                    if data.get(k) is not None and str(data[k]) != ""
+                ),
+                None,
             )
-            if report_num is not None and str(report_num) != "":
+            if report_num is not None:
                 hash_parts.append(f"rn:{report_num}")
 
             # 动作维度：同一事件的 update / archived / cancelled 应分别落盘。
@@ -101,31 +110,52 @@ class EventHashBuilder:
             if action:
                 hash_parts.append(f"act:{action}")
 
-            if report_num is None or str(report_num) == "":
-                updated = (
-                    data.get("updated")
-                    or data.get("updateTime")
-                    or data.get("lastUpdateMs")
-                    or data.get("timestampMs")
+            if report_num is None:
+                updated_keys = ["updated", "updateTime", "lastUpdateMs", "timestampMs"]
+                updated = next(
+                    (
+                        data[k]
+                        for k in updated_keys
+                        if data.get(k) is not None and str(data[k]) != ""
+                    ),
+                    None,
                 )
-                if updated:
+                if updated is not None:
                     hash_parts.append(f"up:{str(updated)}")
 
-                mag = data.get("magnitude") or data.get("Magnitude")
-                if mag:
+                mag = (
+                    data.get("magnitude")
+                    if data.get("magnitude") is not None
+                    else data.get("Magnitude")
+                )
+                if mag is not None:
                     hash_parts.append(f"m:{mag}")
 
             return "|".join(hash_parts)
 
-        time_info = (
-            data.get("shockTime")
-            or data.get("time")
-            or data.get("OriginTime")
-            or data.get("originTimeIso")
-            or data.get("originTimeMs")
+        # 退化匹配路径：时间字段可能为 ISO 字符串或毫秒时间戳，保留原字符串精细度以防截断后冲突
+        time_info_keys = [
+            "shockTime",
+            "time",
+            "OriginTime",
+            "originTimeIso",
+            "originTimeMs",
+        ]
+        time_info = next(
+            (
+                data[k]
+                for k in time_info_keys
+                if data.get(k) is not None and str(data[k]) != ""
+            ),
+            None,
         )
-        if time_info:
-            hash_parts.append(f"et:{str(time_info)[:16]}")
+        if time_info is not None:
+            time_str = str(time_info)
+            # 如果是普通的简短时间串截取前 16 位，如果是精确 ISO/毫秒串则全量保留
+            if "T" in time_str or len(time_str) > 16:
+                hash_parts.append(f"et:{time_str}")
+            else:
+                hash_parts.append(f"et:{time_str[:16]}")
 
         mag = data.get("magnitude") or data.get("Magnitude")
         if mag:

--- a/core/message/logging/filters/event_hash_builder.py
+++ b/core/message/logging/filters/event_hash_builder.py
@@ -85,14 +85,29 @@ class EventHashBuilder:
         if event_id:
             hash_parts.append(f"eid:{event_id}")
 
+            # OpenQuake/GQ 使用 revisionId；其他 EEW 使用 updates/ReportNum/Serial。
             report_num = (
-                data.get("updates") or data.get("ReportNum") or data.get("Serial")
+                data.get("updates")
+                or data.get("ReportNum")
+                or data.get("Serial")
+                or data.get("revisionId")
+                or data.get("revision_id")
             )
-            if report_num:
+            if report_num is not None and str(report_num) != "":
                 hash_parts.append(f"rn:{report_num}")
 
-            if not report_num:
-                updated = data.get("updated") or data.get("updateTime")
+            # 动作维度：同一事件的 update / archived / cancelled 应分别落盘。
+            action = data.get("action")
+            if action:
+                hash_parts.append(f"act:{action}")
+
+            if report_num is None or str(report_num) == "":
+                updated = (
+                    data.get("updated")
+                    or data.get("updateTime")
+                    or data.get("lastUpdateMs")
+                    or data.get("timestampMs")
+                )
                 if updated:
                     hash_parts.append(f"up:{str(updated)}")
 
@@ -102,7 +117,13 @@ class EventHashBuilder:
 
             return "|".join(hash_parts)
 
-        time_info = data.get("shockTime") or data.get("time") or data.get("OriginTime")
+        time_info = (
+            data.get("shockTime")
+            or data.get("time")
+            or data.get("OriginTime")
+            or data.get("originTimeIso")
+            or data.get("originTimeMs")
+        )
         if time_info:
             hash_parts.append(f"et:{str(time_info)[:16]}")
 
@@ -117,6 +138,10 @@ class EventHashBuilder:
                 hash_parts.append(f"el:{float(lat):.1f},{float(lon):.1f}")
             except (ValueError, TypeError):
                 pass
+
+        action = data.get("action")
+        if action:
+            hash_parts.append(f"act:{action}")
 
         return "|".join(hash_parts)
 

--- a/core/message/logging/support/message_log_helper_service.py
+++ b/core/message/logging/support/message_log_helper_service.py
@@ -25,7 +25,7 @@ class MessageLogHelperService:
 
     @staticmethod
     def extract_payload(data: dict[str, Any]) -> dict[str, Any]:
-        """提取实际业务载荷，兼容 FAN / P2P / Wolfx 等结构。"""
+        """提取实际业务载荷，兼容 FAN / P2P / Wolfx / OpenQuake 等结构。"""
         # 不同来源的消息封装层级不一致，这里统一剥离外层包装，方便后续哈希与展示逻辑复用。
         if not isinstance(data, dict):
             return {}
@@ -34,6 +34,21 @@ class MessageLogHelperService:
             return data["Data"]
         if "data" in data and isinstance(data["data"], dict):
             return data["data"]
+        # OpenQuakeAPI RealtimeEvent: {source,type,action,timestampMs,payload:{...}}
+        # 业务主键（id/revisionId 等）在内层 payload，必须解包，否则去重哈希会退化成
+        # 仅 source+etype，导致同一来源后续所有地震更新都被当成重复事件过滤掉。
+        if "payload" in data and isinstance(data["payload"], dict):
+            inner = dict(data["payload"])
+            # 保留外层动作/类型，便于区分 update / archived / cancelled 等不同日志。
+            if "action" in data and "action" not in inner:
+                inner["action"] = data["action"]
+            if "type" in data and "type" not in inner:
+                inner["type"] = data["type"]
+            if "source" in data and "source" not in inner:
+                inner["source"] = data["source"]
+            if "timestampMs" in data and "timestampMs" not in inner:
+                inner["timestampMs"] = data["timestampMs"]
+            return inner
         if "code" in data and "issue" in data:
             return data
         if "type" in data and ("EventID" in data or "ID" in data):


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

改进地震事件哈希生成和消息负载提取逻辑，以正确处理 OpenQuake/OpenQuakeAPI 消息，并避免在原始消息日志中出现过度去重的问题。

Bug 修复：
- 确保地震哈希生成使用 OpenQuake 的修订标识符和时间戳，这样 OpenQuakeAPI 的更新就不会被错误地视为重复事件并被过滤掉。
- 在事件哈希中保留并包含操作信息（例如：update/archived/cancelled），以便同一地震的不同生命周期事件可以分别记录到日志中。
- 在保留关键外层元数据的同时，解包 OpenQuakeAPI 的 `RealtimeEvent` 负载，从而对这些消息进行正确的去重和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve earthquake event hash generation and message payload extraction to correctly handle OpenQuake/OpenQuakeAPI messages and avoid over-aggressive de-duplication in raw message logging.

Bug Fixes:
- Ensure earthquake hash generation uses OpenQuake revision identifiers and timestamps so OpenQuakeAPI updates are not incorrectly treated as duplicate events and filtered out.
- Preserve and include action information (e.g., update/archived/cancelled) in event hashes so different lifecycle events of the same earthquake are logged separately.
- Unwrap OpenQuakeAPI RealtimeEvent payloads while retaining key outer metadata to allow proper de-duplication and logging for these messages.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 增强地震事件去重哈希逻辑，正确识别如 `0` 等有效标识，并扩展候选字段来源以提高兼容性。
  * 在哈希中纳入动作维度（当存在且为真值时），减少不同动作被错误合并。
  * 更新事件载荷解析能力：兼容更多消息结构，并对嵌套 `payload` 进行字段补齐合并，提升去重判定准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->