### PR TITLE
refactor: 重构 EQSC 通道为共享服务并统一数据源命名

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,9 +541,9 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 - **日本气象厅地震情报 (`japan_jma_earthquake`)**: 接收 JMA 地震列表。
 - **中国地震台网地震测定 (`china_cenc_earthquake`)**: 接收 CENC 地震列表。
 
-#### 🔹 Global Quake (实时测算)
+#### 🔹 OpenQuakeAPI
 
-- **原理**: 连接到 OpenQuakeAPI 的 `/ws/all` 聚合端点，按 `source` 字段路由 Global Quake 等子源。这些数据是由全球数千个测站通过算法实时计算得出的。
+- **原理**: 连接到 OpenQuakeAPI 的 `/ws/all` 聚合端点，按 `source` 字段路由 Global Quake、中国气象局气象预警（CMA）等子源。这些数据是由全球数千个测站通过算法实时计算得出的。
 - **特点**: 在偏远地区或国际海域，由于官方机构反应时间较长，GQ 往往能最先提供初步数据，但震级和位置可能随报数更新而有较大波动。
 
 ---
@@ -2094,7 +2094,7 @@ graph TB
 ```text
 ===================================
 🕐 日志写入时间: 2026-02-27 14:28:19
-📡 来源: websocket_global_quake
+📡 来源: websocket_openquake_api
 📋 类型: websocket_message
 🔗 连接: URL: wss://api.aloys23.link/ws/all
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -209,7 +209,7 @@
           }
         }
       },
-      "global_quake": {
+      "openquake_api": {
         "description": "OpenQuakeAPI 数据源",
         "type": "object",
         "hint": "OpenQuakeAPI 连接组数据源总开关。",
@@ -258,7 +258,7 @@
             "hint": "从 EQuake 设置界面获取的访问令牌（以 ARh. 开头），用于创建 AccessToken。请妥善保管，不要泄露。",
             "hidden": true
           },
-          "typhoon_enrichment": {
+          "typhoon": {
             "description": "启用台风轮询",
             "type": "bool",
             "default": true,

--- a/admin/js/components/status/ConnectionsGrid.jsx
+++ b/admin/js/components/status/ConnectionsGrid.jsx
@@ -236,10 +236,13 @@ function ConnectionsGrid() {
                 displayName: 'OpenQuakeAPI',
                 matcher: (key) => {
                     const k = String(key || '').toLowerCase();
+                    // OpenQuakeAPI 连接组 key 为 openquake_api；兼容历史 global_quake / gq
                     return (
-                        k.includes('global')
-                        || k.includes('openquake')
+                        k === 'openquake_api'
+                        || k === 'global_quake'
                         || k === 'gq'
+                        || k.includes('openquake')
+                        || k.includes('global_quake')
                     ) && !k.includes('eqsc');
                 },
                 compact: true,

--- a/admin/js/components/status/EewStatusCard.jsx
+++ b/admin/js/components/status/EewStatusCard.jsx
@@ -80,17 +80,22 @@ function EewStatusCard() {
                 continue;
             }
 
-            // C. 正在发布地震预警
+            // C. 正在发布地震预警（双保险：若后端下发的 expires_at 已过期则视为无生效预警）
             if (statusText === 'active') {
-                const magnitude = item?.magnitude;
-                const place = item?.place || '未知地点';
-                let magText = '?';
-                if (magnitude !== null && magnitude !== undefined) {
-                    const num = Number(magnitude);
-                    magText = Number.isFinite(num) ? num.toFixed(1) : String(magnitude);
+                const expiresAt = parseDateSafe(item?.expires_at);
+                const isExpired = expiresAt && tickNowMs > expiresAt.getTime();
+                if (!isExpired) {
+                    const magnitude = item?.magnitude;
+                    const place = item?.place || '未知地点';
+                    let magText = '?';
+                    if (magnitude !== null && magnitude !== undefined) {
+                        const num = Number(magnitude);
+                        magText = Number.isFinite(num) ? num.toFixed(1) : String(magnitude);
+                    }
+                    activeLines.push(`[${activeName}] 当前正在发布地震预警：M ${magText} ${place}`);
+                    continue;
                 }
-                activeLines.push(`[${activeName}] 当前正在发布地震预警：M ${magText} ${place}`);
-                continue;
+                // 已过期：回落到下方“无生效预警”统计分支
             }
 
             // D. 安全无预警状态下：根据发震时间 issued_at 与本地跳表累加秒数

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -10,7 +10,7 @@
 
     // 仅允许全局配置修改的嵌套路径（会话模式隐藏且保存时剥离）
     // S-Net 轮询间隔、EQSC 通道鉴权参数影响全局运行态；
-    // typhoon_enrichment 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
+    // eqsc.typhoon 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
     const CONFIG_SESSION_GLOBAL_ONLY_PATHS = [
         ['data_sources', 'snet', 'poll_interval_seconds'],
         ['data_sources', 'eqsc', 'enabled'],

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -62,6 +62,7 @@ from .runtime.disaster_service_reconnect import DisasterServiceReconnectService
 from .runtime.disaster_service_runtime import DisasterServiceRuntimeService
 from .runtime.disaster_service_status import DisasterServiceStatusService
 from .runtime.startup_silence_coordinator import StartupSilenceCoordinator
+from .services.eqsc_channel_service import EqscChannelService
 from .services.typhoon_enrichment_service import TyphoonEnrichmentService
 from .services.typhoon_history_rebuild_service import TyphoonHistoryRebuildService
 
@@ -167,10 +168,17 @@ class DisasterWarningService:
         )
         # 通知中心独立维护远端通知同步、本地缓存和已读状态，供管理端前端复用。
         self.notification_center = NotificationCenter(self)
+        # EQSC 通道服务：统一管理 EQSC 鉴权、健康状态与熔断器，
+        # 台风富化、海啸轮询、CENC 烈度速报轮询共享该通道。
+        self.eqsc_channel_service = EqscChannelService(
+            config,
+            message_logger=self.message_logger,
+        )
         # 台风 EQSC 富化服务，在台风事件进入流水线前按需拉取 EQSC 详细数据。
         # 注入 message_logger，使 EQSC HTTP 响应进入原始消息日志链路。
         self.typhoon_enrichment_service = TyphoonEnrichmentService(
             config,
+            self.eqsc_channel_service,
             message_logger=self.message_logger,
         )
         # 冷启动历史重建编排独立服务，避免主服务继续堆叠台风业务细节。
@@ -324,13 +332,13 @@ class DisasterWarningService:
                 bind = getattr(self.message_manager, "set_silence_callbacks", None)
                 if callable(bind):
                     bind(self.is_silencing, self._absorb_event_for_silence)
-            # 就绪日志以真实轮询服务为准（catalog 组总闸 + typhoon_enrichment）
+            # 就绪日志以真实轮询服务为准
             typhoon_poll = getattr(self, "eqsc_typhoon_poll_service", None)
             poll_enabled = bool(typhoon_poll is not None and typhoon_poll.is_enabled())
-            enrichment = self.typhoon_enrichment_service
+            channel = self.eqsc_channel_service
             if poll_enabled:
                 logger.info("[灾害预警] EQSC 台风轮询服务已就绪")
-            elif getattr(enrichment, "is_channel_enabled", False):
+            elif getattr(channel, "is_channel_enabled", False):
                 logger.info(
                     "[灾害预警] EQSC 通道已启用，但台风轮询子开关关闭；"
                     "实时台风推送将不可用"
@@ -358,14 +366,14 @@ class DisasterWarningService:
         AccessToken（约 1 小时）过期后会长期显示“鉴权失效”。
         """
         # 通道级预热：只要组总闸开启且 token 已配置即可，不依赖台风富化子开关
-        enrichment = self.typhoon_enrichment_service
-        if not getattr(enrichment, "is_channel_enabled", enrichment.is_enabled):
+        channel = self.eqsc_channel_service
+        if not channel.is_channel_enabled:
             return
 
         async def _warmup_and_keepalive() -> None:
-            await enrichment.warm_up_access_token()
+            await channel.warm_up_access_token()
             # 预热成功与否都启动保活：失败时循环会按重试间隔继续尝试
-            start_keepalive = getattr(enrichment, "start_token_keepalive", None)
+            start_keepalive = getattr(channel, "start_token_keepalive", None)
             if callable(start_keepalive):
                 start_keepalive(register_task=self.register_background_task)
 
@@ -527,11 +535,12 @@ class DisasterWarningService:
 
         try:
             # 台风事件：
-            # 1) FAN 遗留触发：多台风共舞时会整包重推，富化前先只读去重；
+            # 1) FAN 触发路径：多台风共舞时会整包重推，富化前先只读去重；
+            #    该路径数据仅有单值风圈，需 EQSC 富化补充轨迹与四象限风圈；
             # 2) EQSC 独立轮询：事件已含完整轨迹，跳过二次富化。
             if event.event_type == "typhoon":
                 source_id = str(getattr(event, "source_id", "") or "").strip()
-                if source_id != "typhoon_eqsc":
+                if source_id == "typhoon_fanstudio":
                     deduplicator = getattr(
                         getattr(self, "message_manager", None), "deduplicator", None
                     )

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -170,10 +170,7 @@ class DisasterWarningService:
         self.notification_center = NotificationCenter(self)
         # EQSC 通道服务：统一管理 EQSC 鉴权、健康状态与熔断器，
         # 台风富化、海啸轮询、CENC 烈度速报轮询共享该通道。
-        self.eqsc_channel_service = EqscChannelService(
-            config,
-            message_logger=self.message_logger,
-        )
+        self.eqsc_channel_service = EqscChannelService(config)
         # 台风 EQSC 富化服务，在台风事件进入流水线前按需拉取 EQSC 详细数据。
         # 注入 message_logger，使 EQSC HTTP 响应进入原始消息日志链路。
         self.typhoon_enrichment_service = TyphoonEnrichmentService(

--- a/core/app/runtime/disaster_service_cache.py
+++ b/core/app/runtime/disaster_service_cache.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from astrbot.api import logger
+
+from ...services.identity.event_identity import ensure_utc_datetime
 
 
 class DisasterServiceCacheService:
@@ -85,13 +88,27 @@ class DisasterServiceCacheService:
                         )
                         supported_institutions = set(institutions.keys())
 
+                    # 当前 UTC 时间，用于剔除“被错误时区污染到未来”的历史状态
+                    now_utc = datetime.now(timezone.utc)
+
                     for key, value in data.items():
                         # 仅恢复当前仍受支持的机构键，避免历史版本缓存污染现有状态结构。
                         if supported_institutions and key not in supported_institutions:
                             continue
                         if not isinstance(value, dict):
                             continue
-                        if not value.get("issued_at"):
+                        issued_at_raw = str(value.get("issued_at") or "").strip()
+                        if not issued_at_raw:
+                            continue
+                        # 防御：若缓存中的发布时间被解析到未来（超过 1 小时），
+                        # 说明该记录曾被错误时区污染，直接丢弃避免复活脏状态。
+                        issued_dt = ensure_utc_datetime(
+                            issued_at_raw,
+                            source_id=str(value.get("source_id") or "").strip(),
+                        )
+                        if issued_dt is None or issued_dt > now_utc + timedelta(
+                            seconds=3600
+                        ):
                             continue
                         restored[key] = value  # 校验通过，载入缓存
             else:
@@ -133,6 +150,9 @@ class DisasterServiceCacheService:
             for source_id in meta.get("source_ids", []):
                 source_to_institution[str(source_id).strip()] = institution_key
 
+        # 当前 UTC 时间，用于剔除“被错误时区污染到未来”的历史状态
+        now_utc = datetime.now(timezone.utc)
+
         # 遍历近期推送，提取其中的地震预警(earthquake_warning)事件
         for record in recent_pushes:
             if not isinstance(record, dict):
@@ -148,6 +168,11 @@ class DisasterServiceCacheService:
                 continue
             issued_at = str(record.get("time") or "").strip()
             if not issued_at:
+                continue
+            # 防御：若恢复出的发布时间被解析到未来（超过 1 小时），
+            # 说明该记录的时间被错误时区污染，直接丢弃避免复活脏状态。
+            issued_dt = ensure_utc_datetime(issued_at, source_id=source_id)
+            if issued_dt is None or issued_dt > now_utc + timedelta(seconds=3600):
                 continue
             # 组装 EEW 查询状态字典
             state[institution_key] = {
@@ -195,6 +220,9 @@ class DisasterServiceCacheService:
             for source_id in meta.get("source_ids", []):
                 source_to_institution[str(source_id).strip()] = institution_key
 
+        # 当前 UTC 时间，用于剔除“被错误时区污染到未来”的历史状态
+        now_utc = datetime.now(timezone.utc)
+
         # 遍历数据库近期事件并填补状态
         for record in recent_events:
             if not isinstance(record, dict):
@@ -209,6 +237,11 @@ class DisasterServiceCacheService:
                 continue
             issued_at = str(record.get("time") or "").strip()
             if not issued_at:
+                continue
+            # 防御：若恢复出的发布时间被解析到未来（超过 1 小时），
+            # 说明该记录的时间被错误时区污染，直接丢弃避免复活脏状态。
+            issued_dt = ensure_utc_datetime(issued_at, source_id=source_id)
+            if issued_dt is None or issued_dt > now_utc + timedelta(seconds=3600):
                 continue
             # 组装状态元数据
             state[institution_key] = {

--- a/core/app/runtime/disaster_service_cache.py
+++ b/core/app/runtime/disaster_service_cache.py
@@ -19,6 +19,39 @@ from ...services.identity.event_identity import ensure_utc_datetime
 class DisasterServiceCacheService:
     """灾害服务缓存持久化服务。"""
 
+    # 未来时间容差窗口（秒）：历史记录被错误时区解析到“未来超过 1 小时”时视为污染。
+    # 统一在此维护，避免多个恢复路径各自硬编码导致行为漂移。
+    FUTURE_POLLUTION_TOLERANCE_SECONDS = 3600
+
+    @staticmethod
+    def _is_future_contaminated(
+        issued_at_raw: str,
+        source_id: str,
+        now_utc: datetime | None = None,
+    ) -> bool:
+        """判断发布时间是否被错误时区污染到未来（超过容差窗口）。
+
+        防御性工具：若恢复出的发布时间被解析到未来（超过 1 小时），
+        说明该记录的时间被错误时区污染，应直接丢弃避免复活脏状态。
+
+        Args:
+            issued_at_raw: 原始发布时间字符串。
+            source_id: 数据源 ID，用于时区解析。
+            now_utc: 当前 UTC 时间；不传时内部实时获取。
+
+        Returns:
+            True 表示该时间被污染到未来，应丢弃。
+        """
+        if not issued_at_raw:
+            return True
+        now = now_utc if now_utc is not None else datetime.now(timezone.utc)
+        issued_dt = ensure_utc_datetime(issued_at_raw, source_id=source_id)
+        if issued_dt is None:
+            return True
+        return issued_dt > now + timedelta(
+            seconds=DisasterServiceCacheService.FUTURE_POLLUTION_TOLERANCE_SECONDS
+        )
+
     def __init__(self, service):
         self.service = service  # 主服务 DisasterWarningService 实例
 
@@ -98,16 +131,10 @@ class DisasterServiceCacheService:
                         if not isinstance(value, dict):
                             continue
                         issued_at_raw = str(value.get("issued_at") or "").strip()
-                        if not issued_at_raw:
-                            continue
-                        # 防御：若缓存中的发布时间被解析到未来（超过 1 小时），
-                        # 说明该记录曾被错误时区污染，直接丢弃避免复活脏状态。
-                        issued_dt = ensure_utc_datetime(
+                        if self._is_future_contaminated(
                             issued_at_raw,
                             source_id=str(value.get("source_id") or "").strip(),
-                        )
-                        if issued_dt is None or issued_dt > now_utc + timedelta(
-                            seconds=3600
+                            now_utc=now_utc,
                         ):
                             continue
                         restored[key] = value  # 校验通过，载入缓存
@@ -167,12 +194,9 @@ class DisasterServiceCacheService:
             if not institution_key or institution_key in state:
                 continue
             issued_at = str(record.get("time") or "").strip()
-            if not issued_at:
-                continue
-            # 防御：若恢复出的发布时间被解析到未来（超过 1 小时），
-            # 说明该记录的时间被错误时区污染，直接丢弃避免复活脏状态。
-            issued_dt = ensure_utc_datetime(issued_at, source_id=source_id)
-            if issued_dt is None or issued_dt > now_utc + timedelta(seconds=3600):
+            if self._is_future_contaminated(
+                issued_at, source_id=source_id, now_utc=now_utc
+            ):
                 continue
             # 组装 EEW 查询状态字典
             state[institution_key] = {
@@ -236,12 +260,9 @@ class DisasterServiceCacheService:
             if not institution_key or institution_key in state:
                 continue
             issued_at = str(record.get("time") or "").strip()
-            if not issued_at:
-                continue
-            # 防御：若恢复出的发布时间被解析到未来（超过 1 小时），
-            # 说明该记录的时间被错误时区污染，直接丢弃避免复活脏状态。
-            issued_dt = ensure_utc_datetime(issued_at, source_id=source_id)
-            if issued_dt is None or issued_dt > now_utc + timedelta(seconds=3600):
+            if self._is_future_contaminated(
+                issued_at, source_id=source_id, now_utc=now_utc
+            ):
                 continue
             # 组装状态元数据
             state[institution_key] = {

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -369,12 +369,15 @@ class DisasterServiceLifecycleService:
                 if eqsc_cenc_ir_poll is not None:
                     await eqsc_cenc_ir_poll.stop()
 
-                # 关闭台风 EQSC 富化服务的 HTTP 会话与令牌管理器资源
+                # 先关闭台风富化服务，最后关闭 EQSC 通道服务（停止保活并释放令牌管理器资源）。
                 typhoon_enrichment = getattr(
                     self.service, "typhoon_enrichment_service", None
                 )
                 if typhoon_enrichment:
                     await typhoon_enrichment.close()
+                eqsc_channel = getattr(self.service, "eqsc_channel_service", None)
+                if eqsc_channel:
+                    await eqsc_channel.close()
 
                 # 统计数据库只在已初始化时关闭，避免访问尚未建立的数据库句柄。
                 if (

--- a/core/app/runtime/disaster_service_runtime.py
+++ b/core/app/runtime/disaster_service_runtime.py
@@ -64,7 +64,12 @@ class DisasterServiceRuntimeService:
         for conn_name, conn_config in ordered_items:
             # 这里只处理由连接计划生成的 WebSocket 连接；
             # 具体断线重连、备用地址切换等细节由连接管理器内部负责。
-            if conn_config["handler"] in ["fan_studio", "p2p", "wolfx", "global_quake"]:
+            if conn_config["handler"] in [
+                "fan_studio",
+                "p2p",
+                "wolfx",
+                "openquake_api",
+            ]:
                 # 这份连接附加信息会一路传入连接管理器，作为连接状态展示、重连通知、
                 # 管理端查询等场景的上下文信息。
                 connection_info = {

--- a/core/app/runtime/disaster_service_status.py
+++ b/core/app/runtime/disaster_service_status.py
@@ -53,7 +53,7 @@ class DisasterServiceStatusService:
             message_logger_enabled=self.service.message_logger.enabled
             if self.service.message_logger
             else False,
-            global_quake_connected=bool(metrics.get("global_quake_connected")),
+            openquake_connected=bool(metrics.get("openquake_connected")),
         )
         # total_connections 已由 runtime snapshot 按 catalog 期望通道统计
         # （含 EQSC / S-Net / 已停用通道），此处不再二次累加。

--- a/core/app/services/eqsc_channel_service.py
+++ b/core/app/services/eqsc_channel_service.py
@@ -1,0 +1,320 @@
+"""
+EQSC 通道服务。
+
+负责 EQSC HTTP 通道的公共基础设施：
+- 组总闸与子开关解析（resolve_eqsc_flags）
+- AccessToken 管理（EqscTokenManager）与启动预热 / 后台保活
+- 通道健康状态与连接计数（get_health_status / get_connection_counts）
+- 通道级熔断器（连续失败短路，供富化 / 查询复用）
+
+台风富化、海啸轮询、CENC 烈度速报轮询等 EQSC 子能力共享本通道，
+避免各自维护一份鉴权状态与熔断状态。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from ....utils.plugin_logger import plugin_logger as logger
+from ...network.http.eqsc_token_manager import EqscTokenManager
+
+
+class EqscChannelService:
+    """EQSC HTTP 通道总闸服务。"""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        message_logger: Any | None = None,
+    ):
+        """初始化 EQSC 通道服务。
+
+        Args:
+            config: 插件全局配置字典。
+            message_logger: 可选原始消息记录器（保留签名，供子客户端注入使用）。
+        """
+        eqsc_config = config.get("data_sources", {}).get("eqsc", {})
+        if not isinstance(eqsc_config, dict):
+            eqsc_config = {}
+        self._eqsc_config = eqsc_config
+        self._message_logger = message_logger
+        channel_enabled, typhoon_enrichment = self.resolve_eqsc_flags(eqsc_config)
+        # 组总闸：控制 EQSC 通道（鉴权/连通/后续子能力入口）
+        self._channel_enabled = channel_enabled
+        # 子能力：台风轮询/富化（可独立关闭）
+        self._typhoon_enrichment_enabled = typhoon_enrichment
+        self._token_manager = EqscTokenManager(eqsc_config)
+
+        # 熔断器参数（通道级：连续失败短路）
+        self._circuit_failure_threshold = 5
+        self._circuit_cooldown = 300
+        self._circuit_failures = 0
+        self._circuit_open_until: float = 0.0
+
+        # AccessToken 后台保活：状态面板只读 has_valid_access_token，
+        # 若仅启动预热、无业务请求触发 get_access_token，约 1 小时后会误显示“鉴权失效”。
+        self._token_keepalive_task: asyncio.Task | None = None
+        self._token_keepalive_stop = asyncio.Event()
+        # 最短检查间隔，避免异常情况下 tight loop
+        self._token_keepalive_min_interval = 30.0
+        # 无有效 token 时的重试间隔
+        self._token_keepalive_retry_interval = 120.0
+
+    @staticmethod
+    def resolve_eqsc_flags(eqsc_config: dict[str, Any] | None) -> tuple[bool, bool]:
+        """解析 EQSC 组总闸与台风子开关。
+
+        Returns:
+            (channel_enabled, typhoon_enrichment_enabled)
+
+        兼容旧配置：若缺少 typhoon 字段，则回退使用 enabled 的值
+        （旧语义下 enabled 同时表示通道与台风轮询）。
+        """
+        if not isinstance(eqsc_config, dict):
+            return False, False
+        channel_enabled = bool(eqsc_config.get("enabled", False))
+        if "typhoon" in eqsc_config:
+            typhoon_enrichment = bool(eqsc_config.get("typhoon"))
+        else:
+            typhoon_enrichment = channel_enabled
+        return channel_enabled, typhoon_enrichment
+
+    @property
+    def is_channel_enabled(self) -> bool:
+        """EQSC 通道是否可用：组总闸开启且 refresh_token 已配置。"""
+        return self._channel_enabled and self._token_manager.is_configured
+
+    @property
+    def is_typhoon_enrichment_enabled(self) -> bool:
+        """台风子能力是否开启（不含 token 判定）。"""
+        return bool(self._typhoon_enrichment_enabled)
+
+    @property
+    def token_manager(self) -> EqscTokenManager:
+        """共享的 EQSC 令牌管理器（供子客户端复用）。"""
+        return self._token_manager
+
+    # ---------- 熔断器（通道级） ----------
+
+    def is_circuit_open(self) -> bool:
+        """检查通道熔断器是否处于开启状态。"""
+        if self._circuit_failures >= self._circuit_failure_threshold:
+            if time.time() < self._circuit_open_until:
+                return True
+            # 冷却期已过，重置熔断器
+            self._circuit_failures = 0
+        return False
+
+    def record_success(self) -> None:
+        """记录一次成功，重置熔断器。"""
+        self._circuit_failures = 0
+
+    def record_failure(self) -> None:
+        """记录一次失败，可能触发熔断器。"""
+        self._circuit_failures += 1
+        if self._circuit_failures >= self._circuit_failure_threshold:
+            self._circuit_open_until = time.time() + self._circuit_cooldown
+            logger.warning(
+                f"[灾害预警] EQSC 熔断器已开启，{self._circuit_cooldown}秒内跳过 EQSC 查询"
+            )
+
+    # ---------- 健康与连接状态 ----------
+
+    def get_health_status(self) -> dict[str, Any]:
+        """返回 EQSC 通道健康快照，供管理端连接状态面板使用。"""
+        circuit_open = self.is_circuit_open()
+        # config_enabled：组总闸（不混入 token）
+        config_enabled = bool(self._channel_enabled)
+        typhoon_enrichment = bool(self._typhoon_enrichment_enabled)
+        access_token_valid = bool(self._token_manager.has_valid_access_token)
+        # 海啸子开关：缺省跟随通道总闸（与配置校验语义一致）
+        raw_eqsc = self._eqsc_config if isinstance(self._eqsc_config, dict) else {}
+        if "jma_tsunami" in raw_eqsc:
+            jma_tsunami = bool(raw_eqsc.get("jma_tsunami"))
+        else:
+            jma_tsunami = config_enabled
+        if "china_cenc_intensity_report" in raw_eqsc:
+            cenc_ir = bool(raw_eqsc.get("china_cenc_intensity_report"))
+        else:
+            cenc_ir = config_enabled
+        return {
+            # enabled：通道可工作（组总闸 + token 已配置）
+            "enabled": self.is_channel_enabled,
+            "config_enabled": config_enabled,
+            "typhoon": typhoon_enrichment,
+            # 台风富化实际可工作
+            "typhoon_active": self.is_channel_enabled and typhoon_enrichment,
+            "jma_tsunami": jma_tsunami,
+            "china_cenc_intensity_report": cenc_ir,
+            "token_configured": bool(self._token_manager.is_configured),
+            "access_token_valid": access_token_valid,
+            "circuit_open": circuit_open,
+            "circuit_failures": int(self._circuit_failures),
+            "connection_type": "http",
+            "provider": "eqsc",
+            # EQSC 子数据源：台风 → 海啸 → CENC 烈度速报
+            "sub_sources": {
+                "china_typhoon": typhoon_enrichment,
+                "jma_tsunami": jma_tsunami,
+                "china_cenc_intensity_report": cenc_ir,
+            },
+        }
+
+    def get_connection_counts(self) -> tuple[int, int]:
+        """返回 EQSC 对活跃/总连接数的贡献 (active, total)。
+
+        - total：组总闸开启且 refresh_token 已配置时计 1
+        - active：当前内存 AccessToken 仍有效时计 1
+        """
+        health = self.get_health_status()
+        total = 1 if bool(health.get("enabled")) else 0
+        active = 1 if bool(health.get("access_token_valid")) else 0
+        return active, total
+
+    @staticmethod
+    def resolve_connection_counts(service: Any) -> tuple[int, int]:
+        """从灾害主服务安全解析 EQSC 连接计数，供状态/实时载荷复用。"""
+        if service is None:
+            return 0, 0
+        channel = getattr(service, "eqsc_channel_service", None)
+        if channel is None:
+            return 0, 0
+        getter = getattr(channel, "get_connection_counts", None)
+        if not callable(getter):
+            return 0, 0
+        try:
+            result = getter()
+        except Exception:
+            return 0, 0
+        if not isinstance(result, tuple) or len(result) != 2:
+            return 0, 0
+        try:
+            return int(result[0] or 0), int(result[1] or 0)
+        except (TypeError, ValueError):
+            return 0, 0
+
+    # ---------- AccessToken 预热与保活 ----------
+
+    async def warm_up_access_token(self) -> bool:
+        """启动后主动预热 AccessToken，避免状态面板长期显示鉴权失效。
+
+        仅在 EQSC 通道已启用且 token 已配置时请求；不触发业务查询。
+        成功返回 True，未启用/失败返回 False。
+        """
+        if not self.is_channel_enabled:
+            return False
+        try:
+            access_token = await self._token_manager.get_access_token()
+            if access_token:
+                logger.info("[灾害预警] EQSC AccessToken 预热成功")
+                return True
+            logger.warning("[灾害预警] EQSC AccessToken 预热失败：未拿到有效令牌")
+            return False
+        except Exception as exc:
+            logger.warning(
+                f"[灾害预警] EQSC AccessToken 预热异常: {type(exc).__name__}: {exc}"
+            )
+            return False
+
+    def start_token_keepalive(self, *, register_task=None) -> None:
+        """启动 AccessToken 后台保活循环（幂等）。
+
+        在过期前提前调用 get_access_token 续期，保证状态面板在无台风业务时
+        也不会因内存 token 过期而长期显示“鉴权失效”。
+
+        Args:
+            register_task: 可选回调，用于把保活任务登记到服务级后台任务集合，
+                便于停机时统一回收（例如 DisasterService.register_background_task）。
+        """
+        if not self.is_channel_enabled:
+            return
+        if (
+            self._token_keepalive_task is not None
+            and not self._token_keepalive_task.done()
+        ):
+            return
+        self._token_keepalive_stop.clear()
+        self._token_keepalive_task = asyncio.create_task(
+            self._token_keepalive_loop(),
+            name="dw_eqsc_token_keepalive",
+        )
+        if callable(register_task):
+            try:
+                register_task(self._token_keepalive_task)
+            except Exception as exc:
+                logger.debug(
+                    f"[灾害预警] 注册 EQSC token 保活任务失败: {type(exc).__name__}: {exc}"
+                )
+
+    async def stop_token_keepalive(self) -> None:
+        """停止 AccessToken 后台保活循环。"""
+        self._token_keepalive_stop.set()
+        task = self._token_keepalive_task
+        self._token_keepalive_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
+    async def _token_keepalive_loop(self) -> None:
+        """周期性确保内存 AccessToken 未过期。"""
+        logger.debug("[灾害预警] EQSC AccessToken 保活循环已启动")
+        try:
+            while not self._token_keepalive_stop.is_set():
+                if not self.is_channel_enabled:
+                    break
+
+                # 先尝试获取/续期（内部会在提前刷新窗口内真正打网络）
+                try:
+                    token = await self._token_manager.get_access_token()
+                except Exception as exc:
+                    logger.debug(
+                        f"[灾害预警] EQSC AccessToken 保活刷新异常: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                    token = None
+
+                if not token:
+                    sleep_seconds = self._token_keepalive_retry_interval
+                else:
+                    # 在真正过期前 access_advance_seconds 触发续期；
+                    # 再留一点缓冲，避免刚好踩在边界。
+                    remaining = self._token_manager.seconds_until_expiry()
+                    advance = float(
+                        getattr(self._token_manager, "_access_advance_seconds", 60)
+                        or 60
+                    )
+                    sleep_seconds = max(
+                        self._token_keepalive_min_interval,
+                        remaining - advance,
+                    )
+                    # 上限避免极端有效期导致长时间不检查配置变更
+                    sleep_seconds = min(sleep_seconds, 1800.0)
+
+                try:
+                    await asyncio.wait_for(
+                        self._token_keepalive_stop.wait(),
+                        timeout=sleep_seconds,
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            raise
+        finally:
+            logger.debug("[灾害预警] EQSC AccessToken 保活循环已停止")
+
+    async def close(self) -> None:
+        """关闭通道服务：停止保活循环并释放令牌管理器资源。"""
+        await self.stop_token_keepalive()
+        await self._token_manager.close()
+
+
+__all__ = ["EqscChannelService"]

--- a/core/app/services/eqsc_channel_service.py
+++ b/core/app/services/eqsc_channel_service.py
@@ -27,19 +27,16 @@ class EqscChannelService:
     def __init__(
         self,
         config: dict[str, Any],
-        message_logger: Any | None = None,
     ):
         """初始化 EQSC 通道服务。
 
         Args:
             config: 插件全局配置字典。
-            message_logger: 可选原始消息记录器（保留签名，供子客户端注入使用）。
         """
         eqsc_config = config.get("data_sources", {}).get("eqsc", {})
         if not isinstance(eqsc_config, dict):
             eqsc_config = {}
         self._eqsc_config = eqsc_config
-        self._message_logger = message_logger
         channel_enabled, typhoon_enrichment = self.resolve_eqsc_flags(eqsc_config)
         # 组总闸：控制 EQSC 通道（鉴权/连通/后续子能力入口）
         self._channel_enabled = channel_enabled
@@ -95,6 +92,29 @@ class EqscChannelService:
     def token_manager(self) -> EqscTokenManager:
         """共享的 EQSC 令牌管理器（供子客户端复用）。"""
         return self._token_manager
+
+    @staticmethod
+    def resolve_shared_token_manager(service: Any) -> EqscTokenManager | None:
+        """从灾害主服务安全解析共享的 EQSC 令牌管理器。
+
+        供台风富化、海啸轮询、CENC 烈度速报轮询等 EQSC 子能力复用，
+        避免各自维护一份鉴权状态。
+
+        Args:
+            service: 灾害主服务（DisasterWarningService）实例。
+
+        Returns:
+            共享的 EqscTokenManager；服务缺失或类型不符时返回 None。
+        """
+        if service is None:
+            return None
+        channel = getattr(service, "eqsc_channel_service", None)
+        if channel is None:
+            return None
+        token_manager = getattr(channel, "token_manager", None)
+        if isinstance(token_manager, EqscTokenManager):
+            return token_manager
+        return None
 
     # ---------- 熔断器（通道级） ----------
 
@@ -260,8 +280,10 @@ class EqscChannelService:
             await task
         except asyncio.CancelledError:
             pass
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug(
+                f"[灾害预警] 停止 EQSC token 保活任务异常: {type(exc).__name__}: {exc}"
+            )
 
     async def _token_keepalive_loop(self) -> None:
         """周期性确保内存 AccessToken 未过期。"""
@@ -287,10 +309,7 @@ class EqscChannelService:
                     # 在真正过期前 access_advance_seconds 触发续期；
                     # 再留一点缓冲，避免刚好踩在边界。
                     remaining = self._token_manager.seconds_until_expiry()
-                    advance = float(
-                        getattr(self._token_manager, "_access_advance_seconds", 60)
-                        or 60
-                    )
+                    advance = float(self._token_manager.access_advance_seconds or 60)
                     sleep_seconds = max(
                         self._token_keepalive_min_interval,
                         remaining - advance,

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -411,7 +411,9 @@ class TyphoonEnrichmentService:
             if result:
                 self._channel_service.record_success()
                 return result
-            self._channel_service.record_failure()
+            # 空结果属于正常业务情况（编号不存在 / 不在 EQSC 列表中），
+            # 此时 HTTP 请求本身成功，不应计入通道级熔断失败；
+            # 仅异常路径（下方 except）才累积熔断计数。
             return None
         except Exception as e:
             self._channel_service.record_failure()

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -4,18 +4,20 @@
 负责在收到 FAN Studio 台风推送后，向 EQSC API 拉取台风详细数据
 （历史轨迹、预测路径、四象限风圈），并合并到事件中供展示使用。
 
+EQSC 通道级能力（鉴权、保活、健康、熔断）由 EqscChannelService 统一提供，
+本服务只保留台风业务相关逻辑：Fan 触发路径的富化合并与台风查询入口。
+
 核心策略：
 1. 同步阻塞等待 EQSC 查询完成才推送，只有一直匹配不上才回退到 FAN Studio 基础数据。
 2. 指数退避重试，最多约5分钟。
 3. 最大等待上限：300秒后强制放弃，以 FAN Studio 基础数据回退。
-4. 熔断器：连续失败后短路，5分钟内跳过 EQSC 查询直接回退。
+4. 熔断器：连续失败后短路（通道级，由 EqscChannelService 维护）。
 5. 按台风 ID 缓存 EQSC 结果（5分钟 TTL），避免重复请求。
 """
 
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import Any
 
 from ....utils.plugin_logger import plugin_logger as logger
@@ -25,41 +27,41 @@ from ...domain.typhoon import (
     constrain_wind_circle_by_fan_radius,
     to_eqsc_id,
 )
-from ...network.http.eqsc_token_manager import EqscTokenManager
 from ...network.http.eqsc_typhoon_client import EqscTyphoonClient
+from .eqsc_channel_service import EqscChannelService
 
 
 class TyphoonEnrichmentService:
-    """台风 EQSC 富化服务。"""
+    """台风 EQSC 富化服务（FAN 触发路径的遗留兼容 + 台风查询入口）。"""
 
     def __init__(
         self,
         config: dict[str, Any],
+        eqsc_channel_service: EqscChannelService,
         message_logger: Any | None = None,
     ):
         """初始化富化服务。
 
         Args:
             config: 插件全局配置字典。
+            eqsc_channel_service: EQSC 通道服务（提供共享令牌与熔断状态）。
             message_logger: 可选原始消息记录器，用于落盘 EQSC HTTP 响应。
         """
         eqsc_config = config.get("data_sources", {}).get("eqsc", {})
         if not isinstance(eqsc_config, dict):
             eqsc_config = {}
-        # 保留原始 EQSC 配置，供健康面板读取海啸等子开关
-        self._eqsc_config = eqsc_config
-        channel_enabled, typhoon_enrichment = self.resolve_eqsc_flags(eqsc_config)
-        # 组总闸：控制 EQSC 通道（鉴权/连通/后续子能力入口）
-        self._channel_enabled = channel_enabled
-        # 子能力：台风富化（可独立关闭）
-        self._typhoon_enrichment_enabled = typhoon_enrichment
-        # 兼容旧属性名：历史代码可能读取 _enabled 表示“服务是否工作”
-        self._enabled = self._channel_enabled
-        self._token_manager = EqscTokenManager(eqsc_config)
+        self._channel_service = eqsc_channel_service
+        # 台风富化子开关（通道总闸由 EqscChannelService 维护）
+        self._typhoon_enrichment_enabled = (
+            eqsc_channel_service.is_typhoon_enrichment_enabled
+        )
+        # 复用通道服务的 token_manager（不拥有；关闭由通道服务负责）
+        self._token_manager = eqsc_channel_service.token_manager
         self._typhoon_client = EqscTyphoonClient(
             self._token_manager,
             eqsc_config,
             message_logger=message_logger,
+            owns_token_manager=False,
         )
 
         # 重试参数（硬编码，降低使用门槛）
@@ -69,44 +71,10 @@ class TyphoonEnrichmentService:
         self._max_delay = 180  # 指数退避延迟上限（秒）
         self._max_total_wait = 300  # 后台重试总等待上限（秒）
 
-        # 熔断器参数（硬编码）
-        self._circuit_failure_threshold = 5  # 连续失败此次数后开启熔断器
-        self._circuit_cooldown = 300  # 熔断器冷却时间（秒）
-        self._circuit_failures = 0
-        self._circuit_open_until: float = 0.0
-
-        # AccessToken 后台保活：状态面板只读 has_valid_access_token，
-        # 若仅启动预热、无业务请求触发 get_access_token，约 1 小时后会误显示“鉴权失效”。
-        self._token_keepalive_task: asyncio.Task | None = None
-        self._token_keepalive_stop = asyncio.Event()
-        # 最短检查间隔，避免异常情况下 tight loop
-        self._token_keepalive_min_interval = 30.0
-        # 无有效 token 时的重试间隔
-        self._token_keepalive_retry_interval = 120.0
-
-    @staticmethod
-    def resolve_eqsc_flags(eqsc_config: dict[str, Any] | None) -> tuple[bool, bool]:
-        """解析 EQSC 组总闸与台风富化子开关。
-
-        Returns:
-            (channel_enabled, typhoon_enrichment_enabled)
-
-        兼容旧配置：若缺少 typhoon_enrichment 字段，则回退使用 enabled 的值
-        （旧语义下 enabled 同时表示通道与台风富化）。
-        """
-        if not isinstance(eqsc_config, dict):
-            return False, False
-        channel_enabled = bool(eqsc_config.get("enabled", False))
-        if "typhoon_enrichment" in eqsc_config:
-            typhoon_enrichment = bool(eqsc_config.get("typhoon_enrichment"))
-        else:
-            typhoon_enrichment = channel_enabled
-        return channel_enabled, typhoon_enrichment
-
     @property
     def is_channel_enabled(self) -> bool:
-        """EQSC 通道是否可用：组总闸开启且 refresh_token 已配置。"""
-        return self._channel_enabled and self._token_manager.is_configured
+        """EQSC 通道是否可用（委托通道服务）。"""
+        return self._channel_service.is_channel_enabled
 
     @property
     def is_typhoon_enrichment_enabled(self) -> bool:
@@ -117,215 +85,6 @@ class TyphoonEnrichmentService:
     def is_enabled(self) -> bool:
         """台风富化是否可实际工作：通道可用 + 子开关开启。"""
         return self.is_channel_enabled and self._typhoon_enrichment_enabled
-
-    def get_health_status(self) -> dict[str, Any]:
-        """返回 EQSC 通道健康快照，供管理端连接状态面板使用。"""
-        circuit_open = self._is_circuit_open()
-        # config_enabled：组总闸（不混入 token）
-        config_enabled = bool(self._channel_enabled)
-        typhoon_enrichment = bool(self._typhoon_enrichment_enabled)
-        access_token_valid = bool(self._token_manager.has_valid_access_token)
-        # 海啸子开关：缺省跟随通道总闸（与配置校验语义一致）
-        raw_eqsc = self._eqsc_config if isinstance(self._eqsc_config, dict) else {}
-        if "jma_tsunami" in raw_eqsc:
-            jma_tsunami = bool(raw_eqsc.get("jma_tsunami"))
-        else:
-            jma_tsunami = config_enabled
-        if "china_cenc_intensity_report" in raw_eqsc:
-            cenc_ir = bool(raw_eqsc.get("china_cenc_intensity_report"))
-        else:
-            cenc_ir = config_enabled
-        return {
-            # enabled：通道可工作（组总闸 + token 已配置）
-            "enabled": self.is_channel_enabled,
-            "config_enabled": config_enabled,
-            "typhoon_enrichment": typhoon_enrichment,
-            # 台风富化实际可工作
-            "typhoon_enrichment_active": self.is_enabled,
-            "jma_tsunami": jma_tsunami,
-            "china_cenc_intensity_report": cenc_ir,
-            "token_configured": bool(self._token_manager.is_configured),
-            "access_token_valid": access_token_valid,
-            "circuit_open": circuit_open,
-            "circuit_failures": int(self._circuit_failures),
-            "connection_type": "http",
-            "provider": "eqsc",
-            # EQSC 子数据源：台风 → 海啸 → CENC 烈度速报
-            "sub_sources": {
-                "china_typhoon": typhoon_enrichment,
-                "jma_tsunami": jma_tsunami,
-                "china_cenc_intensity_report": cenc_ir,
-            },
-        }
-
-    def get_connection_counts(self) -> tuple[int, int]:
-        """返回 EQSC 对活跃/总连接数的贡献 (active, total)。
-
-        - total：组总闸开启且 refresh_token 已配置时计 1
-        - active：当前内存 AccessToken 仍有效时计 1
-        """
-        health = self.get_health_status()
-        total = 1 if bool(health.get("enabled")) else 0
-        active = 1 if bool(health.get("access_token_valid")) else 0
-        return active, total
-
-    async def warm_up_access_token(self) -> bool:
-        """启动后主动预热 AccessToken，避免状态面板长期显示鉴权失效。
-
-        仅在 EQSC 通道已启用且 token 已配置时请求；不触发业务查询。
-        成功返回 True，未启用/失败返回 False。
-        """
-        if not self.is_channel_enabled:
-            return False
-        try:
-            access_token = await self._token_manager.get_access_token()
-            if access_token:
-                logger.info("[灾害预警] EQSC AccessToken 预热成功")
-                return True
-            logger.warning("[灾害预警] EQSC AccessToken 预热失败：未拿到有效令牌")
-            return False
-        except Exception as exc:
-            logger.warning(
-                f"[灾害预警] EQSC AccessToken 预热异常: {type(exc).__name__}: {exc}"
-            )
-            return False
-
-    def start_token_keepalive(self, *, register_task=None) -> None:
-        """启动 AccessToken 后台保活循环（幂等）。
-
-        在过期前提前调用 get_access_token 续期，保证状态面板在无台风业务时
-        也不会因内存 token 过期而长期显示“鉴权失效”。
-
-        Args:
-            register_task: 可选回调，用于把保活任务登记到服务级后台任务集合，
-                便于停机时统一回收（例如 DisasterService.register_background_task）。
-        """
-        if not self.is_channel_enabled:
-            return
-        if (
-            self._token_keepalive_task is not None
-            and not self._token_keepalive_task.done()
-        ):
-            return
-        self._token_keepalive_stop.clear()
-        self._token_keepalive_task = asyncio.create_task(
-            self._token_keepalive_loop(),
-            name="dw_eqsc_token_keepalive",
-        )
-        if callable(register_task):
-            try:
-                register_task(self._token_keepalive_task)
-            except Exception as exc:
-                logger.debug(
-                    f"[灾害预警] 注册 EQSC token 保活任务失败: {type(exc).__name__}: {exc}"
-                )
-
-    async def stop_token_keepalive(self) -> None:
-        """停止 AccessToken 后台保活循环。"""
-        self._token_keepalive_stop.set()
-        task = self._token_keepalive_task
-        self._token_keepalive_task = None
-        if task is None:
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            pass
-
-    async def _token_keepalive_loop(self) -> None:
-        """周期性确保内存 AccessToken 未过期。"""
-        logger.debug("[灾害预警] EQSC AccessToken 保活循环已启动")
-        try:
-            while not self._token_keepalive_stop.is_set():
-                if not self.is_channel_enabled:
-                    break
-
-                # 先尝试获取/续期（内部会在提前刷新窗口内真正打网络）
-                try:
-                    token = await self._token_manager.get_access_token()
-                except Exception as exc:
-                    logger.debug(
-                        f"[灾害预警] EQSC AccessToken 保活刷新异常: "
-                        f"{type(exc).__name__}: {exc}"
-                    )
-                    token = None
-
-                if not token:
-                    sleep_seconds = self._token_keepalive_retry_interval
-                else:
-                    # 在真正过期前 access_advance_seconds 触发续期；
-                    # 再留一点缓冲，避免刚好踩在边界。
-                    remaining = self._token_manager.seconds_until_expiry()
-                    advance = float(
-                        getattr(self._token_manager, "_access_advance_seconds", 60)
-                        or 60
-                    )
-                    sleep_seconds = max(
-                        self._token_keepalive_min_interval,
-                        remaining - advance,
-                    )
-                    # 上限避免极端有效期导致长时间不检查配置变更
-                    sleep_seconds = min(sleep_seconds, 1800.0)
-
-                try:
-                    await asyncio.wait_for(
-                        self._token_keepalive_stop.wait(),
-                        timeout=sleep_seconds,
-                    )
-                    break
-                except asyncio.TimeoutError:
-                    continue
-        except asyncio.CancelledError:
-            raise
-        finally:
-            logger.debug("[灾害预警] EQSC AccessToken 保活循环已停止")
-
-    @staticmethod
-    def resolve_connection_counts(service: Any) -> tuple[int, int]:
-        """从灾害主服务安全解析 EQSC 连接计数，供状态/实时载荷复用。"""
-        if service is None:
-            return 0, 0
-        enrichment = getattr(service, "typhoon_enrichment_service", None)
-        if enrichment is None:
-            return 0, 0
-        getter = getattr(enrichment, "get_connection_counts", None)
-        if not callable(getter):
-            return 0, 0
-        try:
-            result = getter()
-        except Exception:
-            return 0, 0
-        if not isinstance(result, tuple) or len(result) != 2:
-            return 0, 0
-        try:
-            return int(result[0] or 0), int(result[1] or 0)
-        except (TypeError, ValueError):
-            return 0, 0
-
-    def _is_circuit_open(self) -> bool:
-        """检查熔断器是否处于开启状态。"""
-        if self._circuit_failures >= self._circuit_failure_threshold:
-            if time.time() < self._circuit_open_until:
-                return True
-            # 冷却期已过，重置熔断器
-            self._circuit_failures = 0
-        return False
-
-    def _record_success(self) -> None:
-        """记录一次成功，重置熔断器。"""
-        self._circuit_failures = 0
-
-    def _record_failure(self) -> None:
-        """记录一次失败，可能触发熔断器。"""
-        self._circuit_failures += 1
-        if self._circuit_failures >= self._circuit_failure_threshold:
-            self._circuit_open_until = time.time() + self._circuit_cooldown
-            logger.warning(
-                f"[灾害预警] EQSC 熔断器已开启，{self._circuit_cooldown}秒内跳过 EQSC 查询"
-            )
 
     def _extract_eqsc_track_data(
         self,
@@ -552,7 +311,7 @@ class TyphoonEnrichmentService:
             return envelope
 
         # 熔断器开启时直接回退
-        if self._is_circuit_open():
+        if self._channel_service.is_circuit_open():
             logger.debug("[灾害预警] EQSC 熔断器开启中，跳过富化直接回退")
             return envelope
 
@@ -568,7 +327,7 @@ class TyphoonEnrichmentService:
                 timeout=float(self._initial_timeout),
             )
             if result:
-                self._record_success()
+                self._channel_service.record_success()
                 logger.info(f"[灾害预警] 台风 {typhoon_id} EQSC 富化成功（首次查询）")
                 return self._merge_eqsc_into_event(envelope, result)
         except Exception as e:
@@ -586,7 +345,7 @@ class TyphoonEnrichmentService:
                 break
 
             # 检查熔断器
-            if self._is_circuit_open():
+            if self._channel_service.is_circuit_open():
                 logger.info(f"[灾害预警] 台风 {typhoon_id} EQSC 重试因熔断器开启而中止")
                 break
 
@@ -600,7 +359,7 @@ class TyphoonEnrichmentService:
             try:
                 result = await self._try_fetch_eqsc(typhoon_id, name, name_en)
                 if result:
-                    self._record_success()
+                    self._channel_service.record_success()
                     logger.info(
                         f"[灾害预警] 台风 {typhoon_id} EQSC 富化成功（第 {attempt} 次重试）"
                     )
@@ -614,7 +373,7 @@ class TyphoonEnrichmentService:
             delay = min(delay * 2, float(self._max_delay))
 
         # 所有重试均失败，回退到 FAN Studio 基础数据
-        self._record_failure()
+        self._channel_service.record_failure()
         logger.warning(
             f"[灾害预警] 台风 {typhoon_id} EQSC 富化失败，已用 FAN Studio 基础数据回退"
         )
@@ -638,7 +397,7 @@ class TyphoonEnrichmentService:
         """
         if not self.is_enabled:
             return None
-        if self._is_circuit_open():
+        if self._channel_service.is_circuit_open():
             logger.debug("[灾害预警] EQSC 熔断器开启中，跳过台风详情查询")
             return None
 
@@ -650,12 +409,12 @@ class TyphoonEnrichmentService:
                 use_cache=use_cache,
             )
             if result:
-                self._record_success()
+                self._channel_service.record_success()
                 return result
-            self._record_failure()
+            self._channel_service.record_failure()
             return None
         except Exception as e:
-            self._record_failure()
+            self._channel_service.record_failure()
             logger.error(f"[灾害预警] EQSC 台风详情查询异常: {e}")
             return None
 
@@ -674,7 +433,7 @@ class TyphoonEnrichmentService:
         if not self.is_enabled:
             return []
 
-        if self._is_circuit_open():
+        if self._channel_service.is_circuit_open():
             logger.debug("[灾害预警] EQSC 熔断器开启中，跳过历史台风列表查询")
             return []
 
@@ -691,23 +450,18 @@ class TyphoonEnrichmentService:
                 use_cache=use_cache,
             )
             if typhoon_list:
-                self._record_success()
+                self._channel_service.record_success()
                 logger.info(
                     f"[灾害预警] EQSC 历史台风列表查询成功，共 {len(typhoon_list)} 个台风"
                 )
             return typhoon_list
         except Exception as e:
-            self._record_failure()
+            self._channel_service.record_failure()
             logger.error(f"[灾害预警] EQSC 获取历史台风列表异常: {e}")
             return []
 
-    async def fetch_active_typhoons(self) -> list[dict[str, Any]]:
-        """兼容旧名：实际返回 EQSC 无参台风列表（含历史）。"""
-        return await self.fetch_history_typhoons()
-
     async def close(self) -> None:
-        """关闭富化服务，释放资源。"""
-        await self.stop_token_keepalive()
+        """关闭富化服务，释放 HTTP 会话（token 由通道服务负责）。"""
         await self._typhoon_client.close()
 
 

--- a/core/message/builders/text_message_builder.py
+++ b/core/message/builders/text_message_builder.py
@@ -51,7 +51,7 @@ class TextMessageBuilder:
             "local_monitoring": active_config.get("local_monitoring", {}),
             # 台风展示是否暴露本地距离/逼近信息，对齐地震 local_monitoring.enabled。
             "typhoon_config": active_config.get("typhoon_config", {}),
-            # 会话级 data_sources（如 eqsc.typhoon_enrichment）影响台风展示是否使用 EQSC 富化字段。
+            # 会话级 data_sources（如 eqsc.typhoon）影响台风展示是否使用 EQSC 富化字段。
             "data_sources": active_config.get("data_sources", {}),
         }
 

--- a/core/message/logging/filters/raw_message_filter.py
+++ b/core/message/logging/filters/raw_message_filter.py
@@ -50,7 +50,7 @@ class RawMessageFilter:
         字符串与字典两个入口共用该检查，避免字符串形式的 tsunami/station/status
         消息绕过过滤而增大日志存储与处理压力。
         """
-        if "global_quake" in source_id.lower():
+        if "global_quake" in source_id.lower() or "openquake" in source_id.lower():
             inner_type = str(data.get("type") or "").lower()
             if inner_type not in ("earthquake", "weather"):
                 return f"OpenQuakeAPI 非地震/气象业务JSON消息过滤: {inner_type}"

--- a/core/message/message_logger.py
+++ b/core/message/message_logger.py
@@ -197,7 +197,7 @@ class MessageLogger:
         conn_type = (connection_info or {}).get("connection_type", "")
         if message_type != "websocket_message" and conn_type != "websocket":
             return None
-        if "global_quake" not in source.lower():
+        if "global_quake" not in source.lower() and "openquake" not in source.lower():
             return None
 
         try:

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -208,9 +208,9 @@ class PushExecutionService:
             eqsc_cfg = data_sources.get("eqsc", {})
             if not isinstance(eqsc_cfg, dict):
                 eqsc_cfg = {}
-            # 会话级 typhoon_enrichment 影响台风正文是否展示 EQSC 富化字段。
-            if "typhoon_enrichment" in eqsc_cfg:
-                typhoon_enrichment = bool(eqsc_cfg.get("typhoon_enrichment"))
+            # 会话级 typhoon 开关影响台风正文是否展示 EQSC 富化字段。
+            if "typhoon" in eqsc_cfg:
+                typhoon_enrichment = bool(eqsc_cfg.get("typhoon"))
             else:
                 typhoon_enrichment = bool(eqsc_cfg.get("enabled", True))
             cache_key = json.dumps(
@@ -261,7 +261,7 @@ class PushExecutionService:
                         "show_local_estimation": typhoon_config.get(
                             "show_local_estimation", False
                         ),
-                        "typhoon_enrichment": typhoon_enrichment,
+                        "typhoon": typhoon_enrichment,
                     },
                     # 本地监控配置差异会导致地震正文附带不同的本地预估，
                     # 缺失时会使不同会话误共享同一份渲染结果。

--- a/core/message/runtime/bootstrap_service.py
+++ b/core/message/runtime/bootstrap_service.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from astrbot.api import logger
 
+from ...app.services.eqsc_channel_service import EqscChannelService
 from ...services.config.config_service import ConfigAccessor
 from ...services.identity.event_deduplication_service import EventDeduplicationService
 from ..builders.card_message_builder import CardMessageBuilder
@@ -110,8 +111,7 @@ class MessageManagerBootstrapService:
             )
             or bool(
                 isinstance(eqsc_cfg, dict)
-                and eqsc_cfg.get("enabled", False)
-                and eqsc_cfg.get("typhoon", False)
+                and EqscChannelService.resolve_eqsc_flags(eqsc_cfg) == (True, True)
             )
         )
         if playwright_mode == "local" and need_browser:

--- a/core/message/runtime/bootstrap_service.py
+++ b/core/message/runtime/bootstrap_service.py
@@ -111,7 +111,7 @@ class MessageManagerBootstrapService:
             or bool(
                 isinstance(eqsc_cfg, dict)
                 and eqsc_cfg.get("enabled", False)
-                and eqsc_cfg.get("typhoon_enrichment", False)
+                and eqsc_cfg.get("typhoon", False)
             )
         )
         if playwright_mode == "local" and need_browser:

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
-from ....app.services.typhoon_enrichment_service import TyphoonEnrichmentService
+from ....app.services.eqsc_channel_service import EqscChannelService
 from ....services.query.source_runtime_query_service import SourceRuntimeQueryService
 
 
@@ -70,21 +70,19 @@ class ConnectionsPayloadBuilder:
             if isinstance(raw, dict):
                 eqsc_cfg = raw
 
-        channel_enabled, typhoon_enrichment = (
-            TyphoonEnrichmentService.resolve_eqsc_flags(eqsc_cfg)
+        channel_enabled, typhoon_enrichment = EqscChannelService.resolve_eqsc_flags(
+            eqsc_cfg
         )
         config_enabled = channel_enabled
         token_configured = bool(str(eqsc_cfg.get("refresh_token", "") or "").strip())
         latency = self.latency_cache.get("eqsc")
 
         health: dict[str, Any] = {}
-        enrichment = None
+        eqsc_channel = None
         if self.disaster_service is not None:
-            enrichment = getattr(
-                self.disaster_service, "typhoon_enrichment_service", None
-            )
-        if enrichment is not None:
-            getter = getattr(enrichment, "get_health_status", None)
+            eqsc_channel = getattr(self.disaster_service, "eqsc_channel_service", None)
+        if eqsc_channel is not None:
+            getter = getattr(eqsc_channel, "get_health_status", None)
             if callable(getter):
                 try:
                     maybe_health = getter()
@@ -104,9 +102,7 @@ class ConnectionsPayloadBuilder:
         )
         # 子数据源展示只看子开关本身，不与总闸/服务状态做 AND
         effective_typhoon_enrichment = bool(
-            health.get("typhoon_enrichment", typhoon_enrichment)
-            if health
-            else typhoon_enrichment
+            health.get("typhoon", typhoon_enrichment) if health else typhoon_enrichment
         )
         if "jma_tsunami" in eqsc_cfg:
             jma_tsunami_cfg = bool(eqsc_cfg.get("jma_tsunami"))
@@ -176,7 +172,7 @@ class ConnectionsPayloadBuilder:
             "circuit_open": circuit_open,
             "token_configured": bool(health.get("token_configured", token_configured)),
             "config_enabled": effective_config_enabled,
-            "typhoon_enrichment": effective_typhoon_enrichment,
+            "typhoon": effective_typhoon_enrichment,
             "access_token_valid": access_token_valid,
         }
 

--- a/core/network/admin/payloads/realtime_payload_builder.py
+++ b/core/network/admin/payloads/realtime_payload_builder.py
@@ -87,7 +87,7 @@ class RealtimePayloadBuilder:
             message_logger_enabled=self.disaster_service.message_logger.enabled
             if getattr(self.disaster_service, "message_logger", None)
             else False,
-            global_quake_connected=bool(metrics.get("global_quake_connected")),
+            openquake_connected=bool(metrics.get("openquake_connected")),
         )
         # total_connections 已在 snapshot 内按期望通道统计，避免 EQSC/S-Net 重复累加。
         return snapshot

--- a/core/network/event_ingress_dispatch_service.py
+++ b/core/network/event_ingress_dispatch_service.py
@@ -51,8 +51,9 @@ class EventIngressDispatchService:
 
         dispatch_family = (entry.dispatch_family or "").strip()
 
-        # 台风事件需要同步等待 EQSC 富化查询（可能阻塞数分钟），
-        # 必须转为后台异步分发，避免阻塞 FAN Studio WS 接收线程
+        # FAN 台风路径：富化查询可能同步阻塞较久（EQSC 重试链最长约 5 分钟），
+        # 必须转为后台异步分发，避免阻塞 FAN Studio WS 接收线程。
+        # 注意：EQSC 独立轮询路径不经过此分发，直接由轮询协程驱动。
         if dispatch_family == "fan_studio_typhoon":
             return True
 

--- a/core/network/http/eqsc_token_manager.py
+++ b/core/network/http/eqsc_token_manager.py
@@ -56,6 +56,11 @@ class EqscTokenManager:
         """当前缓存 AccessToken 的过期时间戳（epoch 秒）；无缓存时为 0。"""
         return float(self._access_token_expires_at or 0.0)
 
+    @property
+    def access_advance_seconds(self) -> float:
+        """令牌过期前的提前刷新窗口（秒），供保活等外部逻辑只读复用。"""
+        return float(self._access_advance_seconds or 0)
+
     def seconds_until_expiry(self) -> float:
         """距离 AccessToken 真正过期的剩余秒数；无缓存或已过期时返回 0。"""
         if not self._access_token:

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -126,7 +126,6 @@ class EqscTyphoonClient(EqscHttpClient):
         """查询 EQSC 台风列表（无参，至多约 20 个最新台风，含历史）。
 
         注意：该接口并非严格“仅活跃台风”，实际常返回最新历史编报集合。
-        兼容别名：`fetch_active_typhoons`。
 
         Args:
             use_cache: 为 False 时强制绕过列表缓存（轮询侧使用）。
@@ -164,17 +163,6 @@ class EqscTyphoonClient(EqscHttpClient):
                 f"[灾害预警] EQSC 查询台风列表异常: {type(e).__name__}: {e or repr(e)}"
             )
             return []
-
-    async def fetch_active_typhoons(
-        self,
-        access_token: str | None = None,
-        *,
-        use_cache: bool = True,
-    ) -> list[dict[str, Any]]:
-        """兼容旧名：实际返回 EQSC 无参台风列表（含历史）。"""
-        return await self.fetch_typhoon_list(
-            access_token=access_token, use_cache=use_cache
-        )
 
     def find_typhoon_by_name(
         self,

--- a/core/network/monitoring/source_health_monitor.py
+++ b/core/network/monitoring/source_health_monitor.py
@@ -20,7 +20,7 @@ class SourceHealthMonitor:
         "fan_studio_cenc_ir": "ws.fanstudio.tech",
         "p2p_main": "api.p2pquake.net",
         "wolfx_all": "ws-api.wolfx.jp",
-        "global_quake": "api.aloys23.link",
+        "openquake_api": "api.aloys23.link",
         # EQSC 为 HTTP 辅助通道，默认探测官方主机；可被 host_overrides 覆盖
         "eqsc": "equake.top",
         # S-Net：MSIL 瓦片源（TCP 443 探测连通性）
@@ -33,7 +33,7 @@ class SourceHealthMonitor:
         "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
         "p2p_main": "P2P地震情報",
         "wolfx_all": "Wolfx",
-        "global_quake": "OpenQuakeAPI",
+        "openquake_api": "OpenQuakeAPI",
         "eqsc": "EQSC API",
         "snet_msil": "NIED S-Net",
     }

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -89,7 +89,7 @@ class SourceMessageRouter:
         ws_manager.register_handler("fan_studio", self._create_fan_studio_handler())
         ws_manager.register_handler("p2p", self._create_p2p_handler())
         ws_manager.register_handler("wolfx", self._create_wolfx_handler())
-        ws_manager.register_handler("global_quake", self._create_global_quake_handler())
+        ws_manager.register_handler("openquake_api", self._create_openquake_handler())
 
     async def _dispatch_event(
         self,
@@ -628,14 +628,14 @@ class SourceMessageRouter:
 
         return wolfx_handler
 
-    def _create_global_quake_handler(self):
+    def _create_openquake_handler(self):
         """创建 OpenQuakeAPI 聚合连接的消息处理器。
 
         连接挂在全量端点后，按 RealtimeEvent.source 分发到已注册子源；
         当前仅接入 Global Quake（gq），其余 source 先忽略以便后续继续接入。
         """
 
-        async def global_quake_handler(
+        async def openquake_handler(
             message, connection_name=None, connection_info=None
         ):
             self._log_received_message(
@@ -647,7 +647,7 @@ class SourceMessageRouter:
 
             # 任意入站帧都可推进静默门闩（含状态/心跳类），避免无震时干等 first_payload_timeout
             self._note_connection_bootstrap(
-                connection_name, kind="global_quake_first_payload"
+                connection_name, kind="openquake_first_payload"
             )
 
             try:
@@ -727,10 +727,10 @@ class SourceMessageRouter:
                 # 异常遥测
                 await self._track_router_error(
                     error,
-                    module="core.source_message_router.global_quake_handler",
+                    module="core.source_message_router.openquake_handler",
                 )
 
-        return global_quake_handler
+        return openquake_handler
 
 
 __all__ = ["SourceMessageRouter"]

--- a/core/parsers/parser_registry.py
+++ b/core/parsers/parser_registry.py
@@ -129,12 +129,17 @@ def create_parser_for_source(source_id: str, *args, **kwargs):
 
 
 def validate_catalog_parser_names() -> None:
-    """校验数据源目录中引用的解析器名称都能被解析。"""
+    """校验数据源目录中引用的解析器名称都能被解析。
+
+    空 parser_name 表示该源不通过消息解析器接入（例如 EQSC 轮询源，
+    事件由轮询服务直接构建），属于合法状态，跳过校验。
+    """
     # 抽取静态数据源配置名录中所有引用的解析器名称，与已注册的解析器表做一致性对齐
     missing_names = {
         entry.parser_name
         for entry in SOURCE_CATALOG.values()
-        if entry.parser_name not in PARSER_CLASS_BY_NAME
+        if (entry.parser_name or "").strip()
+        and entry.parser_name not in PARSER_CLASS_BY_NAME
     }
     # 若存在名录中有定义，但实际上解析器静态字典内未注册的配置，强行抛出运行时异常
     if missing_names:

--- a/core/rules/time_rule.py
+++ b/core/rules/time_rule.py
@@ -33,12 +33,13 @@ class EventTimeRule(BaseRule):
         """判断当前事件是否为产出较慢的地震补充产品（烈度速报 / CMT）。"""
         try:
             envelope = context.envelope
-        except TypeError:
+        except (TypeError, AttributeError):
             return False
-        source_id = str(context.source_id or "").strip()
+        source_id = str(getattr(context, "source_id", "") or "").strip()
         # 从领域事件 metadata 与信封 metadata 双渠道提取 info_type
         info_type = ""
-        domain_meta = getattr(envelope.event, "metadata", None)
+        event_obj = getattr(envelope, "event", None)
+        domain_meta = getattr(event_obj, "metadata", None)
         if isinstance(domain_meta, dict):
             info_type = str(domain_meta.get("info_type") or "").strip()
         if not info_type:

--- a/core/rules/time_rule.py
+++ b/core/rules/time_rule.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from ..services.identity.event_identity import resolve_event_time_aware
+from ..storage.source_compat import is_earthquake_supplement_product
 from .base_rule import BaseRule, RuleContext
 from .rule_result import RuleDecision
 
@@ -17,10 +18,41 @@ class EventTimeRule(BaseRule):
 
     rule_name = "time_rule"
 
-    def __init__(self, max_age_hours: float = 3.0):
-        # 默认限制历史事件时间距今不得超过 3 小时
-        # （CMT 等补充产品可能在发震后 1～2 小时才产出，1 小时阈值会误拦）
+    # 常规事件的最大允许时效（小时）：60 分钟
+    DEFAULT_MAX_AGE_HOURS = 1.0
+    # 补充产品（烈度速报 / CMT 等）产出较慢，可能滞后 1～2 小时才发布，单独放宽到 3 小时
+    SUPPLEMENT_MAX_AGE_HOURS = 3.0
+
+    def __init__(self, max_age_hours: float = DEFAULT_MAX_AGE_HOURS):
+        # 默认限制历史事件时间距今不得超过 60 分钟；
+        # 烈度速报 / CMT 等补充产品单独放宽至 3 小时。
         self.max_age_hours = max_age_hours
+
+    @staticmethod
+    def _is_supplement_product(context: RuleContext) -> bool:
+        """判断当前事件是否为产出较慢的地震补充产品（烈度速报 / CMT）。"""
+        try:
+            envelope = context.envelope
+        except TypeError:
+            return False
+        source_id = str(context.source_id or "").strip()
+        # 从领域事件 metadata 与信封 metadata 双渠道提取 info_type
+        info_type = ""
+        domain_meta = getattr(envelope.event, "metadata", None)
+        if isinstance(domain_meta, dict):
+            info_type = str(domain_meta.get("info_type") or "").strip()
+        if not info_type:
+            envelope_meta = getattr(envelope, "metadata", None)
+            if isinstance(envelope_meta, dict):
+                info_type = str(envelope_meta.get("info_type") or "").strip()
+        return is_earthquake_supplement_product(source_id, info_type=info_type)
+
+    def _resolve_max_age_hours(self, context: RuleContext) -> float:
+        """按事件类型解析允许的最大时效（小时）。"""
+        # 补充产品产出较慢，保留 3 小时窗口；其余事件一律收紧为 60 分钟。
+        if self._is_supplement_product(context):
+            return self.SUPPLEMENT_MAX_AGE_HOURS
+        return self.max_age_hours
 
     def evaluate(self, context: RuleContext) -> RuleDecision:
         """检查事件时间是否超过允许的最老时效。"""
@@ -33,11 +65,14 @@ class EventTimeRule(BaseRule):
         # 统一换算为小时差值，便于直接与规则配置的时效阈值比较
         time_diff = (current_time_utc - event_time_aware).total_seconds() / 3600
 
+        # 根据事件类型解析适用的时效阈值（补充产品放宽至 3 小时，其余 60 分钟）
+        max_age_hours = self._resolve_max_age_hours(context)
+
         # 超时拦截，丢弃过于陈旧的历史事件，防止刷屏
-        if time_diff > self.max_age_hours:
+        if time_diff > max_age_hours:
             return RuleDecision.reject(
                 reason="事件时间过早",
-                detail=f"事件时间过早（{time_diff:.1f}小时前）",
-                context={"age_hours": time_diff},
+                detail=f"事件时间过早（{time_diff:.1f} 小时前，最大允许 {max_age_hours:.0f} 小时）",
+                context={"age_hours": time_diff, "max_age_hours": max_age_hours},
             )
         return RuleDecision.accept(reason="事件时间有效")

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -1267,8 +1267,19 @@ class ConfigValidator:
         if not isinstance(cfg, dict):
             return cfg
 
+        # OpenQuakeAPI 配置组更名：旧 key "global_quake" → 新 key "openquake_api"。
+        # 仅做复制迁移，保留旧 key 避免破坏未知扩展；新 key 优先。
+        if "openquake_api" not in cfg and "global_quake" in cfg:
+            cfg["openquake_api"] = cfg["global_quake"]
+
         # 确保主要分类存在且为字典，规避非字典类型在运行时发生键提取错误
-        for key in ["fan_studio", "p2p_earthquake", "wolfx", "global_quake", "snet"]:
+        for key in [
+            "fan_studio",
+            "p2p_earthquake",
+            "wolfx",
+            "openquake_api",
+            "snet",
+        ]:
             if key in cfg:
                 if not isinstance(cfg[key], dict):
                     logger.warning(
@@ -1281,7 +1292,7 @@ class ConfigValidator:
 
         # OpenQuakeAPI：组总闸 + Global Quake 子源开关 + CMA 气象预警子源开关
         # 旧配置仅有 enabled 时，将子源开关回填为 enabled 的值，避免升级后静默关闭。
-        gq_cfg = cfg.get("global_quake")
+        gq_cfg = cfg.get("openquake_api")
         if isinstance(gq_cfg, dict):
             ConfigValidator._ensure_bool(gq_cfg, "enabled", True)
             if "global_quake" not in gq_cfg:
@@ -1372,10 +1383,10 @@ class ConfigValidator:
         eqsc_cfg = cfg.get("eqsc")
         if isinstance(eqsc_cfg, dict):
             ConfigValidator._ensure_bool(eqsc_cfg, "enabled", False)
-            # 兼容旧配置：缺少 typhoon_enrichment 时，回退为 enabled 的值
-            if "typhoon_enrichment" not in eqsc_cfg:
-                eqsc_cfg["typhoon_enrichment"] = bool(eqsc_cfg.get("enabled", False))
-            ConfigValidator._ensure_bool(eqsc_cfg, "typhoon_enrichment", False)
+            # 台风子开关：缺省时跟随通道总闸，便于旧配置平滑启用
+            if "typhoon" not in eqsc_cfg:
+                eqsc_cfg["typhoon"] = bool(eqsc_cfg.get("enabled", False))
+            ConfigValidator._ensure_bool(eqsc_cfg, "typhoon", False)
             # 海啸子开关：缺省时跟随通道总闸，便于旧配置平滑启用
             if "jma_tsunami" not in eqsc_cfg:
                 eqsc_cfg["jma_tsunami"] = bool(eqsc_cfg.get("enabled", False))

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -100,7 +100,7 @@ class ConnectionPlanBuilder:
                 logger.info("[灾害预警] 已配置 P2P 地震情报连接")
             elif group_key == "wolfx_all":
                 logger.info("[灾害预警] 已配置 Wolfx 全量数据连接")
-            elif group_key == "global_quake":
+            elif group_key == "openquake_api":
                 logger.info("[灾害预警] 已配置 OpenQuakeAPI 全量数据连接")
             else:
                 logger.info(f"[灾害预警] 已配置数据连接，连接分组为 {group_key}")

--- a/core/services/display/builders/typhoon_context_builder.py
+++ b/core/services/display/builders/typhoon_context_builder.py
@@ -159,15 +159,15 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
         typhoon_config = {}
     show_local_estimation = bool(typhoon_config.get("show_local_estimation", False))
 
-    # 会话级 typhoon_enrichment：关闭时展示层回退 Fan 字段，不暴露 EQSC 轨迹/四象限风圈。
+    # 会话级 typhoon 开关：关闭时展示层回退 Fan 字段，不暴露 EQSC 轨迹/四象限风圈。
     data_sources = display_options.get("data_sources", {})
     if not isinstance(data_sources, dict):
         data_sources = {}
     eqsc_cfg = data_sources.get("eqsc", {})
     if not isinstance(eqsc_cfg, dict):
         eqsc_cfg = {}
-    if "typhoon_enrichment" in eqsc_cfg:
-        allow_eqsc_enrichment = bool(eqsc_cfg.get("typhoon_enrichment"))
+    if "typhoon" in eqsc_cfg:
+        allow_eqsc_enrichment = bool(eqsc_cfg.get("typhoon"))
     else:
         # 兼容旧配置：缺省时跟随通道 enabled
         allow_eqsc_enrichment = bool(eqsc_cfg.get("enabled", True))

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -86,11 +86,11 @@ class EqscCencIntensityPollService:
         return max(self.MIN_LIST_LIMIT, min(limit, self.MAX_LIST_LIMIT))
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
-        """优先复用台风富化服务的 token_manager，避免双份鉴权状态。"""
-        enrichment = getattr(self.service, "typhoon_enrichment_service", None)
-        if enrichment is None:
+        """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
+        channel = getattr(self.service, "eqsc_channel_service", None)
+        if channel is None:
             return None
-        token_manager = getattr(enrichment, "_token_manager", None)
+        token_manager = getattr(channel, "token_manager", None)
         if isinstance(token_manager, EqscTokenManager):
             return token_manager
         return None

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -20,6 +20,7 @@ from typing import Any
 from astrbot.api import logger
 
 from ....utils.plugin_logger import plugin_logger
+from ...app.services.eqsc_channel_service import EqscChannelService
 from ...network.http.eqsc_cenc_intensity_client import EqscCencIntensityClient
 from ...network.http.eqsc_token_manager import EqscTokenManager
 from ..query.source_runtime_query_service import SourceRuntimeQueryService
@@ -87,13 +88,7 @@ class EqscCencIntensityPollService:
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
         """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
-        channel = getattr(self.service, "eqsc_channel_service", None)
-        if channel is None:
-            return None
-        token_manager = getattr(channel, "token_manager", None)
-        if isinstance(token_manager, EqscTokenManager):
-            return token_manager
-        return None
+        return EqscChannelService.resolve_shared_token_manager(self.service)
 
     def _ensure_client(self) -> EqscCencIntensityClient | None:
         """懒创建客户端；共享 token_manager 时不接管其生命周期。"""

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -76,11 +76,11 @@ class EqscTsunamiPollService:
         return bool(self._eqsc_config().get("jma_tsunami_include_training", False))
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
-        """优先复用台风富化服务的 token_manager，避免双份鉴权状态。"""
-        enrichment = getattr(self.service, "typhoon_enrichment_service", None)
-        if enrichment is None:
+        """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
+        channel = getattr(self.service, "eqsc_channel_service", None)
+        if channel is None:
             return None
-        token_manager = getattr(enrichment, "_token_manager", None)
+        token_manager = getattr(channel, "token_manager", None)
         if isinstance(token_manager, EqscTokenManager):
             return token_manager
         return None

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from astrbot.api import logger
 
+from ...app.services.eqsc_channel_service import EqscChannelService
 from ...domain.tsunami.jma_tsunami_normalize import (
     build_jma_tsunami_content_fingerprint,
     coerce_bool,
@@ -77,13 +78,7 @@ class EqscTsunamiPollService:
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
         """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
-        channel = getattr(self.service, "eqsc_channel_service", None)
-        if channel is None:
-            return None
-        token_manager = getattr(channel, "token_manager", None)
-        if isinstance(token_manager, EqscTokenManager):
-            return token_manager
-        return None
+        return EqscChannelService.resolve_shared_token_manager(self.service)
 
     def _ensure_client(self) -> EqscTsunamiClient | None:
         """懒创建海啸客户端；共享 token_manager 时不接管其生命周期。"""

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -52,7 +52,7 @@ class EqscTyphoonPollService:
         return self._task is not None and not self._task.done()
 
     def is_enabled(self) -> bool:
-        """数据源是否启用（组总闸 + typhoon_enrichment 子开关）。"""
+        """数据源是否启用。"""
         return self._source_runtime_query.is_source_enabled(self.SOURCE_ID)
 
     def _eqsc_config(self) -> dict[str, Any]:
@@ -73,17 +73,17 @@ class EqscTyphoonPollService:
         return max(self.MIN_INTERVAL_SECONDS, min(interval, self.MAX_INTERVAL_SECONDS))
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
-        """优先复用台风富化服务的 token_manager，避免双份鉴权状态。"""
-        enrichment = getattr(self.service, "typhoon_enrichment_service", None)
-        if enrichment is None:
+        """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
+        channel = getattr(self.service, "eqsc_channel_service", None)
+        if channel is None:
             return None
-        token_manager = getattr(enrichment, "_token_manager", None)
+        token_manager = getattr(channel, "token_manager", None)
         if isinstance(token_manager, EqscTokenManager):
             return token_manager
         return None
 
     def _get_shared_typhoon_client(self) -> EqscTyphoonClient | None:
-        """优先复用富化服务内的台风客户端。"""
+        """优先复用台风富化服务内的台风客户端。"""
         enrichment = getattr(self.service, "typhoon_enrichment_service", None)
         if enrichment is None:
             return None

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -14,6 +14,7 @@ from typing import Any
 from astrbot.api import logger
 
 from ....utils.plugin_logger import plugin_logger
+from ...app.services.eqsc_channel_service import EqscChannelService
 from ...domain.event_models import TyphoonEvent
 from ...domain.typhoon import (
     build_typhoon_event_envelope,
@@ -74,13 +75,7 @@ class EqscTyphoonPollService:
 
     def _get_shared_token_manager(self) -> EqscTokenManager | None:
         """优先复用 EQSC 通道服务的 token_manager，避免双份鉴权状态。"""
-        channel = getattr(self.service, "eqsc_channel_service", None)
-        if channel is None:
-            return None
-        token_manager = getattr(channel, "token_manager", None)
-        if isinstance(token_manager, EqscTokenManager):
-            return token_manager
-        return None
+        return EqscChannelService.resolve_shared_token_manager(self.service)
 
     def _get_shared_typhoon_client(self) -> EqscTyphoonClient | None:
         """优先复用台风富化服务内的台风客户端。"""

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -32,7 +32,7 @@ COMPONENT_ORDER: tuple[str, ...] = (
     "fan_studio_cenc_ir",
     "p2p_main",
     "wolfx_all",
-    "global_quake",
+    "openquake_api",
     "snet_msil",
     "eqsc",
 )
@@ -42,7 +42,7 @@ COMPONENT_DISPLAY_NAMES: dict[str, str] = {
     "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
     "p2p_main": "P2P地震情報",
     "wolfx_all": "Wolfx",
-    "global_quake": "OpenQuakeAPI",
+    "openquake_api": "OpenQuakeAPI",
     "snet_msil": "NIED S-Net",
     "eqsc": "EQSC API",
 }
@@ -55,7 +55,7 @@ DISPLAY_NAME_ALIASES: dict[str, str] = {
     "Fan Studio（烈度速报）": "fan_studio_cenc_ir",
     "P2P地震情報": "p2p_main",
     "Wolfx": "wolfx_all",
-    "OpenQuakeAPI": "global_quake",
+    "OpenQuakeAPI": "openquake_api",
     "NIED S-Net": "snet_msil",
     "EQSC API": "eqsc",
 }

--- a/core/services/query/eew_query_state_service.py
+++ b/core/services/query/eew_query_state_service.py
@@ -307,8 +307,13 @@ class EEWQueryStateService:
             # 计算此预警发布至今已经过去了多少秒，以便前端显示
             elapsed = int((now_utc - issued_at).total_seconds())
             item["elapsed_seconds"] = max(0, elapsed)
-            # 根据当前系统绝对时间戳判断该预警的生效状态
-            item["status"] = "active" if now_utc < expires_at else "inactive"
+            # 防御：若 issued_at 明显晚于当前时间（超过 1 小时），说明该时间被错误时区
+            # 解析到了未来（例如历史事件被当成另一时区），此时不应渲染为正在生效。
+            if issued_at > now_utc + timedelta(seconds=3600):
+                item["status"] = "inactive"
+            else:
+                # 根据当前系统绝对时间戳判断该预警的生效状态
+                item["status"] = "active" if now_utc < expires_at else "inactive"
             institutions.append(item)
 
         return {

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -176,13 +176,24 @@ class SourceRuntimeQueryService:
         ):
             active += 1
 
-        connection_tasks = (
-            getattr(service, "connection_tasks", []) if service is not None else []
+        # OpenQuakeAPI 在线标记优先以实际连接状态为准：
+        # 建连失败/服务停止后任务名仍可能残留，无法代表真实连通性。
+        # actual_connections 由 ws_manager 实时维护 connected 状态，作为首选口径；
+        # 任务名检查仅作为连接状态缺失时的兜底。
+        oq_status = actual_connections.get("openquake_api")
+        openquake_connected = bool(
+            isinstance(oq_status, dict) and oq_status.get("connected")
         )
-        openquake_connected = any(
-            "openquake_api" in task.get_name() if hasattr(task, "get_name") else False
-            for task in connection_tasks
-        )
+        if not openquake_connected:
+            connection_tasks = (
+                getattr(service, "connection_tasks", []) if service is not None else []
+            )
+            openquake_connected = any(
+                "openquake_api" in task.get_name()
+                if hasattr(task, "get_name")
+                else False
+                for task in connection_tasks
+            )
         return {
             "active_websocket_connections": int(active),
             "openquake_connected": bool(openquake_connected),

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -17,7 +17,7 @@ _CONNECTION_GROUP_ALIAS: dict[str, str] = {
     ProviderFamily.FAN_STUDIO.value: "fan_studio_all",
     ProviderFamily.P2P.value: "p2p_main",
     ProviderFamily.WOLFX.value: "wolfx_all",
-    ProviderFamily.GLOBAL_QUAKE.value: "global_quake",
+    ProviderFamily.GLOBAL_QUAKE.value: "openquake_api",
     ProviderFamily.DIRECT_HTTP.value: "snet_msil",
 }
 
@@ -27,7 +27,7 @@ _CONNECTION_DISPLAY_NAME: dict[str, str] = {
     "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
     "p2p_main": "P2P地震情報",
     "wolfx_all": "Wolfx",
-    "global_quake": "OpenQuakeAPI",
+    "openquake_api": "OpenQuakeAPI",
     "snet_msil": "NIED S-Net",
     # EQSC 为 HTTP 通道；展示名必须与 ConnectionsPayloadBuilder.EQSC_DISPLAY_NAME
     # 完全一致，否则 catalog 占位会以原始键 "eqsc" 残留，前端误显示“未连接”。
@@ -159,11 +159,9 @@ class SourceRuntimeQueryService:
         )
 
         # 延迟导入，避免 query 层与 app 层形成硬循环依赖。
-        from ...app.services.typhoon_enrichment_service import TyphoonEnrichmentService
+        from ...app.services.eqsc_channel_service import EqscChannelService
 
-        eqsc_active, _eqsc_total = TyphoonEnrichmentService.resolve_connection_counts(
-            service
-        )
+        eqsc_active, _eqsc_total = EqscChannelService.resolve_connection_counts(service)
         active += int(eqsc_active or 0)
 
         snet_poll = getattr(service, "snet_poll_service", None) if service else None
@@ -181,13 +179,13 @@ class SourceRuntimeQueryService:
         connection_tasks = (
             getattr(service, "connection_tasks", []) if service is not None else []
         )
-        global_quake_connected = any(
-            "global_quake" in task.get_name() if hasattr(task, "get_name") else False
+        openquake_connected = any(
+            "openquake_api" in task.get_name() if hasattr(task, "get_name") else False
             for task in connection_tasks
         )
         return {
             "active_websocket_connections": int(active),
-            "global_quake_connected": bool(global_quake_connected),
+            "openquake_connected": bool(openquake_connected),
         }
 
     def build_runtime_snapshot(
@@ -200,7 +198,7 @@ class SourceRuntimeQueryService:
         uptime: str = "未运行",
         active_websocket_connections: int = 0,
         message_logger_enabled: bool = False,
-        global_quake_connected: bool = False,
+        openquake_connected: bool = False,
     ) -> dict[str, Any]:
         """构建统一运行态快照。
 
@@ -244,7 +242,7 @@ class SourceRuntimeQueryService:
             "running": running,
             "uptime": uptime,
             "active_websocket_connections": active_websocket_connections,
-            "global_quake_connected": global_quake_connected,
+            "openquake_connected": openquake_connected,
             "total_connections": len(expected_groups),
             "connection_details": actual_connections,
             "connections": connections,

--- a/core/sources/source_catalog.py
+++ b/core/sources/source_catalog.py
@@ -327,7 +327,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         source_enum="global_quake",
         source_type=SourceType.EARTHQUAKE_WARNING,
         provider_family=ProviderFamily.GLOBAL_QUAKE,
-        config_group="global_quake",
+        config_group="openquake_api",
         config_key="global_quake",
         parser_name="global_quake_parser",
         presentation_type="global_quake",
@@ -341,8 +341,8 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         publish_time_field="update_time",
         report_num_field="report_num",
         fingerprint_prefix="gq",
-        connection_group="global_quake",
-        connection_handler="global_quake",
+        connection_group="openquake_api",
+        connection_handler="openquake_api",
         connection_data_source="openquake_mixed",
         connection_url="wss://api.aloys23.link/ws/all",
         dispatch_family="global_quake",
@@ -644,7 +644,9 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         priority=1,
         display_name="美国 ShakeAlert",
         description="美国 ShakeAlert 地震预警 - FAN Studio WebSocket",
-        default_timezone="America/Los_Angeles",
+        # FAN Studio 文档明确：/sa 的 shockTime 一律为 UTC+8（北京时间），
+        # 并非美国本地时区；误配会导致历史事件被解析到未来、EEW 状态悬挂。
+        default_timezone="Asia/Shanghai",
         publish_time_field="shockTime",
         fingerprint_prefix="sa",
         connection_group="fan_studio_all",
@@ -800,7 +802,7 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         source_enum="openquake_cma_weather",
         source_type=SourceType.WEATHER,
         provider_family=ProviderFamily.GLOBAL_QUAKE,
-        config_group="global_quake",
+        config_group="openquake_api",
         config_key="china_weather_alarm",
         parser_name="weather_alarm_parser",
         presentation_type="weather",
@@ -813,8 +815,8 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
         default_timezone="Asia/Shanghai",
         publish_time_field="issue_time",
         fingerprint_prefix="cn_weather_oq",
-        connection_group="global_quake",
-        connection_handler="global_quake",
+        connection_group="openquake_api",
+        connection_handler="openquake_api",
         connection_data_source="openquake_mixed",
         connection_url="wss://api.aloys23.link/ws/all",
         dispatch_family="openquake_weather",
@@ -855,14 +857,19 @@ SOURCE_CATALOG: dict[str, SourceEntry] = {
     ),
     # typhoon_eqsc: 实时活跃台风 - EQSC HTTP 独立轮询
     # 不挂 WebSocket 连接计划：connection_url 留空，由 EqscTyphoonPollService 独立轮询。
+    # 不走解析器（parser_name 留空）：事件由 EqscTyphoonPollService 直接
+    # 通过 build_typhoon_event_envelope 构建；parser_name 原指向 typhoon_parser
+    # 是历史残留（该解析器仅服务 FAN 路径 typhoon_fanstudio）。
+    # config_key 为 typhoon：对应 data_sources.eqsc.typhoon 开关
+    # （原 typhoon_enrichment 键名已随台风功能上线前的重构迁移为 typhoon）。
     "typhoon_eqsc": SourceEntry(
         source_id="typhoon_eqsc",
         source_enum="eqsc_typhoon",
         source_type=SourceType.TYPHOON,
         provider_family=ProviderFamily.EQSC,
         config_group="eqsc",
-        config_key="typhoon_enrichment",
-        parser_name="typhoon_parser",
+        config_key="typhoon",
+        parser_name="",
         presentation_type="typhoon",
         text_presenter_key="typhoon",
         report_policy="none",

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -52,7 +52,7 @@ class SessionConfigManager:
 
     # 仅允许全局配置修改的嵌套路径（会话 override 写入时强制剥离）。
     # S-Net 轮询间隔、EQSC 通道鉴权/轮询参数影响全局运行态；
-    # typhoon_enrichment / jma_tsunami 允许会话差异（部分会话可单独关闭推送）。
+    # typhoon / jma_tsunami 允许会话差异（部分会话可单独关闭推送）。
     GLOBAL_ONLY_NESTED_PATHS: tuple[tuple[str, ...], ...] = (
         ("data_sources", "snet", "poll_interval_seconds"),
         ("data_sources", "eqsc", "enabled"),

--- a/plugin/commands/plugin_admin_command_service.py
+++ b/plugin/commands/plugin_admin_command_service.py
@@ -13,7 +13,7 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
 from ...core.app.services import quoted_plain_result
-from ...core.app.services.typhoon_enrichment_service import TyphoonEnrichmentService
+from ...core.app.services.eqsc_channel_service import EqscChannelService
 from ...utils.version import get_plugin_version
 from .telemetry_mixin import CommandTelemetryMixin
 
@@ -118,7 +118,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                     ("fan_studio_cenc_ir", "FAN Studio 烈度速报"),
                     ("p2p_main", "P2P地震情報"),
                     ("wolfx_all", "Wolfx"),
-                    ("global_quake", "OpenQuakeAPI"),
+                    ("openquake_api", "OpenQuakeAPI"),
                 ]
             )
             source_group_label_map = OrderedDict(
@@ -126,7 +126,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                     ("fan_studio", "FAN Studio"),
                     ("p2p_earthquake", "P2P地震情報"),
                     ("wolfx", "Wolfx"),
-                    ("global_quake", "OpenQuakeAPI"),
+                    ("openquake_api", "OpenQuakeAPI"),
                     ("eqsc", "EQSC API"),
                     ("snet", "NIED S-Net"),
                 ]
@@ -178,7 +178,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                     "china_weather_alarm": "中国气象局: 气象预警",
                 },
                 "EQSC API": {
-                    "typhoon_enrichment": "中国气象局：实时活跃台风",
+                    "typhoon": "中国气象局：实时活跃台风",
                     "jma_tsunami": "日本气象厅: 海啸予报",
                     "china_cenc_intensity_report": "中国地震台网 (CENC) 烈度速报",
                 },
@@ -215,11 +215,11 @@ class PluginAdminCommandService(CommandTelemetryMixin):
             # EQSC / S-Net 为 HTTP 通道，不在 ws_manager 连接表中，单独补充
             # 注意：get_service_status() 已把 EQSC、S-Net 计入 active/total，这里只负责展示详情
             eqsc_health: dict = {}
-            enrichment = getattr(
-                self.plugin.disaster_service, "typhoon_enrichment_service", None
+            eqsc_channel = getattr(
+                self.plugin.disaster_service, "eqsc_channel_service", None
             )
-            if enrichment is not None:
-                getter = getattr(enrichment, "get_health_status", None)
+            if eqsc_channel is not None:
+                getter = getattr(eqsc_channel, "get_health_status", None)
                 if callable(getter):
                     try:
                         maybe_health = getter()
@@ -229,7 +229,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                         eqsc_health = {}
 
             if not eqsc_health:
-                # 富化服务不可用时，回退到配置层判定
+                # 通道服务不可用时，回退到配置层判定
                 eqsc_cfg = (
                     (self.plugin.config.get("data_sources", {}) or {}).get("eqsc", {})
                     if isinstance(self.plugin.config, dict)
@@ -238,7 +238,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 if not isinstance(eqsc_cfg, dict):
                     eqsc_cfg = {}
                 config_enabled, typhoon_enrichment = (
-                    TyphoonEnrichmentService.resolve_eqsc_flags(eqsc_cfg)
+                    EqscChannelService.resolve_eqsc_flags(eqsc_cfg)
                 )
                 token_configured = bool(
                     str(eqsc_cfg.get("refresh_token", "") or "").strip()
@@ -246,7 +246,7 @@ class PluginAdminCommandService(CommandTelemetryMixin):
                 eqsc_health = {
                     "enabled": config_enabled and token_configured,
                     "config_enabled": config_enabled,
-                    "typhoon_enrichment": typhoon_enrichment,
+                    "typhoon": typhoon_enrichment,
                     "token_configured": token_configured,
                     "access_token_valid": False,
                     "circuit_open": False,

--- a/resources/card_templates/Typhoon/typhoon_track.html
+++ b/resources/card_templates/Typhoon/typhoon_track.html
@@ -1876,6 +1876,59 @@ function computeTrackBoundsRaw() {
     };
 }
 
+/**
+ * 用风圈半径扩展路径四至，保证风圈（含最大半径方向）完整可见。
+ *
+ * 策略：对每个含风圈数据的节点，取 r7/r10/r12 四象限中的最大半径（km），
+ * 换算成经纬度扩展量（纬度 1°≈111.32km；经度按该纬度余弦折算），
+ * 与该节点的经纬度合成一个“风圈包围盒”，再与路径四至取并集。
+ *
+ * 这样当预报点很少或台风几乎不动时，视图由风圈范围兜底，
+ * 不会出现“风圈比视图还大、看不全”的情况。
+ */
+function expandBoundsForRadii(bounds) {
+    if (!bounds || !bounds.fromTrack) return bounds;
+    var la = bounds.la;
+    var ha = bounds.ha;
+    var lo = bounds.lo;
+    var hi = bounds.hi;
+    var changed = false;
+
+    function expandFor(node) {
+        if (!node) return;
+        var maxR = 0;
+        [node.r7, node.r10, node.r12].forEach(function(c) {
+            if (!c) return;
+            ['NE', 'SE', 'SW', 'NW'].forEach(function(k) {
+                var v = c[k];
+                if (v != null && v > maxR) maxR = v;
+            });
+        });
+        if (!(maxR > 0)) return;
+
+        var latPad = maxR / 111.32;
+        var cosLat = Math.cos(node.lat * Math.PI / 180);
+        // 高纬地区 cos 趋 0 时给一个兜底上限，避免扩展量爆炸
+        var lonPad = cosLat > 0.05
+            ? maxR / (111.32 * cosLat)
+            : Math.min(maxR / (111.32 * 0.05), 20);
+
+        var nLa = node.lat - latPad;
+        var nHa = node.lat + latPad;
+        var nLo = node.lon - lonPad;
+        var nHi = node.lon + lonPad;
+        if (nLa < la) { la = nLa; changed = true; }
+        if (nHa > ha) { ha = nHa; changed = true; }
+        if (nLo < lo) { lo = nLo; changed = true; }
+        if (nHi > hi) { hi = nHi; changed = true; }
+    }
+
+    PAST.forEach(expandFor);
+    FCST.forEach(expandFor);
+    if (!changed) return bounds;
+    return { la: la, ha: ha, lo: lo, hi: hi, fromTrack: true };
+}
+
 /** Web Mercator Y（0~1，北小南大的补：这里用标准 0 北→南 递增） */
 function mercatorY(lat) {
     var rad = lat * Math.PI / 180;
@@ -1916,10 +1969,13 @@ function applyMapView() {
         return;
     }
 
-    var la = raw.la;
-    var ha = raw.ha;
-    var lo = raw.lo;
-    var hi = raw.hi;
+    // 风圈半径参与视图取值：路径四至与各节点风圈包围盒取并集，
+    // 保证有风圈时（尤其预报点少/台风近乎静止）风圈也能完整显示
+    var ext = expandBoundsForRadii(raw);
+    var la = ext.la;
+    var ha = ext.ha;
+    var lo = ext.lo;
+    var hi = ext.hi;
 
     var lonSpan0 = Math.max(hi - lo, 0.05);
     var latSpan0 = Math.max(ha - la, 0.05);


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

将 EQSC 集成重构为共享的通道服务，统一 OpenQuake 配置命名，并加强时间与 EEW 状态处理，同时改进台风可视化和状态报告。

Enhancements:
- 引入 `EqscChannelService`，集中管理 EQSC 令牌、健康状态上报以及所有基于 EQSC 功能的熔断机制。
- 重构台风增强与 EQSC 轮询服务，复用共享的 EQSC 通道，从而简化配置与生命周期管理。
- 将与 OpenQuake 相关的配置、连接处理器和监控键从 `global_quake` 重命名并统一为 `openquake_api`，以保持一致性。
- 通过依据风场半径扩展地图边界改进台风路径渲染，确保风场始终完整可见。
- 调整 `EventTimeRule`，对普通事件和较慢发布的地震补充产品使用不同的有效时间窗口，使时间过滤更加精确。
- 在恢复或报告状态时跳过时间戳明显位于未来的 EEW 条目，防止陈旧或被污染的预警被误判为仍然有效。
- 增强管理和运行时状态负载，更准确地反映 EQSC/OpenQuake 的连通性和当前生效的 EEW 状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor EQSC integration into a shared channel service, standardize OpenQuake configuration naming, and harden time and EEW state handling, while improving typhoon visualization and status reporting.

Enhancements:
- Introduce EqscChannelService to centralize EQSC token management, health reporting, and circuit breaking for all EQSC-based features.
- Refactor typhoon enrichment and EQSC polling services to reuse the shared EQSC channel, simplifying configuration and lifecycle management.
- Rename and align OpenQuake-related configuration, connection handlers, and monitoring keys from global_quake to openquake_api for consistency.
- Improve typhoon track rendering by expanding map bounds based on wind radii so wind fields remain fully visible.
- Adjust EventTimeRule to use different freshness windows for regular events and slower earthquake supplement products, making time filtering more accurate.
- Skip EEW entries whose timestamps are clearly in the future when restoring or reporting state, preventing stale or polluted warnings from appearing active.
- Enhance admin and runtime status payloads to better reflect EQSC/OpenQuake connectivity and active EEW states.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * OpenQuakeAPI 支持按来源路由多个数据源，并新增中国气象局气象预警说明。
  * 台风地图视野会自动覆盖历史及预报风圈范围。
* **问题修复**
  * 过期或时间异常的地震预警不再显示为有效状态。
  * 地震补充产品采用更合适的时效判断。
  * 优化 EQSC 通道鉴权、健康检查与故障熔断，减少重复处理。
* **配置更新**
  * 统一 OpenQuakeAPI 与台风数据源的配置命名，并保留旧配置兼容迁移。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->