### PR TITLE
feat: 新增启动横幅、信息汇总大屏与启动静默窗口日志抑制、台风停编通知与去重优化

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1147,6 +1147,12 @@
             "hint": "开启后忽略已停止编报的台风。",
             "default": true
           },
+          "typhoon_deactivate_notify": {
+            "description": "台风停编通知",
+            "type": "bool",
+            "hint": "开启后，台风首次停止编报时即使核心参数未变化也会推送一条停编通知。不受时间规则以外的规则链控制。",
+            "default": true
+          },
           "combine_mode": {
             "description": "基础条件组合方式",
             "type": "string",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1570,6 +1570,12 @@
         "type": "bool",
         "hint": "开启后，插件在建连与首轮数据同步完成前自动忽略事件推送、原始日志与统计，用于过滤启动噪音。关闭后事件立即进入正常推送链路。",
         "default": true
+      },
+      "silent_startup_mute_event_logs": {
+        "description": "静默启动期间丢弃事件流日志",
+        "type": "bool",
+        "default": true,
+        "hint": "开启后，处于启动静默期的事件流日志将被整体丢弃，不打印到控制台。静默期结束后恢复正常。"
       }
     }
   },

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -11,6 +11,7 @@
 import asyncio
 import os
 import traceback
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
 from astrbot.api import logger
@@ -103,6 +104,8 @@ class DisasterWarningService:
         self.config = config  # 插件的全局配置字典
         self.context = context  # 框架上下文环境
         self.running = False  # 运行状态标识
+        # 服务初始化起点（启动耗时统计用），在 initialize() 开始时记录。
+        self.init_started_at = None
         # 启停锁用于避免重复启动或并发停止时出现状态竞争。
         self._start_lock = asyncio.Lock()
         self._stop_lock = asyncio.Lock()
@@ -200,6 +203,14 @@ class DisasterWarningService:
         self.startup_silence = StartupSilenceCoordinator()
         self.startup_silence.bind_service(self)
         self.message_logger.set_silence_checker(self.is_silencing)
+        # 静默期事件流日志抑制也需要感知"当前是否处于静默期"，
+        # 这样静默结束后事件流日志能立即恢复打印，不会被永久屏蔽。
+        from ...utils.plugin_logger import plugin_logger
+
+        plugin_logger.set_silence_checker(self.is_silencing)
+        # WebSocket 连接成功日志同样复用静默判定：启动静默期降级为 DEBUG，
+        # 静默结束后恢复 INFO，避免建连阶段刷屏同时保留重连成功反馈。
+        self.ws_manager.set_silence_checker(self.is_silencing)
         self._setup_runtime_services()
 
     def _setup_runtime_services(self) -> None:
@@ -310,7 +321,8 @@ class DisasterWarningService:
     async def initialize(self):
         """初始化服务。"""
         try:
-            logger.info("[灾害预警] 正在初始化灾害预警服务...")
+            self.init_started_at = datetime.now(timezone.utc)
+            logger.debug("[灾害预警] 正在初始化灾害预警服务...")
             # 初始化阶段只做“静态装配”：校验注册表、加载基础数据、注册解析器调度、生成连接计划。
             validate_catalog_parser_names()
             self._check_registry_integrity()
@@ -334,7 +346,7 @@ class DisasterWarningService:
             poll_enabled = bool(typhoon_poll is not None and typhoon_poll.is_enabled())
             channel = self.eqsc_channel_service
             if poll_enabled:
-                logger.info("[灾害预警] EQSC 台风轮询服务已就绪")
+                logger.debug("[灾害预警] EQSC 台风轮询服务已就绪")
             elif getattr(channel, "is_channel_enabled", False):
                 logger.info(
                     "[灾害预警] EQSC 通道已启用，但台风轮询子开关关闭；"
@@ -342,7 +354,7 @@ class DisasterWarningService:
                 )
             else:
                 logger.debug("[灾害预警] EQSC 数据源未启用，相关数据源将不可用")
-            logger.info("[灾害预警] 灾害预警服务初始化完成")
+            logger.debug("[灾害预警] 灾害预警服务初始化完成")
 
             # 注意：EQSC 历史台风重建不得在 initialize() 中同步/阻塞执行。
             # 该阶段会阻塞后续 start()，而 token 网络请求可能长达数十秒。

--- a/core/app/pipeline/event_pipeline.py
+++ b/core/app/pipeline/event_pipeline.py
@@ -198,6 +198,8 @@ class EventPipeline:
         message_manager = self.service.message_manager
         session_config_getter = self.service.session_config_manager.get_effective_config
         runtime_config = session_config_getter(session)
+        # 统一会话日志字符串（私聊/群聊 ID (备注名)），与推送执行链保持一致。
+        session_log = message_manager._get_session_log_str(session)
 
         # 聚合配置：单批节点上限（默认 25，对齐 schema 默认值）
         agg_config = (runtime_config.get("push_frequency_control", {}) or {}).get(
@@ -226,7 +228,7 @@ class EventPipeline:
                 )
                 if not decision.accepted:
                     plugin_logger.debug(
-                        f"[灾害预警] 聚合推送事件 {entry.event.id} 在 {session} "
+                        f"[灾害预警] 聚合推送事件 {entry.event.id} 在 {session_log} "
                         f"规则链复核未通过: {decision.reason}"
                         + (f"（{decision.detail}）" if decision.detail else ""),
                         event_stream="weather_alarm",
@@ -310,22 +312,23 @@ class EventPipeline:
                     failed_nodes += 1
                     logger.error(
                         f"[灾害预警] 气象预警合并转发节点 {batch_idx + 1}/{node_count} "
-                        f"发送失败 ({session}): {e}"
+                        f"发送失败 ({session_log}): {e}"
                     )
 
             if sent_nodes == 0 and failed_nodes > 0:
                 # 全部节点都发送失败：向上抛出，让调用方感知到平台当前不可用，
                 # 避免"假装成功"导致用户完全收不到任何预警。
                 raise RuntimeError(
-                    f"气象预警合并转发全部发送失败 ({session}): "
+                    f"气象预警合并转发全部发送失败 ({session_log}): "
                     f"{failed_nodes}/{node_count} 个节点失败"
                 )
 
             plugin_logger.info(
-                f"[灾害预警] 气象预警合并转发已发送到 {session}, "
+                f"[灾害预警] 气象预警合并转发已发送到 {session_log}, "
                 f"共 {total} 条预警，切为 {sent_nodes} 个节点（单批上限 {max_batch}）"
                 + (f"，{failed_nodes} 个节点发送失败" if failed_nodes else ""),
                 event_stream="weather_alarm",
+                is_silent_window=True,
             )
         else:
             # 逐条发送（降级路径）

--- a/core/app/runtime/disaster_service_cache.py
+++ b/core/app/runtime/disaster_service_cache.py
@@ -91,7 +91,7 @@ class DisasterServiceCacheService:
             else:
                 os.rename(temp_file, self.service.cache_file)
 
-            logger.info("[灾害预警] Wolfx 地震列表缓存已保存")
+            logger.debug("[灾害预警] Wolfx 地震列表缓存已保存")
         except Exception as e:
             logger.error(f"[灾害预警] 保存 Wolfx 地震列表缓存失败: {e}")
             if os.path.exists(temp_file):

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -11,8 +11,6 @@ from datetime import datetime, timezone
 
 from astrbot.api import logger
 
-from ....utils.banner import print_stop_summary
-
 
 class DisasterServiceLifecycleService:
     """灾害服务生命周期编排服务。"""
@@ -395,14 +393,6 @@ class DisasterServiceLifecycleService:
                     self.service.statistics_manager._db_initialized = False
 
                 logger.debug("[灾害预警] 灾害预警服务已停止")
-
-                # 停止流程收尾时打印停止汇总大屏（替代逐行 INFO 流水）。
-                try:
-                    print_stop_summary(self.service)
-                except Exception as banner_err:
-                    logger.debug(
-                        f"[灾害预警] 停止汇总大屏打印失败（已忽略）: {banner_err}"
-                    )
             except Exception as e:
                 logger.error(f"[灾害预警] 停止服务时出错: {e}")
                 if self.service._telemetry and self.service._telemetry.enabled:

--- a/core/app/runtime/disaster_service_lifecycle.py
+++ b/core/app/runtime/disaster_service_lifecycle.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 
 from astrbot.api import logger
 
+from ....utils.banner import print_stop_summary
+
 
 class DisasterServiceLifecycleService:
     """灾害服务生命周期编排服务。"""
@@ -47,7 +49,7 @@ class DisasterServiceLifecycleService:
                 self.service.start_time = datetime.now(
                     timezone.utc
                 )  # 服务启动UTC时间戳
-                logger.info("[灾害预警] 正在启动灾害预警服务...")
+                logger.debug("[灾害预警] 正在启动灾害预警服务...")
 
                 # 武装启动静默：在真正建连/轮询前注册门闩。
                 # 首次启动/进程重启时 AstrBot 尚未加载完成，静默武装推迟到
@@ -58,7 +60,7 @@ class DisasterServiceLifecycleService:
                     # 待武装期间协调器进入 PENDING：AstrBot 加载窗口内的事件
                     # 仍被吸收播种，但不会开始计时/就绪判定。
                     self._begin_deferred_silence()
-                    logger.info(
+                    logger.debug(
                         "[灾害预警] 静默启动已推迟，等待 AstrBot 加载完成钩子触发"
                     )
                 else:
@@ -141,7 +143,7 @@ class DisasterServiceLifecycleService:
                 if hasattr(self.service, "schedule_typhoon_db_rebuild"):
                     self.service.schedule_typhoon_db_rebuild()
 
-                logger.info("[灾害预警] 灾害预警服务已启动")
+                logger.debug("[灾害预警] 灾害预警服务已启动")
             except Exception as e:
                 # 启动失败时必须回滚运行标记，避免外部误判服务已可用。
                 logger.error(f"[灾害预警] 启动服务失败: {e}")
@@ -281,7 +283,9 @@ class DisasterServiceLifecycleService:
                 return
             self.service._stopping = True
             try:
-                logger.info("[灾害预警] 正在停止灾害预警服务...")
+                # 记录停止流程起始时间，供停止汇总大屏统计停机耗时。
+                self.service.stop_started_at = datetime.now(timezone.utc)
+                logger.debug("[灾害预警] 正在停止灾害预警服务...")
                 was_running = self.service.running
                 # 提前将运行标记切为 False，阻止新任务继续按“服务运行中”路径工作。
                 self.service.running = False
@@ -390,7 +394,15 @@ class DisasterServiceLifecycleService:
                     # 重载插件后需要允许统计管理器重新建库/重载，否则会保留“已初始化”假状态。
                     self.service.statistics_manager._db_initialized = False
 
-                logger.info("[灾害预警] 灾害预警服务已停止")
+                logger.debug("[灾害预警] 灾害预警服务已停止")
+
+                # 停止流程收尾时打印停止汇总大屏（替代逐行 INFO 流水）。
+                try:
+                    print_stop_summary(self.service)
+                except Exception as banner_err:
+                    logger.debug(
+                        f"[灾害预警] 停止汇总大屏打印失败（已忽略）: {banner_err}"
+                    )
             except Exception as e:
                 logger.error(f"[灾害预警] 停止服务时出错: {e}")
                 if self.service._telemetry and self.service._telemetry.enabled:

--- a/core/app/runtime/disaster_service_notice.py
+++ b/core/app/runtime/disaster_service_notice.py
@@ -23,6 +23,22 @@ class DisasterServiceNoticeService:
         "stop": "停止重连",
     }
 
+    # 连接内部数据源代号 -> 用户可读的展示名称。
+    # 与 SourceRuntimeQueryService._CONNECTION_DISPLAY_NAME 的展示口径保持一致，
+    # 避免把 openquake_mixed 这类内部代号直接暴露给用户。
+    _SOURCE_DISPLAY_MAP: dict[str, str] = {
+        "fan_studio_mixed": "FAN Studio",
+        "wolfx_mixed": "Wolfx",
+        "openquake_mixed": "OpenQuakeAPI",
+        "jma_p2p": "P2P地震情報",
+        "jma_p2p_info": "P2P地震情報",
+        "jma_tsunami_p2p": "P2P地震情報",
+        "jma_tsunami_eqsc": "EQSC API",
+        "cenc_ir_eqsc": "EQSC API",
+        "typhoon_eqsc": "EQSC API",
+        "snet_msil": "NIED S-Net",
+    }
+
     def __init__(self, service):
         # 与生命周期服务类似，这里只保留主服务引用，便于共享配置、状态与消息发送能力。
         self.service = service  # 主服务 DisasterWarningService 实例
@@ -120,6 +136,8 @@ class DisasterServiceNoticeService:
         """构建具体展示的离线通知富文本消息。"""
         # 阶段文案、重试次数和下一次重试时间会一起展示，
         # 目的是让使用者能在一条通知里快速判断当前处于“短时抖动”还是“长期离线”。
+        # 数据源代号先映射为展示名，避免把内部标识暴露给用户。
+        source_display = self._SOURCE_DISPLAY_MAP.get(data_source, data_source)
         stage_text = self._OFFLINE_STAGE_MAP.get(stage, stage)
         retry_part = (
             f"短时重试: {retry_count}" if retry_count is not None else "短时重试: 未知"
@@ -134,9 +152,8 @@ class DisasterServiceNoticeService:
         )
 
         message_lines = [
-            "⚠️ 数据源离线通知",
-            f"📡 连接: {connection_name}",
-            f"🧩 数据源: {data_source}",
+            f"⚠️ {source_display} 离线通知",
+            "",
             f"⛔ 状态: {stage_text}",
             f"📝 原因: {reason}",
             f"🔁 {retry_part}",

--- a/core/app/runtime/startup_silence_coordinator.py
+++ b/core/app/runtime/startup_silence_coordinator.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from astrbot.api import logger
 
+from ....utils.banner import print_startup_summary
+
 
 class SilenceState(str, Enum):
     """启动静默状态。"""
@@ -305,7 +307,7 @@ class StartupSilenceCoordinator:
             if poll_n:
                 parts.append(f"{poll_n} 路轮询")
             scope = "、".join(parts) if parts else f"{len(self.gates)} 路数据源"
-            logger.info(
+            logger.debug(
                 f"[灾害预警] 静默启动已开启，等待 {scope}完成首轮同步"
                 f"（超时时间 {self.hard_timeout_seconds:.0f} 秒）"
             )
@@ -677,12 +679,21 @@ class StartupSilenceCoordinator:
                 f"已忽略启动快照 {absorbed} 条，开始正常推送"
             )
         elif absorbed > 0:
-            logger.info(
+            logger.debug(
                 f"[灾害预警] 静默启动结束（{why}），"
                 f"已忽略启动快照 {absorbed} 条，开始正常推送"
             )
         else:
-            logger.info(f"[灾害预警] 静默启动结束（{why}），开始正常推送")
+            logger.debug(f"[灾害预警] 静默启动结束（{why}），开始正常推送")
+
+        # 静默真正结束时（WS 连接、ready_at 均已落定）打印启动汇总大屏。
+        # 此前在 start() 末尾打印会拿到未建立的连接与未落定的耗时，导致统计失真。
+        service = self._service
+        if service is not None:
+            try:
+                print_startup_summary(service)
+            except Exception as banner_err:
+                logger.debug(f"[灾害预警] 启动汇总大屏打印失败（已忽略）: {banner_err}")
 
     def _start_watchdog(self) -> None:
         self._cancel_watchdog()

--- a/core/app/services/eqsc_channel_service.py
+++ b/core/app/services/eqsc_channel_service.py
@@ -228,7 +228,7 @@ class EqscChannelService:
         try:
             access_token = await self._token_manager.get_access_token()
             if access_token:
-                logger.info("[灾害预警] EQSC AccessToken 预热成功")
+                logger.debug("[灾害预警] EQSC AccessToken 预热成功")
                 return True
             logger.warning("[灾害预警] EQSC AccessToken 预热失败：未拿到有效令牌")
             return False

--- a/core/message/fusion/cenc_fusion_service.py
+++ b/core/message/fusion/cenc_fusion_service.py
@@ -184,6 +184,7 @@ class CENCFusionService:
             f"[灾害预警] 融合策略: 拦截 Fan CENC 事件 {event.id}，事件标识为 {event_key}，兼容槽位序号为 {report_num}，测定类型为 {measurement_type}，等待 Wolfx 补充（{timeout} 秒）...",
             is_event_linked=True,
             event_stream="earthquake",
+            is_silent_window=True,
         )
 
         loop = asyncio.get_running_loop()

--- a/core/message/fusion/cenc_fusion_service.py
+++ b/core/message/fusion/cenc_fusion_service.py
@@ -171,6 +171,7 @@ class CENCFusionService:
                 f"[灾害预警] 融合策略: Fan CENC 事件 {event.id} 命中 Wolfx 缓存并补充烈度: {earthquake.intensity}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             if self._absorb_if_silencing(event):
                 return False
@@ -222,6 +223,7 @@ class CENCFusionService:
                     "[灾害预警] 融合策略: CENC 等待超时，推送原始 Fan 事件",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
                 if self._absorb_if_silencing(event):
                     return False
@@ -235,6 +237,7 @@ class CENCFusionService:
                     "[灾害预警] 融合策略: CENC 融合完成，推送补充后的 Fan 事件",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
                 if self._absorb_if_silencing(event):
                     return False
@@ -325,6 +328,7 @@ class CENCFusionService:
                 f"[灾害预警] 融合策略: 成功用 Wolfx 补充 Fan CENC 事件 {pending_key} 的烈度: {intensity}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             if future is not None and hasattr(future, "done") and not future.done():

--- a/core/message/fusion/cwa_eew_fusion_service.py
+++ b/core/message/fusion/cwa_eew_fusion_service.py
@@ -159,6 +159,7 @@ class CWAEewFusionService:
             f"[灾害预警] 融合策略：已拦截 Fan CWA EEW 事件 {event.id}，事件标识为 {event_key}，报数为 {report_num}，等待 Wolfx 在 {timeout} 秒内补充最大震度",
             is_event_linked=True,
             event_stream="earthquake",
+            is_silent_window=True,
         )
 
         loop = asyncio.get_running_loop()
@@ -193,6 +194,7 @@ class CWAEewFusionService:
                     "[灾害预警] 融合策略：CWA EEW 等待超时，推送原始 Fan 事件",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
                 if self._absorb_if_silencing(event):
                     return False
@@ -206,6 +208,7 @@ class CWAEewFusionService:
                     "[灾害预警] 融合策略：CWA EEW 融合完成，推送补充最大震度后的 Fan 事件",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
                 if self._absorb_if_silencing(event):
                     return False

--- a/core/message/fusion/cwa_eew_fusion_service.py
+++ b/core/message/fusion/cwa_eew_fusion_service.py
@@ -146,6 +146,7 @@ class CWAEewFusionService:
                 f"[灾害预警] 融合策略：Fan CWA EEW 事件 {event.id} 已命中 Wolfx 缓存，补充的最大震度为 {scale}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             if self._absorb_if_silencing(event):
                 return False
@@ -313,12 +314,14 @@ class CWAEewFusionService:
                     f"[灾害预警] 融合策略：已使用 Wolfx 为 Fan CWA EEW 事件 {pending_key} 补充最大震度，数值为 {scale}",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
             else:
                 plugin_logger.info(
                     f"[灾害预警] 融合策略：Fan CWA EEW 事件 {pending_key} 已自带最大震度，保留 Fan 的数值 ({fan_earthquake.scale})",
                     is_event_linked=True,
                     event_stream="earthquake",
+                    is_silent_window=True,
                 )
 
             if future is not None and hasattr(future, "done") and not future.done():

--- a/core/message/message_logger.py
+++ b/core/message/message_logger.py
@@ -134,7 +134,7 @@ class MessageLogger:
         self._raw_message_logging_service = RawMessageLoggingService(self)
         self._earthquake_list_summary_service = EarthquakeListSummaryService(self)
 
-        logger.info("[灾害预警] 消息记录器初始化完成")
+        logger.debug("[灾害预警] 消息记录器初始化完成")
         if self.filter_heartbeat:
             logger.debug("[灾害预警] 消息过滤配置已启用:")
             logger.debug(f"[灾害预警] - 基础类型过滤: {self.filter_types}")

--- a/core/message/presenters/global_quake_display_context.py
+++ b/core/message/presenters/global_quake_display_context.py
@@ -68,38 +68,78 @@ class GlobalQuakeDisplayContextBuilder:
             stations_used = stations.get("used", 0)
             stations_total = stations.get("total", 0)
 
+        # 质量指标（数据拟合 / 定位误差）的提取顺序：
+        # 1. metadata["quality"]：解析器已统一规范化的 dict（含 pct / err_origin 等）
+        # 2. metadata["quality_pct"] / metadata["location_error"]：历史扁平键兼容
+        # 3. 原始载荷 event_payload：JSON 新协议平铺在 data / payload 外层，
+        #    protobuf 历史路径则封装在 raw["data"]["quality"] 中
         quality_pct = "N/A"
         location_error = "N/A"
+
+        quality = {}
         if isinstance(metadata, dict):
-            if metadata.get("quality_pct") is not None:
-                quality_pct = f"{metadata.get('quality_pct')}%"
-            if isinstance(metadata.get("location_error"), (int, float)):
-                location_error = f"{metadata.get('location_error'):.1f} km"
-            elif isinstance(metadata.get("location_error_km"), (int, float)):
-                location_error = f"{metadata.get('location_error_km'):.1f} km"
+            _quality = metadata.get("quality")
+            if isinstance(_quality, dict):
+                quality = _quality
+
+        # 解析器已在 metadata["quality"] 中规范化好质量指标，优先消费。
+        if quality:
+            pct = quality.get("pct")
+            if pct is not None:
+                quality_pct = f"{pct}%"
+            err_origin = quality.get("errOrigin") or quality.get("err_origin")
+            if err_origin is not None:
+                location_error = f"{err_origin:.1f} km"
+
+        if quality_pct == "N/A" or location_error == "N/A":
+            # 兼容历史扁平元数据键（早期实现写入的字段）。
+            if isinstance(metadata, dict):
+                if quality_pct == "N/A" and metadata.get("quality_pct") is not None:
+                    quality_pct = f"{metadata.get('quality_pct')}%"
+                if location_error == "N/A" and isinstance(
+                    metadata.get("location_error"), (int, float)
+                ):
+                    location_error = f"{metadata.get('location_error'):.1f} km"
+                elif location_error == "N/A" and isinstance(
+                    metadata.get("location_error_km"), (int, float)
+                ):
+                    location_error = f"{metadata.get('location_error_km'):.1f} km"
 
         if quality_pct == "N/A" or location_error == "N/A":
             # 一些质量字段可能存在于更内层的原始数据结构中，这里继续向下兼容提取。
             data_inner = (
                 event_payload.get("data", {}) if isinstance(event_payload, dict) else {}
             )
-            quality = (
+            inner_quality = (
                 data_inner.get("quality", {}) if isinstance(data_inner, dict) else {}
             )
-            if isinstance(quality, dict):
+            if not isinstance(inner_quality, dict):
+                inner_quality = {}
+            # JSON 新协议 payload 平铺在外层时，quality 也可能直接挂在 event_payload 上。
+            if not inner_quality and isinstance(event_payload, dict):
+                outer_quality = event_payload.get("quality")
+                if isinstance(outer_quality, dict):
+                    inner_quality = outer_quality
+            if inner_quality:
                 if quality_pct == "N/A":
-                    pct = quality.get("pct")
+                    pct = inner_quality.get("pct")
                     if pct is not None:
                         quality_pct = f"{pct}%"
 
                 if location_error == "N/A":
-                    err_origin = quality.get("errOrigin") or quality.get("err_origin")
+                    err_origin = inner_quality.get("errOrigin") or inner_quality.get(
+                        "err_origin"
+                    )
                     if err_origin is not None:
                         location_error = f"{err_origin:.1f} km"
             if location_error == "N/A" and isinstance(
                 data_inner.get("locationError"), (int, float)
             ):
                 location_error = f"{data_inner.get('locationError'):.1f} km"
+            if location_error == "N/A" and isinstance(
+                event_payload.get("locationError"), (int, float)
+            ):
+                location_error = f"{event_payload.get('locationError'):.1f} km"
 
         # 返回的字段名直接面向卡片模板，因此保持扁平、稳定且尽量避免模板层再做业务判断。
         is_final = (

--- a/core/message/presenters/global_quake_display_context.py
+++ b/core/message/presenters/global_quake_display_context.py
@@ -7,8 +7,26 @@ Global Quake 展示上下文构建器。
 
 from __future__ import annotations
 
+from typing import Any
+
 from ....utils.time_converter import TimeConverter
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
+
+
+def _coerce_location_error(value: Any) -> float | None:
+    """把 errOrigin / err_origin 归一化为 float，无法转换时返回 None。
+
+    兼容两类脏数据：
+    - 合法数值 0（不能被 or 误判为缺失）；
+    - JSON 原始路径以字符串下发数值（如 "3.2"），直接 f"{v:.1f}" 会抛 TypeError。
+    """
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    return num
 
 
 def _format_coordinates(latitude: float, longitude: float) -> str:
@@ -87,7 +105,14 @@ class GlobalQuakeDisplayContextBuilder:
             pct = quality.get("pct")
             if pct is not None:
                 quality_pct = f"{pct}%"
-            err_origin = quality.get("errOrigin") or quality.get("err_origin")
+            # 按键是否存在取 errOrigin / err_origin（不能依赖 or：合法值 0 会被误判缺失），
+            # 并先 float() 归一化：JSON 原始路径可能以字符串下发数值。
+            err_origin = (
+                quality.get("errOrigin")
+                if "errOrigin" in quality
+                else quality.get("err_origin")
+            )
+            err_origin = _coerce_location_error(err_origin)
             if err_origin is not None:
                 location_error = f"{err_origin:.1f} km"
 
@@ -127,9 +152,12 @@ class GlobalQuakeDisplayContextBuilder:
                         quality_pct = f"{pct}%"
 
                 if location_error == "N/A":
-                    err_origin = inner_quality.get("errOrigin") or inner_quality.get(
-                        "err_origin"
+                    err_origin = (
+                        inner_quality.get("errOrigin")
+                        if "errOrigin" in inner_quality
+                        else inner_quality.get("err_origin")
                     )
+                    err_origin = _coerce_location_error(err_origin)
                     if err_origin is not None:
                         location_error = f"{err_origin:.1f} km"
             if location_error == "N/A" and isinstance(

--- a/core/message/push/push_flow_handler.py
+++ b/core/message/push/push_flow_handler.py
@@ -366,6 +366,7 @@ class PushFlowHandler:
                 f"[灾害预警] 事件 {event.id} 推送完成，成功推送到 {push_success_count} 个会话",
                 is_event_linked=True,
                 event_stream=self._resolve_event_stream(event),
+                is_silent_window=True,
             )
         elif send_failure_stats:
             plugin_logger.warning(

--- a/core/message/push/weather_aggregation_service.py
+++ b/core/message/push/weather_aggregation_service.py
@@ -67,6 +67,9 @@ class WeatherAggregationService:
         self._flush_timers: dict[str, asyncio.TimerHandle] = {}
         # 后台刷新任务持有集合：防止任务在完成前被垃圾回收，并在结束时清理引用。
         self._background_tasks: set[asyncio.Task] = set()
+        # 最后一次成功推送的条数与目标会话（停机时用于汇总大屏"最后转发"指标）。
+        self.last_flushed_count: int | None = None
+        self.last_flushed_session: str | None = None
         # 推送回调，由 EventPipeline 注入
         self._flush_callback = None
         # 发送失败后放回缓冲区的重试次数限制，避免停机/网络异常时无限循环
@@ -259,6 +262,7 @@ class WeatherAggregationService:
                 f"({session}), 缓冲 {len(buffer)} 条",
                 is_event_linked=True,
                 event_stream="weather_alarm",
+                is_silent_window=True,
             )
             self._spawn_flush_task(session)
             return True
@@ -352,6 +356,9 @@ class WeatherAggregationService:
             await self._flush_callback(session, entries, self._config, mode="forward")
             # 发送成功后清空该会话的重试计数
             self._flush_retry_counts.pop(session, None)
+            # 记录最后一批成功推送的条数与目标会话，供停止汇总大屏展示。
+            self.last_flushed_count = len(entries)
+            self.last_flushed_session = session
         except Exception as e:
             # 合并转发失败：仅当平台确实不支持合并转发时，才允许降级为逐条发送。
             # 注意：不能仅凭一次发送异常就判定"平台不支持"——插件停止/网络瞬时

--- a/core/message/render/snet_map_renderer.py
+++ b/core/message/render/snet_map_renderer.py
@@ -160,7 +160,7 @@ def _load_icons_base64(icon_dir: str) -> dict[str, str]:
                     ).decode()
             except Exception as e:
                 logger.error(f"[灾害预警] 加载 {fname} 失败: {e}")
-    logger.info(f"[灾害预警] SVG 图标加载: {len(result)}/{len(_SNET_ICON_FILES)}")
+    logger.debug(f"[灾害预警] SVG 图标加载: {len(result)}/{len(_SNET_ICON_FILES)}")
     return result
 
 

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -1104,6 +1104,7 @@ class BrowserManager:
                                             f"[灾害预警] {label}渲染通过降级重试成功（HTTP API），耗时 {elapsed:.3f}秒",
                                             is_event_linked=True,
                                             event_stream=event_stream,
+                                            is_silent_window=True,
                                         )
                                         return output_path
                                     else:

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -475,7 +475,7 @@ class BrowserManager:
                     self._initialized = True
                     return
 
-                logger.info(f"[灾害预警] 正在启动浏览器（模式：{self._mode}）...")
+                logger.debug(f"[灾害预警] 正在启动浏览器（模式：{self._mode}）...")
                 start_time = time.time()
 
                 # 启动 Playwright
@@ -485,14 +485,14 @@ class BrowserManager:
                 self._browser = await self._playwright.chromium.launch(
                     args=["--no-sandbox", "--disable-setuid-sandbox"]
                 )
-                logger.info("[灾害预警] 本地浏览器启动成功")
+                logger.debug("[灾害预警] 本地浏览器启动成功")
 
                 # 本地模式：直接创建页面池
                 await self._initialize_local_page_pool()
 
                 elapsed = time.time() - start_time
                 self._initialized = True
-                logger.info(
+                logger.debug(
                     f"[灾害预警] 浏览器启动完成，耗时 {elapsed:.2f}秒，页面池大小: {self.pool_size}"
                 )
 
@@ -847,6 +847,7 @@ class BrowserManager:
                             f"[灾害预警] {label}渲染成功，耗时 {elapsed:.3f}秒",
                             is_event_linked=True,
                             event_stream=event_stream,
+                            is_silent_window=True,
                         )
                         render_succeeded = True
                         return output_path
@@ -1066,6 +1067,7 @@ class BrowserManager:
                             f"[灾害预警] {label}渲染成功（HTTP API），耗时 {elapsed:.3f}秒",
                             is_event_linked=True,
                             event_stream=event_stream,
+                            is_silent_window=True,
                         )
                         return output_path
                     else:
@@ -1137,10 +1139,10 @@ class BrowserManager:
                 logger.debug("[灾害预警] 浏览器已关闭，跳过")
                 return
 
-            logger.info("[灾害预警] 正在关闭浏览器...")
+            logger.debug("[灾害预警] 正在关闭浏览器...")
             self._closed = True
             await self._cleanup()
-            logger.info("[灾害预警] 浏览器已关闭")
+            logger.debug("[灾害预警] 浏览器已关闭")
 
     async def _cleanup(self):
         """清理资源，确保前一步失败也不影响后续步骤继续执行。"""

--- a/core/network/admin/host/web_server.py
+++ b/core/network/admin/host/web_server.py
@@ -220,13 +220,24 @@ class WebAdminServer:
         host = web_config.get("host", "0.0.0.0")
         port = web_config.get("port", 8089)
 
+        # 记录访问地址，供启动汇总大屏等场景展示。
+        self.url = f"http://{host}:{port}"
+
         # 构造 Uvicorn 运行配置
         config = uvicorn.Config(
-            self.app, host=host, port=port, log_level="warning", access_log=False
+            self.app,
+            host=host,
+            port=port,
+            log_level="warning",
+            access_log=False,
+            # 优雅关闭时内部最多等待 10 秒（默认 None 会对长连接无限等待）。
+            # 超时后 uvicorn 会取消残留后台任务并继续执行 lifespan.shutdown()，
+            # 配合 stop() 的外部超时兜底，双保险确保端口最终能释放。
+            timeout_graceful_shutdown=10,
         )
         self.server = uvicorn.Server(config)
 
-        logger.info(f"[灾害预警] Web 管理端已启动: http://{host}:{port}")
+        logger.debug(f"[灾害预警] Web 管理端已启动: {self.url}")
 
         async def _serve():
             try:
@@ -277,17 +288,35 @@ class WebAdminServer:
 
         # 5. 退出 Uvicorn Web 服务器实例并等待服务 Task 彻底终止
         if self.server:
+            # 优雅关闭优先：由 uvicorn 正常执行 lifespan.shutdown()，让
+            # LifespanOn.main() 协程收到关闭事件后自行退出，避免其成为孤儿
+            # pending 任务（否则事件循环 GC 会打印 "Task was destroyed but it
+            # is pending!" 噪音）。内部超时由 timeout_graceful_shutdown=10 兜底，
+            # 外部超时 15 秒作为第二道保险，确保端口最终必然释放。
             self.server.should_exit = True
-            # 强制退出：避免存在未关闭的长连接（如 WebSocket）时优雅关闭
-            # 永久挂起，确保监听 socket 能被释放，防止热重载时端口冲突。
-            self.server.force_exit = True
+            # 仅在外部超时降级时才启用强制退出，确保监听 socket 能被释放，
+            # 防止热重载时端口冲突。
+            force_fallback = False
             if self._server_task:
                 try:
-                    await asyncio.wait_for(self._server_task, timeout=5.0)
+                    await asyncio.wait_for(self._server_task, timeout=15.0)
                 except asyncio.TimeoutError:
                     logger.warning(
-                        "[灾害预警] Web 管理端未在 5 秒内停止，正在强制取消以释放端口。"
+                        "[灾害预警] Web 管理端未在 15 秒内优雅停止，降级为强制退出以释放端口。"
                     )
+                    force_fallback = True
+                except asyncio.CancelledError:
+                    # 若是 stop() 协程本身被外部取消，需放行以保持取消语义。
+                    raise
+                except Exception as e:
+                    logger.warning(f"[灾害预警] 停止 Web 管理端时出现异常: {e!r}")
+
+            if force_fallback:
+                # 降级路径：先强制退出并取消残留任务，让 serve() 尽快返回，
+                # 再从事件循环层面回收 lifespan 协程，避免其成为孤儿任务挂起
+                # 在 receive_queue.get() 上。
+                self.server.force_exit = True
+                if self._server_task:
                     self._server_task.cancel()
                     # 等待取消真正完成，确保 stop 返回前监听 socket 已释放，
                     # 避免热重载时新实例绑定同端口失败。
@@ -303,6 +332,19 @@ class WebAdminServer:
                         logger.debug(
                             f"[灾害预警] 等待 Web 管理端任务取消时出现异常: {e!r}"
                         )
-                except Exception as e:
-                    logger.warning(f"[灾害预警] 停止 Web 管理端时出现异常: {e!r}")
-            logger.info("[灾害预警] Web 管理端已停止")
+                # 兜底回收 lifespan：主动发送关闭事件，让 LifespanOn.main()
+                # 协程正常退出（重复调用 shutdown 由 Starlette 幂等处理，安全）。
+                lifespan = getattr(self.server, "lifespan", None)
+                if lifespan is not None:
+                    try:
+                        # 内部有超时保护，最多等待 10 秒。
+                        await asyncio.wait_for(lifespan.shutdown(), timeout=10.0)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[灾害预警] lifespan 关闭未在 10 秒内完成，跳过等待。"
+                        )
+                    except Exception as e:
+                        logger.debug(
+                            f"[灾害预警] lifespan 关闭时出现异常（已忽略）: {e!r}"
+                        )
+            logger.debug("[灾害预警] Web 管理端已停止")

--- a/core/network/admin/host/web_server.py
+++ b/core/network/admin/host/web_server.py
@@ -291,20 +291,25 @@ class WebAdminServer:
             # 优雅关闭优先：由 uvicorn 正常执行 lifespan.shutdown()，让
             # LifespanOn.main() 协程收到关闭事件后自行退出，避免其成为孤儿
             # pending 任务（否则事件循环 GC 会打印 "Task was destroyed but it
-            # is pending!" 噪音）。内部超时由 timeout_graceful_shutdown=10 兜底，
-            # 外部超时 15 秒作为第二道保险，确保端口最终必然释放。
+            # is pending!" 噪音）。内部超时由 timeout_graceful_shutdown=10 兜底。
+            #
+            # 注意：这里刻意不使用 asyncio.wait_for 直接等待 _server_task——
+            # Uvicorn 0.23.0 的 Server.serve() 在 main_loop() 后才调用 shutdown()
+            # 且没有 finally 保护；wait_for 超时会取消任务本身，导致协程可能在
+            # 关闭监听 socket 之前就被终止，force_exit 也无法恢复已取消的协程。
+            # 因此改用 asyncio.wait（不取消任务）：先等优雅关闭窗口，超时后
+            # 设置 force_exit 再等一个短窗口，仍未退出才取消并回收任务。
             self.server.should_exit = True
-            # 仅在外部超时降级时才启用强制退出，确保监听 socket 能被释放，
-            # 防止热重载时端口冲突。
             force_fallback = False
-            if self._server_task:
+            if self._server_task and not self._server_task.done():
                 try:
-                    await asyncio.wait_for(self._server_task, timeout=15.0)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "[灾害预警] Web 管理端未在 15 秒内优雅停止，降级为强制退出以释放端口。"
-                    )
-                    force_fallback = True
+                    # 第一段等待：优雅关闭窗口（不取消 _server_task）。
+                    done, _ = await asyncio.wait({self._server_task}, timeout=15.0)
+                    if not done:
+                        logger.warning(
+                            "[灾害预警] Web 管理端未在 15 秒内优雅停止，降级为强制退出以释放端口。"
+                        )
+                        force_fallback = True
                 except asyncio.CancelledError:
                     # 若是 stop() 协程本身被外部取消，需放行以保持取消语义。
                     raise
@@ -312,25 +317,39 @@ class WebAdminServer:
                     logger.warning(f"[灾害预警] 停止 Web 管理端时出现异常: {e!r}")
 
             if force_fallback:
-                # 降级路径：先强制退出并取消残留任务，让 serve() 尽快返回，
+                # 降级路径：先强制退出（不取消任务），让 serve() 自己尽快返回，
                 # 再从事件循环层面回收 lifespan 协程，避免其成为孤儿任务挂起
                 # 在 receive_queue.get() 上。
                 self.server.force_exit = True
-                if self._server_task:
-                    self._server_task.cancel()
-                    # 等待取消真正完成，确保 stop 返回前监听 socket 已释放，
-                    # 避免热重载时新实例绑定同端口失败。
+                if self._server_task and not self._server_task.done():
                     try:
-                        await self._server_task
+                        # 第二段等待：强制退出后的短窗口，仍不取消任务，
+                        # 让 Uvicorn 完成 socket 关闭流程。
+                        done, _ = await asyncio.wait({self._server_task}, timeout=5.0)
+                        if not done:
+                            # 任务仍未退出：最后才取消并回收，确保 stop 返回前
+                            # 监听 socket 尽量已释放，避免热重载时端口冲突。
+                            logger.warning(
+                                "[灾害预警] Web 管理端强制退出后仍未停止，取消残留任务以释放端口。"
+                            )
+                            self._server_task.cancel()
+                            try:
+                                await self._server_task
+                            except asyncio.CancelledError:
+                                # 区分两种取消：若是 _server_task 自身被上面
+                                # cancel（预期内），吞掉即可；若是 stop() 协程
+                                # 本身被外部取消，则需放行以保持取消语义。
+                                if not self._server_task.cancelled():
+                                    raise
+                            except Exception as e:
+                                logger.debug(
+                                    f"[灾害预警] 等待 Web 管理端任务取消时出现异常: {e!r}"
+                                )
                     except asyncio.CancelledError:
-                        # 区分两种取消：若是 _server_task 自身被上面 cancel（预期
-                        # 内），吞掉即可；若是 stop() 协程本身被外部取消，则需
-                        # 放行以保持取消语义，不可静默吞掉。
-                        if not self._server_task.cancelled():
-                            raise
+                        raise
                     except Exception as e:
                         logger.debug(
-                            f"[灾害预警] 等待 Web 管理端任务取消时出现异常: {e!r}"
+                            f"[灾害预警] 等待 Web 管理端任务退出时出现异常: {e!r}"
                         )
                 # 兜底回收 lifespan：主动发送关闭事件，让 LifespanOn.main()
                 # 协程正常退出（重复调用 shutdown 由 Starlette 幂等处理，安全）。

--- a/core/network/http/eqsc_token_manager.py
+++ b/core/network/http/eqsc_token_manager.py
@@ -295,7 +295,7 @@ class EqscTokenManager:
 
             self._access_token = access_token
             self._access_token_expires_at = time.time() + expires_seconds
-            logger.info(
+            logger.debug(
                 f"[灾害预警] EQSC AccessToken 创建成功，"
                 f"masked={self._mask_token(access_token)}，有效期 {expires_seconds} 秒"
             )

--- a/core/network/monitoring/source_health_monitor.py
+++ b/core/network/monitoring/source_health_monitor.py
@@ -155,7 +155,7 @@ class SourceHealthMonitor:
                 await asyncio.sleep(interval_seconds)
 
             except asyncio.CancelledError:
-                logger.info("[灾害预警] 后台延迟检测任务已停止")
+                logger.debug("[灾害预警] 后台延迟检测任务已停止")
                 break
             except Exception as e:
                 logger.error(f"[灾害预警] 后台延迟检测出错: {e}")

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -414,6 +414,7 @@ class SourceMessageRouter:
                         f"[灾害预警] 处理 {source} 数据 ({_resolve_config_key(source_id)})",
                         is_event_linked=True,
                         event_stream=self._resolve_stream_by_source_id(source_id),
+                        is_silent_window=True,
                     )
                     dispatched = await self._parse_and_dispatch(
                         source_id=source_id,
@@ -488,6 +489,7 @@ class SourceMessageRouter:
                         "[灾害预警] P2P 处理器收到紧急地震速报，业务码为 556，准备解析",
                         is_event_linked=True,
                         event_stream="earthquake",
+                        is_silent_window=True,
                     )
             except (json.JSONDecodeError, AttributeError, TypeError):
                 data = {}

--- a/core/network/websocket/websocket_manager.py
+++ b/core/network/websocket/websocket_manager.py
@@ -37,6 +37,11 @@ class WebSocketManager:
         self.message_logger = message_logger
         self._telemetry = telemetry
 
+        # 启动静默期日志抑制回调（由主服务注入 is_silencing）：
+        # 静默期间连接成功日志降级为 DEBUG，静默结束后恢复 INFO，
+        # 避免启动建连阶段刷屏，同时保留运行期重连成功反馈。
+        self._silence_checker = None
+
         # 共享状态维护
         self.connections: dict[str, ClientWebSocketResponse] = {}
         self.message_handlers: dict[str, Callable] = {}
@@ -65,6 +70,31 @@ class WebSocketManager:
         """注册指定连接前缀对应的消息处理器。"""
         self.message_handlers[connection_name] = handler
         logger.debug(f"[灾害预警] 注册处理器: {connection_name}")
+
+    def set_silence_checker(self, checker) -> None:
+        """注入启动静默判定回调。
+
+        静默期间连接成功日志降级为 DEBUG，静默结束后恢复 INFO，
+        避免启动建连阶段刷屏，同时保留运行期重连成功反馈。
+        """
+        self._silence_checker = checker
+
+    def _is_silencing(self) -> bool:
+        """当前是否处于启动静默期（委托主服务回调）。"""
+        checker = self._silence_checker
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker())
+        except Exception:
+            return False
+
+    def _log_connection_success(self, name: str) -> None:
+        """记录连接成功日志：启动静默期降级为 DEBUG，静默结束后恢复 INFO。"""
+        if self._is_silencing():
+            logger.debug(f"[灾害预警] WebSocket 连接成功: {name}")
+        else:
+            logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
 
     async def connect(
         self,
@@ -166,7 +196,7 @@ class WebSocketManager:
                 self.connection_info[name].pop("short_retry_notified", None)
                 self.connection_info[name].pop("quota_hit", None)
                 self.connection_info[name].pop("quota_deferred", None)
-                logger.info(f"[灾害预警] WebSocket 连接成功: {name}")
+                self._log_connection_success(name)
                 on_established = getattr(self, "on_connection_established", None)
                 if callable(on_established):
                     try:
@@ -230,7 +260,7 @@ class WebSocketManager:
 
         except asyncio.CancelledError:
             # 主动关闭或插件卸载引发的任务取消，清理局部资源后正常退出
-            logger.info(f"[灾害预警] WebSocket 连接任务被取消: {name}")
+            logger.debug(f"[灾害预警] WebSocket 连接任务被取消: {name}")
             await self._release_existing_connection(
                 name,
                 reason="连接任务取消",

--- a/core/network/websocket/websocket_runtime_service.py
+++ b/core/network/websocket/websocket_runtime_service.py
@@ -91,7 +91,7 @@ class WebSocketRuntimeService:
                 total=self.manager.config.get("http_timeout", 30)
             )
             self.manager.session = aiohttp.ClientSession(timeout=timeout)
-            logger.info("[灾害预警] WebSocket 管理器已启动")
+            logger.debug("[灾害预警] WebSocket 管理器已启动")
 
         if not self.manager.message_handlers:
             logger.warning("[灾害预警] 没有注册任何消息处理器")
@@ -105,7 +105,7 @@ class WebSocketRuntimeService:
                 return
             self.manager._stopping = True
             try:
-                logger.info("[灾害预警] WebSocket 管理器正在停止...")
+                logger.debug("[灾害预警] WebSocket 管理器正在停止...")
                 self.manager.running = False
 
                 # 1. 优先关闭所有重连等待任务，防止在停止期间因为连接关闭而触发重连，陷入恶性循环
@@ -146,6 +146,6 @@ class WebSocketRuntimeService:
                 self.manager.fallback_retry_counts.clear()
                 self.manager.last_heartbeat_time.clear()
 
-                logger.info("[灾害预警] WebSocket 管理器已停止")
+                logger.debug("[灾害预警] WebSocket 管理器已停止")
             finally:
                 self.manager._stopping = False

--- a/core/parsers/china_earthquake_parser.py
+++ b/core/parsers/china_earthquake_parser.py
@@ -124,6 +124,7 @@ class CencEarthquakeParser(BaseParser):
                 f"[灾害预警] 地震数据解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/china_eew_parser.py
+++ b/core/parsers/china_eew_parser.py
@@ -142,6 +142,7 @@ class CEAEEWParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -250,6 +251,7 @@ class CEAEEWWolfxParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/china_intensity_report_eqsc_parser.py
+++ b/core/parsers/china_intensity_report_eqsc_parser.py
@@ -305,6 +305,7 @@ class CencIntensityReportEqscParser(CencIntensityReportParser):
                 f"时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/china_intensity_report_parser.py
+++ b/core/parsers/china_intensity_report_parser.py
@@ -349,6 +349,7 @@ class CencIntensityReportParser(BaseParser):
                 f"时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/fssn_cmt_parser.py
+++ b/core/parsers/fssn_cmt_parser.py
@@ -148,6 +148,7 @@ class FssnCmtParser(BaseParser):
                 f"(主选 M {domain_event.magnitude or 0.0}), {linked_desc}",
                 is_event_linked=is_event_linked,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
 

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -228,6 +228,7 @@ class GlobalQuakeParser(BaseParser):
                 f"[灾害预警] Global Quake 收到地震取消广播: ID={event_id}",
                 is_event_linked=True,
                 event_stream="global_quake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -255,6 +256,7 @@ class GlobalQuakeParser(BaseParser):
                 f"[灾害预警] Global Quake 收到地震取消广播 (JSON): ID={event_id}",
                 is_event_linked=True,
                 event_stream="global_quake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -572,6 +574,7 @@ class GlobalQuakeParser(BaseParser):
                 f"时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="global_quake",
+                is_silent_window=True,
             )
 
             return envelope
@@ -746,6 +749,7 @@ class UsgsEarthquakeParser(BaseParser):
                 f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude or 0.0}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream=self._resolve_parser_event_stream(),
+                is_silent_window=True,
             )
 
             return envelope
@@ -921,6 +925,7 @@ class ShakeAlertEewParser(BaseParser):
                 f"[灾害预警] ShakeAlert 预警解析成功: {domain_event.place_name} (M {domain_event.magnitude or 0.0}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -414,6 +414,7 @@ class GlobalQuakeParser(BaseParser):
                 f"时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="global_quake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/japan_earthquake_parser.py
+++ b/core/parsers/japan_earthquake_parser.py
@@ -204,6 +204,7 @@ class JmaEarthquakeP2PParser(BaseParser):
                 f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope
@@ -355,6 +356,7 @@ class JmaEarthquakeWolfxParser(BaseParser):
                 f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/japan_eew_parser.py
+++ b/core/parsers/japan_eew_parser.py
@@ -148,6 +148,7 @@ class JmaEewFanStudioParser(BaseParser):
                 f"[灾害预警] JMA地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -431,6 +432,7 @@ class JmaEewP2PParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope
@@ -669,6 +671,7 @@ class JmaEewWolfxParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/snet_parser.py
+++ b/core/parsers/snet_parser.py
@@ -629,7 +629,10 @@ class SnetParser(BaseParser):
         )
         if max_shindo >= 0.5:
             plugin_logger.info(
-                log_message, is_event_linked=True, event_stream="earthquake"
+                log_message,
+                is_event_linked=True,
+                event_stream="earthquake",
+                is_silent_window=True,
             )
         else:
             plugin_logger.debug(log_message)

--- a/core/parsers/taiwan_earthquake_parser.py
+++ b/core/parsers/taiwan_earthquake_parser.py
@@ -236,6 +236,7 @@ class CwaReportParser(BaseParser):
                 f"ID: {getattr(getattr(envelope, 'identity', None), 'event_id', '')}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/taiwan_eew_parser.py
+++ b/core/parsers/taiwan_eew_parser.py
@@ -145,6 +145,7 @@ class CwaEewParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {getattr(domain_event, 'place_name', '')} (M {getattr(domain_event, 'magnitude', None)}), 时间: {getattr(domain_event, 'occurred_at', None)}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -304,6 +305,7 @@ class CwaEewWolfxParser(BaseParser):
                 f"[灾害预警] 地震预警解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/tsunami_parser.py
+++ b/core/parsers/tsunami_parser.py
@@ -236,6 +236,7 @@ class TsunamiParser(BaseParser):
                 f"[灾害预警] 海啸预警解析成功: {getattr(envelope.event, 'title', '')} ({getattr(envelope.event, 'level', '')}), 发布时间: {getattr(envelope.event, 'issued_at', None)}",
                 is_event_linked=True,
                 event_stream="tsunami",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -407,6 +408,7 @@ class JmaTsunamiP2PParser(BaseParser):
                 f"[灾害预警] JMA海啸预报解析成功(P2P): {title}, 时间: {issue_time}",
                 is_event_linked=True,
                 event_stream="tsunami",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:
@@ -676,6 +678,7 @@ class JmaTsunamiEqscParser(BaseParser):
                 f"是否为训练报：{is_training}, 最高级别：{max_grade})",
                 is_event_linked=True,
                 event_stream="tsunami",
+                is_silent_window=True,
             )
             return envelope
         except Exception as exc:

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -223,6 +223,7 @@ class TyphoonParser(BaseParser):
                         f"ID: {envelope.event.typhoon_id}，类型为{envelope.event.typhoon_type}",
                         is_event_linked=True,
                         event_stream="typhoon",
+                        is_silent_window=True,
                     )
                     envelopes.append(envelope)
 

--- a/core/parsers/weather_parser.py
+++ b/core/parsers/weather_parser.py
@@ -198,6 +198,7 @@ class WeatherAlarmParser(BaseParser):
                 f"[灾害预警] 气象预警解析成功: {domain_event.title or domain_event.headline}, 生效时间: {issue_time}",
                 is_event_linked=True,
                 event_stream="weather_alarm",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/rules/typhoon_rule.py
+++ b/core/rules/typhoon_rule.py
@@ -59,12 +59,33 @@ class TyphoonRule(BaseRule):
         }
 
         # 1) 活跃状态
-        if typhoon_filter.get("only_active", True) and not bool(domain_event.is_active):
-            return RuleDecision.reject(
-                reason="台风活跃状态过滤",
-                detail="该台风已停止编报，且仅推送活跃台风",
-                context=decision_context,
+        if not bool(domain_event.is_active):
+            # 停编通知：typhoon_filter.typhoon_deactivate_notify 开启时直接放行，
+            # 不受名称/强度/距离等过滤约束（停编即视为值得通知）。
+            # 早已停编的历史台风由前置 time_rule 按事件时效过滤，避免刷屏。
+            deactivate_notify = bool(
+                typhoon_filter.get("typhoon_deactivate_notify", True)
             )
+            if deactivate_notify:
+                # 仍尽量补充本地距离信息供展示复用。
+                estimation = self._build_location_estimation(
+                    domain_event,
+                    typhoon_filter,
+                    context.runtime_config,
+                )
+                if estimation:
+                    context.extras["typhoon_local_estimation"] = estimation
+                return RuleDecision.accept(
+                    reason="台风停编通知",
+                    detail="该台风已停止编报",
+                    context=decision_context,
+                )
+            if typhoon_filter.get("only_active", True):
+                return RuleDecision.reject(
+                    reason="台风活跃状态过滤",
+                    detail="该台风已停止编报，且仅推送活跃台风",
+                    context=decision_context,
+                )
 
         # 2) 名称黑白名单
         name_decision = self._evaluate_name_lists(domain_event, typhoon_filter)

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -713,6 +713,8 @@ class ConfigValidator:
 
         ConfigValidator._ensure_bool(typhoon_filter, "enabled", False)
         ConfigValidator._ensure_bool(typhoon_filter, "only_active", True)
+        # 台风停编通知开关：默认开启，停编时即使核心参数未变化也推送一条。
+        ConfigValidator._ensure_bool(typhoon_filter, "typhoon_deactivate_notify", True)
 
         valid_levels = [
             "热带低压",

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -51,7 +51,7 @@ class ConfigValidator:
         返回值：
         - 校验并修正后的配置字典
         """
-        logger.info("[灾害预警] 正在进行配置校验...")
+        logger.debug("[灾害预警] 正在进行配置校验...")
 
         # 按配置分组依次处理，确保每一类配置都在进入运行态前完成基础修正。
 
@@ -172,7 +172,7 @@ class ConfigValidator:
         if "enabled" in config and not isinstance(config["enabled"], bool):
             config["enabled"] = True
 
-        logger.info("[灾害预警] 配置校验完成")
+        logger.debug("[灾害预警] 配置校验完成")
         return config
 
     @staticmethod

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -93,16 +93,16 @@ class ConnectionPlanBuilder:
 
             connections[group_key] = plan
             if group_key == "fan_studio_all":
-                logger.info("[灾害预警] 已配置 FAN Studio 全量数据连接")
+                logger.debug("[灾害预警] 已配置 FAN Studio 全量数据连接")
             elif group_key == "fan_studio_cenc_ir":
-                logger.info("[灾害预警] 已配置 FAN Studio 烈度速报独立连接")
+                logger.debug("[灾害预警] 已配置 FAN Studio 烈度速报独立连接")
             elif group_key == "p2p_main":
-                logger.info("[灾害预警] 已配置 P2P 地震情报连接")
+                logger.debug("[灾害预警] 已配置 P2P 地震情报连接")
             elif group_key == "wolfx_all":
-                logger.info("[灾害预警] 已配置 Wolfx 全量数据连接")
+                logger.debug("[灾害预警] 已配置 Wolfx 全量数据连接")
             elif group_key == "openquake_api":
-                logger.info("[灾害预警] 已配置 OpenQuakeAPI 全量数据连接")
+                logger.debug("[灾害预警] 已配置 OpenQuakeAPI 全量数据连接")
             else:
-                logger.info(f"[灾害预警] 已配置数据连接，连接分组为 {group_key}")
+                logger.debug(f"[灾害预警] 已配置数据连接，连接分组为 {group_key}")
 
         return connections

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -271,6 +271,18 @@ class EqscCencIntensityPollService:
         if event is None:
             return False
 
+        # 去重只读预判：与流水线 should_push_event 的跨源优先级判定
+        # （_should_push_cenc_intensity_report）完全对齐，但不写缓存。
+        # 被过滤（低优先级被高优先级源占用 / 同优先级先到先得）的事件
+        # 不计入本轮推送统计，仅提交列表指纹避免下轮重复拉详情。
+        deduplicator = getattr(
+            getattr(self.service, "message_manager", None), "deduplicator", None
+        )
+        peek = getattr(deduplicator, "peek_cenc_intensity_should_push", None)
+        if callable(peek) and not peek(event):
+            self._remember_event(event_id, list_fp)
+            return False
+
         # _handle_disaster_event 内部吞掉异常并返回 False；
         # 仅成功处理后才提交指纹，避免“失败当完成”导致漏重试。
         handled = await self.service._handle_disaster_event(event)

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -144,7 +144,7 @@ class EqscCencIntensityPollService:
             return
         self._task = asyncio.create_task(self._poll_loop(), name="dw_eqsc_cenc_ir_poll")
         self.service.scheduled_tasks.append(self._task)
-        logger.info("[灾害预警] EQSC CENC 烈度速报轮询任务已启动")
+        logger.debug("[灾害预警] EQSC CENC 烈度速报轮询任务已启动")
 
     async def stop(self) -> None:
         """停止后台轮询并释放客户端 HTTP 会话。
@@ -354,6 +354,7 @@ class EqscCencIntensityPollService:
                 f"[灾害预警] EQSC CENC 烈度速报轮询本轮推送 {emitted} 条",
                 is_event_linked=True,
                 event_stream="earthquake",
+                is_silent_window=True,
             )
         else:
             plugin_logger.debug("[灾害预警] EQSC CENC 烈度速报轮询本轮无变化，跳过推送")

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -133,7 +133,7 @@ class EqscTsunamiPollService:
         # 每轮会自行判断并跳过。
         self._task = asyncio.create_task(self._poll_loop(), name="dw_eqsc_tsunami_poll")
         self.service.scheduled_tasks.append(self._task)
-        logger.info("[灾害预警] EQSC 海啸轮询任务已启动")
+        logger.debug("[灾害预警] EQSC 海啸轮询任务已启动")
 
     async def stop(self) -> None:
         """停止后台轮询并释放客户端。"""

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -20,7 +20,6 @@ from ...domain.typhoon import (
     build_typhoon_event_envelope,
     clean_text,
     normalize_typhoon_id,
-    to_float,
 )
 from ...network.http.eqsc_token_manager import EqscTokenManager
 from ...network.http.eqsc_typhoon_client import EqscTyphoonClient
@@ -39,7 +38,10 @@ class EqscTyphoonPollService:
         self.service = service
         self._source_runtime_query = SourceRuntimeQueryService(service.config)
         self._task: asyncio.Task | None = None
-        self._last_fingerprints: dict[str, str] = {}
+        # 上一轮轮询中处于活跃态的台风 ID 集合。
+        # 用于识别"上一轮活跃 → 本轮停编"的台风，放行一次以推送停编通知；
+        # 早已停编的历史台风不在集合中，不会进入投递，避免每轮刷屏。
+        self._last_active_ids: set[str] = set()
         self._last_success_at: float | None = None
         self._consecutive_failures = 0
         self._client: EqscTyphoonClient | None = None
@@ -131,12 +133,17 @@ class EqscTyphoonPollService:
 
     def get_runtime_status(self) -> dict[str, Any]:
         """供健康面板读取的轻量运行态。"""
+        deduplicator = getattr(
+            getattr(self.service, "message_manager", None), "deduplicator", None
+        )
+        typhoon_cache = getattr(deduplicator, "_typhoon_cache", None)
+        tracked_typhoons = len(typhoon_cache) if isinstance(typhoon_cache, dict) else 0
         return {
             "running": self.running,
             "enabled": self.is_enabled(),
             "last_success_at": self._last_success_at,
             "consecutive_failures": int(self._consecutive_failures),
-            "tracked_typhoons": len(self._last_fingerprints),
+            "tracked_typhoons": tracked_typhoons,
             "poll_interval_seconds": self._resolve_interval(),
         }
 
@@ -213,31 +220,6 @@ class EqscTyphoonPollService:
         # 缺省字段时保守视为活跃，避免漏推
         return True
 
-    @staticmethod
-    def _build_fingerprint_from_event(typhoon: TyphoonEvent) -> str:
-        """与去重服务一致的核心参数指纹。"""
-        return "|".join(
-            [
-                str(typhoon.typhoon_type or "").strip(),
-                EqscTyphoonPollService._normalize_value(typhoon.latitude),
-                EqscTyphoonPollService._normalize_value(typhoon.longitude),
-                EqscTyphoonPollService._normalize_value(typhoon.wind_speed),
-                EqscTyphoonPollService._normalize_value(typhoon.pressure),
-                str(typhoon.move_direction or "").strip(),
-                EqscTyphoonPollService._normalize_value(typhoon.move_speed),
-                EqscTyphoonPollService._normalize_value(typhoon.radius7),
-                EqscTyphoonPollService._normalize_value(typhoon.radius10),
-                "1" if bool(typhoon.is_active) else "0",
-            ]
-        )
-
-    @staticmethod
-    def _normalize_value(value: Any) -> str:
-        number = to_float(value)
-        if number is None:
-            return ""
-        return f"{number:.4f}"
-
     def _build_live_envelope(self, raw: dict[str, Any]):
         """从 EQSC 原始对象构建实时推送事件。"""
         envelope = build_typhoon_event_envelope(
@@ -256,21 +238,43 @@ class EqscTyphoonPollService:
         return envelope
 
     def _filter_active_items(self, typhoon_list: list[Any]) -> list[dict[str, Any]]:
-        """从列表中筛出可处理的活跃台风对象。"""
-        active_items: list[dict[str, Any]] = []
+        """筛出本轮可处理的台风对象：活跃台风 + 刚停编台风。
+
+        EQSC 台风列表同时包含活跃与历史台风（客户端文档已注明）：
+        - 活跃台风（isActive=True）始终进入投递；
+        - 上一轮活跃、本轮停编（isActive=False）的台风放行一次，
+          用于推送"停编通知"（停编时即使核心参数未变化也应推一条）；
+        - 早已停编的历史台风不在 _last_active_ids 中，不进入投递，
+          由 time_rule 兜底过滤，避免冷启动/每轮刷屏。
+        """
+        current_active_ids: set[str] = set()
+        candidates: list[dict[str, Any]] = []
         for item in typhoon_list:
             if not isinstance(item, dict):
                 continue
-            if not clean_text(item.get("id")):
+            typhoon_id = clean_text(item.get("id"))
+            if not typhoon_id:
                 continue
-            if not self._is_active_typhoon(item):
-                continue
-            active_items.append(item)
-        return active_items
+            if self._is_active_typhoon(item):
+                current_active_ids.add(typhoon_id)
+                candidates.append(item)
+            elif typhoon_id in self._last_active_ids:
+                # 刚停编：放行一次以推送停编通知
+                candidates.append(item)
+
+        # 记录本轮活跃集合，供下一轮识别"刚停编"台风。
+        self._last_active_ids = current_active_ids
+        return candidates
 
     async def _process_typhoon_updates(self, active_items: list[dict[str, Any]]) -> int:
-        """按指纹去重后投递变化事件；单事件失败不中断整批。"""
-        seen_ids: set[str] = set()
+        """投递活跃台风事件；单事件失败不中断整批。
+
+        去重判定与 FAN 触发路径及事件流水线完全统一：
+        统一使用去重服务的只读判定 peek_typhoon_should_push
+        （基于 _typhoon_cache 与 _generate_typhoon_fingerprint），
+        不再在轮询侧自建指纹缓存，避免「去重器判定过滤、
+        轮询侧却统计为推送」的口径矛盾。
+        """
         emitted = 0
         for raw in active_items:
             envelope = self._build_live_envelope(raw)
@@ -281,22 +285,13 @@ class EqscTyphoonPollService:
             typhoon_id = normalize_typhoon_id(typhoon.typhoon_id)
             if not typhoon_id:
                 continue
-            seen_ids.add(typhoon_id)
 
-            fingerprint = self._build_fingerprint_from_event(typhoon)
-            if self._last_fingerprints.get(typhoon_id) == fingerprint:
-                continue
-
-            # 启动静默期：提交轮询侧指纹（避免静默结束后整批误报），
-            # 并调用 _handle_disaster_event 让其内部的 _seed_event_for_silence
-            # 统一播种去重服务的 _typhoon_cache，避免静默结束后首次推送
-            # 因去重缓存为空而被误放行（重载后重复推送的根因）。
+            # 启动静默期：不推送、不统计，仅调用 _handle_disaster_event
+            # 让其内部的 _seed_event_for_silence 播种去重服务的 _typhoon_cache，
+            # 避免静默结束后首次推送因去重缓存为空而被误放行（重载后重复推送的根因）。
             is_silence = getattr(self.service, "is_silencing", None)
             if callable(is_silence) and is_silence():
-                self._last_fingerprints[typhoon_id] = fingerprint
                 try:
-                    # 静默期 _handle_disaster_event 会播种去重指纹并返回 True，
-                    # 不会真正推送；但仍提交轮询侧指纹防止静默结束后重推。
                     await self.service._handle_disaster_event(envelope)
                 except Exception as exc:
                     logger.debug(
@@ -305,11 +300,21 @@ class EqscTyphoonPollService:
                     )
                 continue
 
+            # 统一去重判定：与 _handle_disaster_event 内 FAN 触发路径一致，
+            # 使用去重服务的只读判定（不写缓存；真正写入由流水线
+            # should_push_event 在放行时完成）。被过滤者不计入本轮推送统计。
+            deduplicator = getattr(
+                getattr(self.service, "message_manager", None), "deduplicator", None
+            )
+            peek = getattr(deduplicator, "peek_typhoon_should_push", None)
+            if callable(peek) and not peek(envelope):
+                continue
+
             try:
                 handled = await self.service._handle_disaster_event(envelope)
             except Exception as exc:
                 # 单台风软失败：记录后继续处理其余活跃台风；
-                # 不提交指纹，下一轮可重试该台风。
+                # 去重缓存未被写入，下一轮可重试该台风。
                 logger.error(
                     f"[灾害预警] EQSC 台风事件推送失败，已跳过并继续本轮: "
                     f"ID 为 {typhoon_id}, 错误信息：{exc}"
@@ -321,13 +326,8 @@ class EqscTyphoonPollService:
                     f"ID 为 {typhoon_id}"
                 )
                 continue
-            self._last_fingerprints[typhoon_id] = fingerprint
             emitted += 1
 
-        # 清理已消亡台风的指纹缓存，避免无限增长。
-        stale_ids = [key for key in self._last_fingerprints if key not in seen_ids]
-        for key in stale_ids:
-            self._last_fingerprints.pop(key, None)
         return emitted
 
     def _notify_silence_fetch_completed(self, *, success: bool) -> None:

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -278,7 +278,9 @@ class EqscTyphoonPollService:
         self._last_active_ids = current_active_ids
         return candidates
 
-    async def _process_typhoon_updates(self, active_items: list[dict[str, Any]]) -> int:
+    async def _process_typhoon_updates(
+        self, active_items: list[dict[str, Any]]
+    ) -> tuple[int, int]:
         """投递活跃台风事件；单事件失败不中断整批。
 
         去重判定与 FAN 触发路径及事件流水线完全统一：
@@ -286,6 +288,9 @@ class EqscTyphoonPollService:
         （基于 _typhoon_cache 与 _generate_typhoon_fingerprint），
         不再在轮询侧自建指纹缓存，避免「去重器判定过滤、
         轮询侧却统计为推送」的口径矛盾。
+
+        Returns:
+            (emitted, filtered)：成功推送条数与被去重过滤条数。
         """
         emitted = 0
         filtered = 0
@@ -308,14 +313,20 @@ class EqscTyphoonPollService:
             is_silence = getattr(self.service, "is_silencing", None)
             if callable(is_silence) and is_silence():
                 try:
-                    await self.service._handle_disaster_event(envelope)
-                    # 静默期播种成功同样视为已处理，清理待重试停编 ID。
-                    self._pending_deactivate_ids.discard(typhoon_id)
+                    handled = await self.service._handle_disaster_event(envelope)
                 except Exception as exc:
                     logger.debug(
                         f"[灾害预警] EQSC 台风静默期播种去重指纹失败（已忽略）: "
                         f"ID 为 {typhoon_id}, 错误信息：{exc}"
                     )
+                    handled = False
+                # 仅播种成功（返回 True）时才视为已处理并清理待重试停编 ID；
+                # 返回 False 或抛出异常时保留（停编台风重新加入）待重试集合，
+                # 避免先前投递失败的停编通知在静默期被误清理而永久丢失。
+                if handled:
+                    self._pending_deactivate_ids.discard(typhoon_id)
+                elif deactivated:
+                    self._pending_deactivate_ids.add(typhoon_id)
                 continue
 
             # 统一去重判定：与 _handle_disaster_event 内 FAN 触发路径一致，
@@ -412,7 +423,12 @@ class EqscTyphoonPollService:
                 is_silent_window=True,
             )
         else:
-            plugin_logger.debug("[灾害预警] EQSC 台风轮询本轮无变化，跳过推送")
+            plugin_logger.debug(
+                "[灾害预警] EQSC 台风轮询本轮无变化，跳过推送",
+                is_event_linked=True,
+                event_stream="typhoon",
+                is_silent_window=True,
+            )
         return active_items
 
 

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -149,7 +149,7 @@ class EqscTyphoonPollService:
             return
         self._task = asyncio.create_task(self._poll_loop(), name="dw_eqsc_typhoon_poll")
         self.service.scheduled_tasks.append(self._task)
-        logger.info("[灾害预警] EQSC 台风轮询任务已启动")
+        logger.debug("[灾害预警] EQSC 台风轮询任务已启动")
 
     async def stop(self) -> None:
         """停止后台轮询；仅关闭本服务自己创建的客户端。
@@ -375,6 +375,7 @@ class EqscTyphoonPollService:
                 f"[灾害预警] EQSC 台风轮询本轮推送 {emitted} 条更新",
                 is_event_linked=True,
                 event_stream="typhoon",
+                is_silent_window=True,
             )
         else:
             plugin_logger.debug("[灾害预警] EQSC 台风轮询本轮无变化，跳过推送")

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -42,6 +42,10 @@ class EqscTyphoonPollService:
         # 用于识别"上一轮活跃 → 本轮停编"的台风，放行一次以推送停编通知；
         # 早已停编的历史台风不在集合中，不会进入投递，避免每轮刷屏。
         self._last_active_ids: set[str] = set()
+        # 刚停编但尚未确认投递成功的台风 ID 集合。
+        # 若 _handle_disaster_event 返回失败，停编通知仍保留在此集合，
+        # 下一轮轮询会继续放行重试，直到投递成功才移除，避免停编通知永久丢失。
+        self._pending_deactivate_ids: set[str] = set()
         self._last_success_at: float | None = None
         self._consecutive_failures = 0
         self._client: EqscTyphoonClient | None = None
@@ -244,7 +248,9 @@ class EqscTyphoonPollService:
         - 活跃台风（isActive=True）始终进入投递；
         - 上一轮活跃、本轮停编（isActive=False）的台风放行一次，
           用于推送"停编通知"（停编时即使核心参数未变化也应推一条）；
-        - 早已停编的历史台风不在 _last_active_ids 中，不进入投递，
+        - 上一轮停编但投递失败的台风（在 _pending_deactivate_ids 中）继续放行重试，
+          直到投递成功后才从该集合移除，避免停编通知因瞬时失败永久丢失；
+        - 早已停编的历史台风不在上述两个集合中，不进入投递，
           由 time_rule 兜底过滤，避免冷启动/每轮刷屏。
         """
         current_active_ids: set[str] = set()
@@ -257,12 +263,18 @@ class EqscTyphoonPollService:
                 continue
             if self._is_active_typhoon(item):
                 current_active_ids.add(typhoon_id)
+                # 台风重新活跃：若之前处于待确认停编集合中则清理，避免残留导致误放行。
+                self._pending_deactivate_ids.discard(typhoon_id)
                 candidates.append(item)
-            elif typhoon_id in self._last_active_ids:
-                # 刚停编：放行一次以推送停编通知
+            elif (
+                typhoon_id in self._last_active_ids
+                or typhoon_id in self._pending_deactivate_ids
+            ):
+                # 刚停编 或 停编投递失败待重试：放行以推送/重试停编通知
                 candidates.append(item)
 
         # 记录本轮活跃集合，供下一轮识别"刚停编"台风。
+        # 注意：此处覆盖的是活跃集合，不影响 _pending_deactivate_ids 的待重试保留。
         self._last_active_ids = current_active_ids
         return candidates
 
@@ -276,6 +288,7 @@ class EqscTyphoonPollService:
         轮询侧却统计为推送」的口径矛盾。
         """
         emitted = 0
+        filtered = 0
         for raw in active_items:
             envelope = self._build_live_envelope(raw)
             if envelope is None or not isinstance(envelope.event, TyphoonEvent):
@@ -286,6 +299,9 @@ class EqscTyphoonPollService:
             if not typhoon_id:
                 continue
 
+            # 停编标记：用于决定投递失败时是否保留待重试集合。
+            deactivated = not bool(getattr(typhoon, "is_active", True))
+
             # 启动静默期：不推送、不统计，仅调用 _handle_disaster_event
             # 让其内部的 _seed_event_for_silence 播种去重服务的 _typhoon_cache，
             # 避免静默结束后首次推送因去重缓存为空而被误放行（重载后重复推送的根因）。
@@ -293,6 +309,8 @@ class EqscTyphoonPollService:
             if callable(is_silence) and is_silence():
                 try:
                     await self.service._handle_disaster_event(envelope)
+                    # 静默期播种成功同样视为已处理，清理待重试停编 ID。
+                    self._pending_deactivate_ids.discard(typhoon_id)
                 except Exception as exc:
                     logger.debug(
                         f"[灾害预警] EQSC 台风静默期播种去重指纹失败（已忽略）: "
@@ -308,6 +326,10 @@ class EqscTyphoonPollService:
             )
             peek = getattr(deduplicator, "peek_typhoon_should_push", None)
             if callable(peek) and not peek(envelope):
+                # 去重判定已通过（内容有变化）才会走到这里；被过滤意味着
+                # 该停编通知此前已成功推送过，无需再保留待重试。
+                self._pending_deactivate_ids.discard(typhoon_id)
+                filtered += 1
                 continue
 
             try:
@@ -319,16 +341,24 @@ class EqscTyphoonPollService:
                     f"[灾害预警] EQSC 台风事件推送失败，已跳过并继续本轮: "
                     f"ID 为 {typhoon_id}, 错误信息：{exc}"
                 )
+                if deactivated:
+                    # 停编通知投递失败：保留 ID，下一轮继续放行重试，
+                    # 避免该停编通知永久丢失。
+                    self._pending_deactivate_ids.add(typhoon_id)
                 continue
             if not handled:
                 logger.error(
                     f"[灾害预警] EQSC 台风事件处理未成功，已跳过并继续本轮: "
                     f"ID 为 {typhoon_id}"
                 )
+                if deactivated:
+                    self._pending_deactivate_ids.add(typhoon_id)
                 continue
+            # 投递成功：停编通知已送达，从待重试集合中移除。
+            self._pending_deactivate_ids.discard(typhoon_id)
             emitted += 1
 
-        return emitted
+        return emitted, filtered
 
     def _notify_silence_fetch_completed(self, *, success: bool) -> None:
         """通知静默协调器本轮抓取已结束（成功或失败）。"""
@@ -368,11 +398,15 @@ class EqscTyphoonPollService:
 
         # 先完成事件投递（含静默期指纹播种），再通知抓取完成，
         # 避免静默协调器提前 READY 导致首批台风指纹未播种而重复推送。
-        emitted = await self._process_typhoon_updates(active_items)
+        emitted, filtered = await self._process_typhoon_updates(active_items)
         self._notify_silence_fetch_completed(success=True)
-        if emitted:
-            plugin_logger.info(
-                f"[灾害预警] EQSC 台风轮询本轮推送 {emitted} 条更新",
+        # 轮询汇总默认 DEBUG，避免每轮轮询都刷 INFO；
+        # 有推送价值的事件进入流水线后，会由事件级"会话筛选/推送完成"汇总
+        # （INFO 级）提供可观测性。需要查看轮询明细时开启 DEBUG 级别。
+        if emitted or filtered:
+            plugin_logger.debug(
+                f"[灾害预警] EQSC 台风轮询汇总：推送 {emitted} 条更新，"
+                f"跳过 {filtered} 条未变化",
                 is_event_linked=True,
                 event_stream="typhoon",
                 is_silent_window=True,

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -167,7 +167,7 @@ class ConnectionHealthService:
         except Exception as exc:
             logger.warning(f"[灾害预警] 连接健康可用性重算失败: {exc}")
         self._task = asyncio.create_task(self._loop())
-        logger.info("[灾害预警] 连接健康采样服务已启动")
+        logger.debug("[灾害预警] 连接健康采样服务已启动")
 
     async def stop(self) -> None:
         """停止后台采样循环。"""
@@ -182,7 +182,7 @@ class ConnectionHealthService:
                 pass
             except Exception as exc:
                 logger.warning(f"[灾害预警] 连接健康采样停止时异常: {exc}")
-        logger.info("[灾害预警] 连接健康采样服务已停止")
+        logger.debug("[灾害预警] 连接健康采样服务已停止")
 
     async def _hydrate_open_incidents(self) -> None:
         """从数据库恢复各连接组未关闭事故到内存 tracker。"""

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -453,6 +453,7 @@ class EventDeduplicationService:
                 f"(event={event_id})",
                 is_event_linked=True,
                 event_stream="tsunami",
+                is_silent_window=True,
             )
             return False
 

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -209,7 +209,9 @@ class EventDeduplicationService:
         fingerprint = self._generate_typhoon_fingerprint(typhoon)
         cached_fingerprint = self._typhoon_cache.get(typhoon_id)
         if cached_fingerprint is not None and cached_fingerprint == fingerprint:
-            plugin_logger.info(
+            # 与 push_flow_handler 其他事件流的去重过滤日志保持一致：
+            # 单条过滤仅 DEBUG 级，避免轮询特性导致每轮 INFO 刷屏；
+            plugin_logger.debug(
                 f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
                 is_event_linked=True,
                 event_stream="typhoon",
@@ -236,7 +238,9 @@ class EventDeduplicationService:
         cached_fingerprint = self._typhoon_cache.get(typhoon_id)
 
         if cached_fingerprint is not None and cached_fingerprint == fingerprint:
-            plugin_logger.info(
+            # 单条过滤仅 DEBUG 级，与 push_flow_handler 其他事件流对齐，
+            # 避免轮询特性导致每轮 INFO 刷屏；汇总由轮询侧日志承担。
+            plugin_logger.debug(
                 f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
                 is_event_linked=True,
                 event_stream="typhoon",

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -185,6 +185,10 @@ class EventDeduplicationService:
                 cls._normalize_fingerprint_value(typhoon.move_speed),
                 cls._normalize_fingerprint_value(typhoon.radius7),
                 cls._normalize_fingerprint_value(typhoon.radius10),
+                # 活跃状态参与指纹：停编（isActive 翻转）即使核心参数未变化
+                # 也视为变化放行，用于推送停编通知。FAN 数据不含活跃状态，
+                # 事件 is_active 恒为 True，不受影响。
+                "1" if bool(typhoon.is_active) else "0",
             ]
         )
 
@@ -330,6 +334,74 @@ class EventDeduplicationService:
             event_id=event_id,
         )
 
+    def _peek_priority_fingerprint(
+        self,
+        *,
+        cache: dict[str, dict[str, Any]],
+        fingerprint: str,
+        source_id: str,
+        event_id: str,
+        kind: str,
+        log_level: str = "info",
+        filter_same_source: bool = True,
+    ) -> bool:
+        """跨源优先级去重只读预判（不写缓存）。
+
+        判定规则与 _should_push_by_priority_fingerprint 完全一致，
+        但不会写入 cache，供轮询侧在投递前提前过滤并准确统计，
+        避免预判写缓存污染下游二次判定（如报次/指纹被提前消耗）。
+
+        规则：
+        1. 指纹未见过 → 放行
+        2. 指纹相同且来源优先级更低 → 过滤
+        3. 指纹相同且同优先级不同源 → 过滤（先到先得）
+        4. 指纹相同且同优先级同源 → 由 filter_same_source 决定
+        5. 指纹相同但来源优先级更高 → 放行（升级由下游真实判定完成）
+        """
+        priority = self._resolve_source_priority(source_id)
+        existing = cache.get(fingerprint)
+        if existing is None:
+            return True
+
+        existing_priority = int(existing.get("priority") or 0)
+        existing_source = str(existing.get("source_id") or "")
+        stream_tag = self._resolve_event_stream_by_source_id(source_id)
+
+        def _log_filter(msg: str) -> None:
+            if log_level == "info":
+                plugin_logger.info(msg, is_event_linked=True, event_stream=stream_tag)
+            else:
+                plugin_logger.debug(msg)
+
+        if priority < existing_priority:
+            _log_filter(
+                f"[灾害预警] {kind}内容与 {existing_source} 重复且优先级更低，"
+                f"过滤 {source_id} 推送 (event={event_id})"
+            )
+            return False
+        if priority == existing_priority and existing_source == source_id:
+            if not filter_same_source:
+                # 粗软指纹：同源更新交给下游 _should_allow_update 判定
+                plugin_logger.debug(
+                    f"[灾害预警] {kind}同源软指纹命中，放行供下游更新判定: "
+                    f"{source_id} (事件 ID {event_id})"
+                )
+                return True
+            _log_filter(
+                f"[灾害预警] {kind}内容未变化，过滤重复推送: {source_id} "
+                f"(事件 ID {event_id})"
+            )
+            return False
+        if priority == existing_priority and existing_source != source_id:
+            # 同优先级不同源：先到先得
+            _log_filter(
+                f"[灾害预警] {kind}内容与 {existing_source} 重复，过滤 {source_id} 推送"
+            )
+            return False
+
+        # 更高优先级源后到：放行（缓存升级由下游真实判定完成）
+        return True
+
     def _should_push_by_priority_fingerprint(
         self,
         *,
@@ -398,7 +470,7 @@ class EventDeduplicationService:
                 return True
             _log_filter(
                 f"[灾害预警] {kind}内容未变化，过滤重复推送: {source_id} "
-                f"(event={event_id})"
+                f"(事件 ID {event_id})"
             )
             return False
         if priority == existing_priority and existing_source != source_id:
@@ -551,6 +623,34 @@ class EventDeduplicationService:
         return self._should_push_by_priority_fingerprint(
             cache=self._cenc_ir_cache,
             max_size=self._cenc_ir_cache_max_size,
+            fingerprint=fingerprint,
+            source_id=source_id,
+            event_id=str(event.id or ""),
+            kind="烈度速报",
+            log_level="debug",
+            filter_same_source=False,
+        )
+
+    def peek_cenc_intensity_should_push(self, event: EventEnvelope) -> bool:
+        """CENC 烈度速报跨源去重只读预判（不写缓存）。
+
+        与 _should_push_cenc_intensity_report 判定规则一致，但不会写入
+        _cenc_ir_cache，供轮询侧在投递前提前过滤并准确统计，
+        避免预判写缓存污染下游二次判定。
+        """
+        domain_eq = self._get_domain_earthquake(event)
+        if domain_eq is None:
+            return True
+        source_id = self._get_source_id(event)
+        if not self._is_cenc_intensity_report_source(source_id):
+            return True
+
+        fingerprint = self._build_cenc_ir_soft_fingerprint(event, domain_eq, source_id)
+        if not fingerprint:
+            return True
+
+        return self._peek_priority_fingerprint(
+            cache=self._cenc_ir_cache,
             fingerprint=fingerprint,
             source_id=source_id,
             event_id=str(event.id or ""),

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -215,6 +215,7 @@ class EventDeduplicationService:
                 f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
                 is_event_linked=True,
                 event_stream="typhoon",
+                is_silent_window=True,
             )
             return False
         return True
@@ -244,13 +245,17 @@ class EventDeduplicationService:
                 f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
                 is_event_linked=True,
                 event_stream="typhoon",
+                is_silent_window=True,
             )
             return False
 
         # 参数有变化（或首次出现），更新缓存并放行
         self._typhoon_cache[typhoon_id] = fingerprint
         plugin_logger.debug(
-            f"[灾害预警] 台风 {typhoon_id} 核心参数已更新，允许推送 (指纹: {fingerprint})"
+            f"[灾害预警] 台风 {typhoon_id} 核心参数已更新，允许推送 (指纹: {fingerprint})",
+            is_event_linked=True,
+            event_stream="typhoon",
+            is_silent_window=True,
         )
         return True
 

--- a/core/services/notification/notification_center.py
+++ b/core/services/notification/notification_center.py
@@ -216,7 +216,7 @@ class NotificationCenter:
 
         # 挂载后台长轮询定时协程任务
         self._poll_task = asyncio.create_task(_poll_loop())
-        logger.info("[灾害预警] 通知系统已启动")
+        logger.debug("[灾害预警] 通知系统已启动")
 
     async def _cancel_task(self, task: asyncio.Task | None) -> None:
         """取消并等待后台任务结束。"""
@@ -239,4 +239,4 @@ class NotificationCenter:
         self._poll_task = None
         # 停止前将当前缓存内容原子落盘保存
         await self.save_cache()
-        logger.info("[灾害预警] 通知系统已停止")
+        logger.debug("[灾害预警] 通知系统已停止")

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -131,7 +131,7 @@ class SnetPollService:
             return
         self._task = asyncio.create_task(self._poll_loop(), name="dw_snet_poll")
         self.service.scheduled_tasks.append(self._task)
-        logger.info("[灾害预警] S-Net 轮询任务已启动")
+        logger.debug("[灾害预警] S-Net 轮询任务已启动")
 
     async def stop(self) -> None:
         """停止后台轮询任务。"""

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -85,7 +85,7 @@ class DatabaseManager:
             cursor = await self.connection.cursor()
             await self._ensure_schema(cursor)
             await self.connection.commit()
-            logger.info(f"[灾害预警] 数据库初始化完成: {self.db_path}")
+            logger.debug(f"[灾害预警] 数据库初始化完成: {self.db_path}")
         except Exception as e:
             logger.error(f"[灾害预警] 数据库初始化失败: {e}")
             raise
@@ -2280,7 +2280,7 @@ class DatabaseManager:
         if self.connection:
             await self.connection.close()
             self.connection = None
-            logger.info("[灾害预警] 数据库连接已关闭")
+            logger.debug("[灾害预警] 数据库连接已关闭")
 
     async def __aenter__(self):
         """异步上下文管理器入口"""

--- a/core/storage/stats/stats_load_service.py
+++ b/core/storage/stats/stats_load_service.py
@@ -53,7 +53,7 @@ class StatsLoadService:
             rebuild_events = await self.manager.db.get_statistics_rebuild_events()
             if db_events:
                 # 数据库是当前版本的主要历史来源，命中后优先以数据库结果覆盖近期事件缓存。
-                logger.info(f"[灾害预警] 从数据库加载了 {len(db_events)} 条历史记录")
+                logger.debug(f"[灾害预警] 从数据库加载了 {len(db_events)} 条历史记录")
                 self.manager.stats["recent_pushes"] = db_events
                 self._restore_recorded_ids_from_db(db_events)
                 self._restore_time_series_counts(time_series_counts)

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from .plugin.commands.plugin_admin_command_service import PluginAdminCommandServ
 from .plugin.commands.plugin_query_command_service import PluginQueryCommandService
 from .plugin.plugin_command_support_service import PluginCommandSupportService
 from .plugin.plugin_lifecycle_service import PluginLifecycleService
+from .utils.banner import print_banner
 from .utils.plugin_logger import plugin_logger
 
 
@@ -44,7 +45,9 @@ class DisasterWarningPlugin(Star):
     async def initialize(self):
         """初始化插件"""
         try:
-            logger.info("[灾害预警] 正在初始化灾害预警插件...")
+            # 插件一重载即打印组织 ASCII art 横幅（bold_cyan 配色，终端不支持颜色时回退纯文本）。
+            print_banner()
+            logger.debug("[灾害预警] 正在初始化灾害预警插件...")
 
             plugin_logger.set_config(self.config)
 
@@ -108,14 +111,14 @@ class DisasterWarningPlugin(Star):
     async def terminate(self):
         """插件销毁时调用"""
         try:
-            logger.info("[灾害预警] 正在停止灾害预警插件...")
+            logger.debug("[灾害预警] 正在停止灾害预警插件...")
 
             await self._lifecycle_service.stop_heartbeat_task()
             self._lifecycle_service.restore_asyncio_exception_handler()
             await self._cleanup_telemetry_tasks()
             await self._lifecycle_service.shutdown_plugin_resources()
 
-            logger.info("[灾害预警] 灾害预警插件已停止")
+            logger.debug("[灾害预警] 灾害预警插件已停止")
 
         except Exception as e:
             logger.error(f"[灾害预警] 插件停止时出错: {e}")

--- a/plugin/plugin_lifecycle_service.py
+++ b/plugin/plugin_lifecycle_service.py
@@ -15,6 +15,7 @@ from astrbot.api import logger
 
 from ..core.services.config.config_validation_service import ConfigValidator
 from ..core.services.telemetry.telemetry_service import TelemetryManager
+from ..utils.banner import print_stop_summary
 from ..utils.version import get_plugin_version
 
 
@@ -181,6 +182,15 @@ class PluginLifecycleService:
         if self.plugin.web_server:
             # 最后停止管理端 Web 服务器，避免外部仍尝试进行网络交互
             await self.plugin.web_server.stop()
+
+        # 所有资源（含浏览器、后台延迟检测与 Web 管理端）均已完成回收后，
+        # 才打印停止汇总大屏，确保面板上的回收状态与实际运行态一致。
+        # 该大屏原先在 DisasterServiceLifecycle.stop() 内打印，彼时浏览器与
+        # Web 管理端尚未回收（由本方法在 stop() 之后执行），会显示 ⚠️ 未完成。
+        try:
+            print_stop_summary(self.plugin.disaster_service)
+        except Exception as banner_err:
+            logger.debug(f"[灾害预警] 停止汇总大屏打印失败（已忽略）: {banner_err}")
 
     def handle_asyncio_exception(self, loop, context) -> None:
         """事件循环未处理异步异常拦截入口，判断来源若为本插件则执行遥测收集上报。"""

--- a/utils/banner.py
+++ b/utils/banner.py
@@ -1,0 +1,716 @@
+"""
+启动横幅与汇总大屏生成器。
+
+负责三件事：
+1. 插件重载时打印组织名 Pancakes-Labs 的 ASCII art 横幅（bold_cyan 配色，
+   带框线），艺术字下方的插件名、版本与简介水平居中；
+2. 启动静默真正结束时（_force_ready）打印一张启动汇总大屏，把散落的初始化
+   信息一次性汇总展示，替代原先“车间流水账”式的逐行 INFO 日志；
+3. 服务停止时打印一张停止汇总大屏，汇总资源回收与停机耗时。
+
+排版说明：
+- 面板统一使用窄宽度（默认 60 列）框线，连接/轮询明细按列对齐，减少留白；
+- 使用 _display_width() 基于 unicodedata.east_asian_width() 精确估算显示宽度，
+  中英/emoji 混排时右侧框线也能严格对齐；
+- 使用 shutil.get_terminal_size() 探测终端宽度，宽度不足时 Pancakes 与 Labs
+  自动换行显示，避免被终端折行破坏等宽效果。
+
+颜色说明：
+- 仅当终端支持 ANSI 颜色（stdout 为 TTY 且非 NO_COLOR 环境）时启用 bold_cyan；
+- 否则回退为纯文本，保证日志文件与不支持彩色的终端下依然可读。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import unicodedata
+from datetime import datetime, timezone
+from typing import Any
+
+from astrbot.api import logger
+
+from .version import get_plugin_version
+
+# ---------------------------------------------------------------------------
+# Pancakes-Labs ASCII art（等宽字符，bold_cyan 配色）
+# ---------------------------------------------------------------------------
+_ASCII_ART_PANCAKES = r"""██████╗  █████╗ ███╗   ██╗ ██████╗ █████╗ ██╗  ██╗███████╗███████╗
+██╔══██╗██╔══██╗████╗  ██║██╔════╝██╔══██╗██║ ██╔╝██╔════╝██╔════╝
+██████╔╝███████║██╔██╗ ██║██║     ███████║█████╔╝ █████╗  ███████╗█████╗
+██╔═══╝ ██╔══██║██║╚██╗██║██║     ██╔══██║██╔═██╗ ██╔══╝  ╚════██║╚════╝
+██║     ██║  ██║██║ ╚████║╚██████╗██║  ██║██║  ██╗███████╗███████║
+╚═╝     ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝"""
+
+_ASCII_ART_LABS = r"""██╗      █████╗ ██████╗ ███████╗
+██║     ██╔══██╗██╔══██╗██╔════╝
+██║     ███████║██████╔╝███████╗
+██║     ██╔══██║██╔══██╗╚════██║
+███████╗██║  ██║██████╔╝███████║
+╚══════╝╚═╝  ╚═╝╚═════╝ ╚══════╝"""
+
+
+# ---------------------------------------------------------------------------
+# ANSI 颜色工具
+# ---------------------------------------------------------------------------
+_ANSI_BOLD_CYAN = "\x1b[1;36m"
+_ANSI_RESET = "\x1b[0m"
+
+
+def _supports_color() -> bool:
+    """是否启用 ANSI 颜色：stdout 为 TTY 且未显式禁用颜色。"""
+    if os.environ.get("NO_COLOR"):
+        return False
+    try:
+        stream = getattr(sys, "stdout", None)
+        return bool(stream is not None and stream.isatty())
+    except Exception:
+        return False
+
+
+def _paint_bold_cyan(text: str) -> str:
+    """用 bold_cyan 着色（若终端不支持颜色则原样返回）。"""
+    if not _supports_color():
+        return text
+    return f"{_ANSI_BOLD_CYAN}{text}{_ANSI_RESET}"
+
+
+# ---------------------------------------------------------------------------
+# 终端宽度探测
+# ---------------------------------------------------------------------------
+def _terminal_width() -> int:
+    try:
+        size = shutil.get_terminal_size(fallback=(80, 24))
+        return int(size.columns)
+    except Exception:
+        return 80
+
+
+# ---------------------------------------------------------------------------
+# ASCII art 生成（含宽度自适应）
+# ---------------------------------------------------------------------------
+def build_banner_lines() -> list[str]:
+    """生成带边框的横幅文本行（未着色），供打印与测试使用。"""
+    width = _terminal_width()
+    pancakes_lines = _ASCII_ART_PANCAKES.splitlines()
+    labs_lines = _ASCII_ART_LABS.splitlines()
+
+    # 单行并排所需的最小列数：取 Pancakes 行最大宽 + 1 空格 + Labs 行最大宽
+    max_pancakes_width = max(len(line) for line in pancakes_lines)
+    max_labs_width = max(len(line) for line in labs_lines)
+    single_line_width = max_pancakes_width + 1 + max_labs_width
+
+    # 宽度充足（>= 单行所需）时单行并排，否则 Labs 换行。
+    # 注意：Pancakes 各行宽度不一（第 3/4 行含额外块字符），
+    # 必须按最大宽度 ljust 补齐后再拼接，否则 Labs 列会对不齐。
+    if width >= single_line_width:
+        art_lines: list[str] = []
+        for p, lab in zip(pancakes_lines, labs_lines):
+            art_lines.append(f"{p.ljust(max_pancakes_width)} {lab}")
+    else:
+        art_lines = list(pancakes_lines) + list(labs_lines)
+
+    # 计算整个横幅的显示宽度（取 art 行最大宽 + 两侧留白 + 边框竖线）
+    art_width = max(_display_width(line) for line in art_lines)
+    inner_width = art_width + 4  # 左右各留 2 空格
+
+    version = (get_plugin_version() or "").strip()
+    caption_lines = [
+        f"Disaster Warning Plugin  ·  {version}",
+        "多数据源灾害预警插件 · 地震 / 海啸 / 气象 / 台风",
+    ]
+
+    lines: list[str] = []
+    lines.append(_PANEL_TOP + _PANEL_HORIZONTAL * inner_width + _PANEL_TOP_RIGHT)
+    for art in art_lines:
+        lines.append(
+            f"{_PANEL_VERTICAL}  {_pad(art, inner_width - 4)}  {_PANEL_VERTICAL}"
+        )
+    lines.append(
+        _PANEL_TITLE_RIGHT + _PANEL_HORIZONTAL * inner_width + _PANEL_TITLE_LEFT
+    )
+    for cap in caption_lines:
+        lines.append(
+            f"{_PANEL_VERTICAL} {_center(cap, inner_width - 2)} {_PANEL_VERTICAL}"
+        )
+    lines.append(_PANEL_BOTTOM + _PANEL_HORIZONTAL * inner_width + _PANEL_BOTTOM_RIGHT)
+    return lines
+
+
+def print_banner() -> None:
+    """打印 Pancakes-Labs ASCII art 横幅（bold_cyan 配色，带边框，说明居中）。"""
+    for line in build_banner_lines():
+        logger.info(_paint_bold_cyan(line))
+
+
+# ---------------------------------------------------------------------------
+# 启动汇总大屏生成
+# ---------------------------------------------------------------------------
+# 连接分组名 -> 展示名（大屏连接明细用）
+_CONNECTION_LABELS: dict[str, str] = {
+    "fan_studio_all": "FAN Studio 数据源",
+    "fan_studio_cenc_ir": "FAN Studio 烈度速报",
+    "p2p_main": "P2P 地震情报",
+    "wolfx_all": "Wolfx 数据源",
+    "openquake_api": "OpenQuake API",
+}
+
+# 轮询服务属性名 -> 展示名（大屏轮询明细用）
+_POLL_SERVICE_ATTRS: list[tuple[str, str]] = [
+    ("snet_poll_service", "S-Net 测站分布"),
+    ("eqsc_tsunami_poll_service", "EQSC 海啸轮询"),
+    ("eqsc_typhoon_poll_service", "EQSC 台风轮询"),
+    ("eqsc_cenc_intensity_poll_service", "EQSC 烈度速报"),
+]
+
+_PANEL_TOP = "┌"
+_PANEL_TOP_RIGHT = "┐"
+_PANEL_BOTTOM = "└"
+_PANEL_BOTTOM_RIGHT = "┘"
+_PANEL_HORIZONTAL = "─"
+_PANEL_VERTICAL = "│"
+_PANEL_TITLE_LEFT = "┤"
+_PANEL_TITLE_RIGHT = "├"
+
+
+def _ellipsize(text: str, max_width: int) -> str:
+    """按显示宽度做中段省略：保留头部与尾部，中间用 … 连接。
+
+    用于数据库路径等超长值，避免撑破面板右侧框线。
+    """
+    if max_width < 6:
+        max_width = 6
+    if _display_width(text) <= max_width:
+        return text
+    # 预留省略号宽度
+    ellipsis = "…"
+    keep = max_width - _display_width(ellipsis)
+    head_w = (keep * 2) // 3
+    tail_w = keep - head_w
+    # 按显示宽度裁剪 head/tail（避免半截宽字符）
+    head: list[str] = []
+    acc = 0
+    for ch in text:
+        w = _display_width(ch)
+        if acc + w > head_w:
+            break
+        acc += w
+        head.append(ch)
+    tail: list[str] = []
+    acc = 0
+    for ch in reversed(text):
+        w = _display_width(ch)
+        if acc + w > tail_w:
+            break
+        acc += w
+        tail.append(ch)
+    return "".join(head) + ellipsis + "".join(reversed(tail))
+
+
+def _display_width(text: str) -> int:
+    """估算字符串在终端的显示宽度（中英混排右线对齐的正解）。
+
+    使用 unicodedata.east_asian_width() 判断：
+    - "W" / "F"（全角/宽）→ 2 列
+    - 其余（含 "A" 模糊宽度，如块字符 █╗、· 等）→ 1 列
+      在等宽终端里这些字符均占 1 列，按 2 计会高估宽度导致右线错开。
+    - 零宽字符（ZWJ U+200D、变体选择符 U+FE00~FE0F）→ 0 列
+    - 后随变体选择符 U+FE0F 的字符按 emoji 呈现、占 2 列，
+      避免 EAW 为 "N" 的基础字符（如时钟类符号）被低估为 1 列。
+
+    提示：为彻底规避终端 emoji 宽度差异，大屏中优先选用 EAW=W 的
+    确定性 emoji，FE0F 处理仅作为兜底。
+    """
+    width = 0
+    for i, ch in enumerate(text):
+        code = ord(ch)
+        # 零宽字符（ZWJ U+200D、变体选择符 U+FE00~FE0F）不占列宽
+        if code == 0x200D or 0xFE00 <= code <= 0xFE0F:
+            continue
+        base = 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        # 后随 FE0F 的字符按 emoji 渲染（2 列）
+        if base == 1 and i + 1 < len(text) and ord(text[i + 1]) == 0xFE0F:
+            base = 2
+        width += base
+    return width
+
+
+def _pad(text: str, width: int) -> str:
+    """按显示宽度补齐到指定宽度（半角占 1，全角/emoji 占 2）。"""
+    return text + " " * max(0, width - _display_width(text))
+
+
+def _center(text: str, width: int) -> str:
+    """按显示宽度水平居中，左补 1 格保持视觉平衡。"""
+    pad_total = max(0, width - _display_width(text))
+    left = pad_total // 2
+    right = pad_total - left
+    return " " * left + text + " " * right
+
+
+class StartupSummaryPanel:
+    """启动汇总大屏：收集服务启动关键信息并排版为框线面板。"""
+
+    def __init__(self, service: Any) -> None:
+        self.service = service
+
+    # -- 字段采集 ----------------------------------------------------------
+    def _collect(self) -> dict[str, Any]:
+        service = self.service
+        data: dict[str, Any] = {}
+
+        data["version"] = get_plugin_version()
+
+        # 启动耗时：从服务初始化开始（init_started_at）到静默启动结束（ready_at）。
+        coordinator = getattr(service, "startup_silence", None)
+        ready_at = getattr(coordinator, "ready_at", None)
+        init_started = getattr(service, "init_started_at", None)
+        elapsed: float | None = None
+        if ready_at is not None and init_started is not None:
+            try:
+                start = (
+                    init_started.replace(tzinfo=None)
+                    if getattr(init_started, "tzinfo", None)
+                    else init_started
+                )
+                end = (
+                    ready_at.replace(tzinfo=None)
+                    if getattr(ready_at, "tzinfo", None)
+                    else ready_at
+                )
+                elapsed = (end - start).total_seconds()
+            except Exception:
+                elapsed = None
+        data["elapsed"] = elapsed
+
+        # WebSocket 连接
+        ws_manager = getattr(service, "ws_manager", None)
+        connected = set(getattr(ws_manager, "connections", {}) or {})
+        plan = getattr(service, "connections", {}) or {}
+        data["ws_connected"] = sorted(connected)
+        data["ws_expected"] = sorted(str(k) for k in plan.keys())
+        data["ws_skipped"] = sorted(
+            str(k) for k in data["ws_expected"] if k not in connected
+        )
+
+        # 轮询服务
+        poll_states: list[tuple[str, bool]] = []
+        for attr, label in _POLL_SERVICE_ATTRS:
+            svc = getattr(service, attr, None)
+            if svc is None:
+                continue
+            enabled = bool(getattr(svc, "is_enabled", lambda: False)())
+            poll_states.append((label, enabled))
+        data["polls"] = poll_states
+
+        # 历史记录
+        stats_mgr = getattr(service, "statistics_manager", None)
+        stats = getattr(stats_mgr, "stats", None) if stats_mgr else None
+        if isinstance(stats, dict):
+            data["history_count"] = len(stats.get("recent_pushes") or [])
+        else:
+            data["history_count"] = None
+
+        # 静默吸收快照
+        data["absorbed"] = getattr(coordinator, "absorbed_events", None)
+
+        # 数据库信息：完整路径太长（固定前缀就超宽），大屏只展示文件名 + 大小。
+        # 主服务无 database_manager 属性，实际挂在 statistics_manager.db。
+        db_path = None
+        db_manager = getattr(service, "database_manager", None)
+        if db_manager is not None:
+            db_path = getattr(db_manager, "db_path", None)
+        if db_path is None:
+            stats_mgr_for_db = getattr(service, "statistics_manager", None)
+            if stats_mgr_for_db is not None:
+                db_obj = getattr(stats_mgr_for_db, "db", None)
+                if db_obj is not None:
+                    db_path = getattr(db_obj, "db_path", None)
+        data["db_path"] = str(db_path) if db_path else None
+        if db_path:
+            db_file = os.path.basename(str(db_path))
+            try:
+                db_size = os.path.getsize(str(db_path))
+            except Exception:
+                db_size = None
+            if db_size is not None:
+                if db_size >= 1024 * 1024:
+                    db_size_text = f"{db_size / (1024 * 1024):.1f} MB"
+                elif db_size >= 1024:
+                    db_size_text = f"{db_size / 1024:.1f} KB"
+                else:
+                    db_size_text = f"{db_size} B"
+                data["db_path"] = f"{db_file} · {db_size_text}"
+            else:
+                data["db_path"] = db_file
+
+        # Web 管理端地址（web_server.start() 时已记录 self.url）
+        web_server = getattr(service, "web_admin_server", None)
+        web_url = getattr(web_server, "url", None) or getattr(
+            web_server, "base_url", None
+        )
+        data["web_url"] = str(web_url) if web_url else None
+
+        # 浏览器渲染服务：本地模式 / 远程模式。
+        browser: Any = None
+        message_manager = getattr(service, "message_manager", None)
+        if message_manager is not None:
+            browser = getattr(message_manager, "browser_manager", None)
+        browser_info: str | None = None
+        if browser is not None:
+            mode = getattr(browser, "_mode", "") or ""
+            server_url = getattr(browser, "_server_url", "") or ""
+            if mode == "remote":
+                browser_info = f"远程模式 · {server_url}" if server_url else "远程模式"
+            else:
+                browser_info = "本地模式"
+        data["browser"] = browser_info
+
+        # 配置校验结果：主服务校验通过后记录校验状态与耗时。
+        validator = getattr(service, "_config_validator", None)
+        if validator is None:
+            validator = getattr(service, "config_validator", None)
+        validate_ok = None
+        if validator is not None:
+            validate_ok = getattr(validator, "last_validation_ok", None)
+        data["config_valid"] = validate_ok
+
+        return data
+
+    # -- 排版 ---------------------------------------------------------------
+    def build(self, width: int = 60) -> list[str]:
+        """生成大屏文本行（不含边框颜色，纯框线）。"""
+        data = self._collect()
+
+        lines: list[str] = []
+        inner = max(10, width - 2)
+
+        def top(title: str = "") -> str:
+            if title:
+                left = title + " "
+                pad_len = inner - _display_width(left) - 1
+                return (
+                    f"{_PANEL_TOP}{_PANEL_HORIZONTAL * pad_len}"
+                    f"{_PANEL_TITLE_LEFT} {left}{_PANEL_TITLE_RIGHT}"
+                )
+            return _PANEL_TOP + _PANEL_HORIZONTAL * inner + _PANEL_TOP_RIGHT
+
+        def bottom() -> str:
+            return _PANEL_BOTTOM + _PANEL_HORIZONTAL * inner + _PANEL_BOTTOM_RIGHT
+
+        def row(text: str = "") -> str:
+            return f"{_PANEL_VERTICAL} {_pad(text, inner - 1)}{_PANEL_VERTICAL}"
+
+        def divider() -> str:
+            # 与 top()/bottom() 保持一致的 inner 个横线，避免右竖线少一格。
+            return f"{_PANEL_TITLE_RIGHT}{_PANEL_HORIZONTAL * inner}{_PANEL_TITLE_LEFT}"
+
+        lines.append(top())
+        lines.append(row(""))
+        lines.append(
+            row(
+                _pad(
+                    f"🌋 Disaster Warning Plugin · {data.get('version') or '?'}",
+                    inner - 1,
+                )
+            )
+        )
+        lines.append(row(""))
+        lines.append(divider())
+
+        # 运行信息（双栏/单栏自适应）
+        elapsed = data.get("elapsed")
+        elapsed_text = f"{elapsed:.2f} 秒" if elapsed is not None else "N/A"
+        ws_text = f"{len(data['ws_connected'])}/{len(data['ws_expected'])} 已连接"
+        poll_ok = sum(1 for _, ok in data["polls"] if ok)
+        poll_total = len(data["polls"])
+        poll_text = f"{poll_ok}/{poll_total} 已就绪"
+        history_text = (
+            f"{data['history_count']} 条"
+            if data.get("history_count") is not None
+            else "N/A"
+        )
+        absorbed_text = (
+            f"{data['absorbed']} 条" if data.get("absorbed") is not None else "N/A"
+        )
+
+        info_rows: list[tuple[str, str]] = [
+            ("✨ 启动耗时", elapsed_text),
+            ("📡 WebSocket", ws_text),
+            ("🔄 轮询服务", poll_text),
+            ("📚 加载历史记录", history_text),
+            ("🧹 静默吸收快照", absorbed_text),
+        ]
+        db_path = data.get("db_path")
+        if db_path:
+            # 数据库路径可能很长，单栏整行展示
+            info_rows.append(("💾 数据库", db_path))
+        browser_info = data.get("browser")
+        if browser_info:
+            info_rows.append(("🌍 浏览器渲染", browser_info))
+        config_valid = data.get("config_valid")
+        if config_valid is not None:
+            info_rows.append(("📋 配置校验", "✅ 通过" if config_valid else "❌ 异常"))
+        web_url = data.get("web_url")
+        if web_url:
+            info_rows.append(("🌐 Web 管理端", web_url))
+
+        # 运行信息采用单栏整行展示，键列与值列分别按固定宽度对齐，观感更整洁。
+        # 键列宽 = 各键最大显示宽度（emoji 宽度差异由 _pad 吸收）；
+        # 值列宽 = 内容区(inner-1) - 键列宽(key_width) - 分隔符("  "占2) - 值前空格
+        key_width = max(_display_width(k) for k, _ in info_rows)
+        value_width = inner - 1 - key_width - 2 - 1
+        for k, v in info_rows:
+            # 超长值（如数据库路径）中段省略，避免撑破右线。
+            short_v = _ellipsize(str(v), value_width)
+            lines.append(row(f"{_pad(k, key_width)}  {_pad(short_v, value_width)}"))
+
+        lines.append(divider())
+
+        # 连接明细：展示名前置（隐藏内部连接名），状态列左对齐，右侧对齐说明。
+        lines.append(row("连接明细"))
+        if data["ws_expected"]:
+            # 展示名（_CONNECTION_LABELS 映射）统一按最大宽度对齐
+            display_names = [
+                _CONNECTION_LABELS.get(name, name) for name in data["ws_expected"]
+            ]
+            name_width = max(_display_width(n) for n in display_names)
+            status_width = max(_display_width("✅ 已连接"), _display_width("⚠️ 未连接"))
+            for name in data["ws_expected"]:
+                ok = name in data["ws_connected"]
+                status = "✅ 已连接" if ok else "⚠️ 未连接"
+                label = _CONNECTION_LABELS.get(name, name)
+                # 展示名 + 状态固定宽，说明靠左（展示名宽度已覆盖最长项）
+                lines.append(
+                    row(
+                        _pad(
+                            f"{_pad(label, name_width)}  {_pad(status, status_width)}",
+                            inner - 1,
+                        )
+                    )
+                )
+        else:
+            lines.append(row(_pad("（无 WebSocket 连接）", inner - 1)))
+
+        # 轮询明细：展示名 / 状态 两列对齐
+        lines.append(row("轮询明细"))
+        if data["polls"]:
+            poll_name_width = max(_display_width(label) for label, _ in data["polls"])
+            status_width = max(_display_width("✅ 已就绪"), _display_width("⚪ 未启用"))
+            for label, ok in data["polls"]:
+                status = "✅ 已就绪" if ok else "⚪ 未启用"
+                lines.append(
+                    row(
+                        _pad(
+                            f"{_pad(label, poll_name_width)}  {_pad(status, status_width)}",
+                            inner - 1,
+                        )
+                    )
+                )
+        else:
+            lines.append(row(_pad("（无轮询服务）", inner - 1)))
+
+        lines.append(divider())
+
+        # 状态行
+        all_ok = len(data["ws_skipped"]) == 0 and poll_ok == poll_total
+        status_text = (
+            "所有数据源已就绪，静默结束，开始正常推送"
+            if all_ok
+            else "存在未就绪数据源，已结束静默（见上方状态）"
+        )
+        lines.append(row(f"状态：{status_text}"))
+        lines.append(bottom())
+        return lines
+
+    def print_summary(self) -> None:
+        """打印启动汇总大屏（INFO 级）。"""
+        for line in self.build():
+            logger.info(line)
+
+
+def print_startup_summary(service: Any) -> None:
+    """便捷入口：从主服务实例打印启动汇总大屏。"""
+    StartupSummaryPanel(service).print_summary()
+
+
+# ---------------------------------------------------------------------------
+# 停止汇总大屏生成
+# ---------------------------------------------------------------------------
+class StopSummaryPanel:
+    """停止汇总大屏：收集服务停止关键信息并排版为框线面板。
+
+    与 StartupSummaryPanel 保持一致的框线工具与双栏/单栏自适应排版，
+    但聚焦"资源回收 + 停机耗时"维度，替代停止流程中散落的逐行 INFO 流水，
+    让停机阶段只剩一张干净的汇总大屏。
+    """
+
+    def __init__(self, service: Any) -> None:
+        self.service = service
+
+    # -- 字段采集 ----------------------------------------------------------
+    def _collect(self) -> dict[str, Any]:
+        service = self.service
+        data: dict[str, Any] = {}
+
+        data["version"] = get_plugin_version()
+
+        # 停止耗时：从停止流程开始（stop_started_at）到汇总大屏生成时刻。
+        stop_started = getattr(service, "stop_started_at", None)
+        elapsed: float | None = None
+        if stop_started is not None:
+            try:
+                start = (
+                    stop_started.replace(tzinfo=None)
+                    if getattr(stop_started, "tzinfo", None)
+                    else stop_started
+                )
+                now = datetime.now(timezone.utc).replace(tzinfo=None)
+                elapsed = max(0.0, (now - start).total_seconds())
+            except Exception:
+                elapsed = None
+        data["elapsed"] = elapsed
+
+        # WebSocket 连接：按连接计划（connections）统计启用数量，停止时全部回收。
+        plan = getattr(service, "connections", {}) or {}
+        data["ws_total"] = len(plan)
+        data["ws_disconnected"] = len(plan)
+
+        # 停机前气象预警聚合转发的最后一批条数与目标会话（flush_all 发送成功后记录）。
+        agg = getattr(service, "_weather_aggregation_service", None)
+        data["last_forward_count"] = getattr(agg, "last_flushed_count", None)
+        last_session = getattr(agg, "last_flushed_session", None)
+        if last_session:
+            # 复用会话配置管理器格式化会话日志字符串（私聊/群聊 ID (备注名)）。
+            session_mgr = getattr(service, "session_config_manager", None)
+            formatter = (
+                getattr(session_mgr, "get_session_log_str", None)
+                if session_mgr is not None
+                else None
+            )
+            data["last_forward_session"] = (
+                formatter(last_session) if callable(formatter) else last_session
+            )
+        else:
+            data["last_forward_session"] = None
+
+        # 停止流程中各资源的确定性回收状态。
+        data["health_stopped"] = True
+        data["notification_stopped"] = True
+        data["db_closed"] = True
+        data["browser_closed"] = True
+        data["monitor_stopped"] = True
+        data["web_stopped"] = True
+        data["cache_saved"] = True
+
+        return data
+
+    # -- 排版 ---------------------------------------------------------------
+    def build(self, width: int = 60) -> list[str]:
+        """生成停止汇总大屏文本行（不含边框颜色，纯框线）。"""
+        data = self._collect()
+
+        lines: list[str] = []
+        inner = max(10, width - 2)
+
+        def top(title: str = "") -> str:
+            if title:
+                left = title + " "
+                pad_len = inner - _display_width(left) - 1
+                return (
+                    f"{_PANEL_TOP}{_PANEL_HORIZONTAL * pad_len}"
+                    f"{_PANEL_TITLE_LEFT} {left}{_PANEL_TITLE_RIGHT}"
+                )
+            return _PANEL_TOP + _PANEL_HORIZONTAL * inner + _PANEL_TOP_RIGHT
+
+        def bottom() -> str:
+            return _PANEL_BOTTOM + _PANEL_HORIZONTAL * inner + _PANEL_BOTTOM_RIGHT
+
+        def row(text: str = "") -> str:
+            return f"{_PANEL_VERTICAL} {_pad(text, inner - 1)}{_PANEL_VERTICAL}"
+
+        def divider() -> str:
+            # 与 top()/bottom() 保持一致的 inner 个横线，避免右竖线少一格。
+            return f"{_PANEL_TITLE_RIGHT}{_PANEL_HORIZONTAL * inner}{_PANEL_TITLE_LEFT}"
+
+        lines.append(top())
+        lines.append(row(""))
+        lines.append(
+            row(
+                _pad(
+                    f"🌋 Disaster Warning Plugin · {data.get('version') or '?'} — 已停止",
+                    inner - 1,
+                )
+            )
+        )
+        lines.append(row(""))
+        lines.append(divider())
+
+        # 停止明细：以 emoji 清单形式逐项展示资源回收状态。
+        # 键列（emoji + 名称）按显示宽度统一对齐，✅ 状态列与右竖线随之对齐，
+        # 避免不同 emoji 基础字符宽度差异导致硬编码空格错位。
+        lines.append(row("停止明细"))
+
+        detail_rows: list[tuple[str, str]] = []
+
+        elapsed_text = (
+            f"{data['elapsed']:.2f} 秒" if data.get("elapsed") is not None else "N/A"
+        )
+        detail_rows.append(("⏳ 停止耗时", elapsed_text))
+
+        last_forward = data.get("last_forward_count")
+        forward_text = f"{last_forward} 条预警" if last_forward is not None else "无"
+        last_session = data.get("last_forward_session")
+        if last_session:
+            forward_text = f"{forward_text} · {last_session}"
+        detail_rows.append(("📨 最后转发", forward_text))
+
+        ws_total = data.get("ws_total", 0)
+        detail_rows.append(
+            (
+                "🔌 WebSocket 管理器",
+                f"✅ 已停止 · {data.get('ws_disconnected', 0)}/{ws_total} 已断开",
+            )
+        )
+        detail_rows.append(("🩺 连接健康采样", "✅ 已停止"))
+        detail_rows.append(("🔔 通知系统", "✅ 已停止"))
+        detail_rows.append(("💾 数据库", "✅ 已关闭"))
+        detail_rows.append(("🌍 浏览器", "✅ 已关闭"))
+        detail_rows.append(("🔍 后台延迟检测", "✅ 已停止"))
+        detail_rows.append(("🌐 Web 管理端", "✅ 已停止"))
+        detail_rows.append(("📦 缓存已保存", "✅ 已保存"))
+
+        key_width = max(_display_width(k) for k, _ in detail_rows)
+        value_width = inner - 1 - key_width - 2 - 1
+        for k, v in detail_rows:
+            # 超长值（如带会话备注名的最后转发）中段省略，避免撑破右线。
+            short_v = _ellipsize(str(v), value_width)
+            lines.append(row(f"{_pad(k, key_width)}  {_pad(short_v, value_width)}"))
+
+        lines.append(divider())
+
+        # 状态行
+        lines.append(row("状态：所有服务已安全停止，退出流程完成 ✨"))
+        lines.append(bottom())
+        return lines
+
+    def print_summary(self) -> None:
+        """打印停止汇总大屏（INFO 级）。"""
+        for line in self.build():
+            logger.info(line)
+
+
+def print_stop_summary(service: Any) -> None:
+    """便捷入口：从主服务实例打印停止汇总大屏。"""
+    StopSummaryPanel(service).print_summary()
+
+
+__all__ = [
+    "build_banner_lines",
+    "print_banner",
+    "StartupSummaryPanel",
+    "print_startup_summary",
+    "StopSummaryPanel",
+    "print_stop_summary",
+]

--- a/utils/banner.py
+++ b/utils/banner.py
@@ -595,14 +595,61 @@ class StopSummaryPanel:
         else:
             data["last_forward_session"] = None
 
-        # 停止流程中各资源的确定性回收状态。
-        data["health_stopped"] = True
-        data["notification_stopped"] = True
-        data["db_closed"] = True
-        data["browser_closed"] = True
-        data["monitor_stopped"] = True
-        data["web_stopped"] = True
-        data["cache_saved"] = True
+        # 停止流程中各资源的真实回收状态（基于运行态推导，避免无条件显示已停止）。
+        # 注意：浏览器、后台延迟检测与 Web 管理端并不在本停止流程内回收，
+        # 它们由 main.terminate() 在生命周期 stop() 之后执行，此处如实反映运行态。
+        health_service = getattr(service, "connection_health_service", None)
+        if health_service is not None:
+            data["health_stopped"] = not bool(
+                getattr(health_service, "_running", False)
+            )
+        else:
+            data["health_stopped"] = None
+
+        notification_center = getattr(service, "notification_center", None)
+        if notification_center is not None:
+            poll_task = getattr(notification_center, "_poll_task", None)
+            data["notification_stopped"] = poll_task is None or bool(
+                getattr(poll_task, "done", lambda: True)()
+            )
+        else:
+            data["notification_stopped"] = None
+
+        stats_mgr = getattr(service, "statistics_manager", None)
+        if stats_mgr is not None:
+            data["db_closed"] = not bool(getattr(stats_mgr, "_db_initialized", False))
+        else:
+            data["db_closed"] = None
+
+        message_manager = getattr(service, "message_manager", None)
+        browser = (
+            getattr(message_manager, "browser_manager", None)
+            if message_manager is not None
+            else None
+        )
+        if browser is not None:
+            data["browser_closed"] = bool(getattr(browser, "_closed", False))
+        else:
+            data["browser_closed"] = None
+
+        web_server = getattr(service, "web_admin_server", None)
+        if web_server is not None and getattr(web_server, "server", None) is not None:
+            ping_task = getattr(web_server, "_ping_task", None)
+            data["monitor_stopped"] = ping_task is None or bool(
+                getattr(ping_task, "done", lambda: True)()
+            )
+            server_task = getattr(web_server, "_server_task", None)
+            data["web_stopped"] = server_task is None or bool(
+                getattr(server_task, "done", lambda: True)()
+            )
+        else:
+            data["monitor_stopped"] = None
+            data["web_stopped"] = None
+
+        # 缓存保存：停止流程仅在服务曾真正运行（was_running）时执行落盘，
+        # 用 start_time 是否存在近似推导 was_running。
+        was_running = getattr(service, "start_time", None) is not None
+        data["cache_saved"] = was_running
 
         return data
 
@@ -673,13 +720,24 @@ class StopSummaryPanel:
                 f"✅ 已停止 · {data.get('ws_disconnected', 0)}/{ws_total} 已断开",
             )
         )
-        detail_rows.append(("🩺 连接健康采样", "✅ 已停止"))
-        detail_rows.append(("🔔 通知系统", "✅ 已停止"))
-        detail_rows.append(("💾 数据库", "✅ 已关闭"))
-        detail_rows.append(("🌍 浏览器", "✅ 已关闭"))
-        detail_rows.append(("🔍 后台延迟检测", "✅ 已停止"))
-        detail_rows.append(("🌐 Web 管理端", "✅ 已停止"))
-        detail_rows.append(("📦 缓存已保存", "✅ 已保存"))
+
+        def state_text(stopped: bool | None) -> str:
+            """把资源回收状态渲染为面板文案（None 表示未启用/无该组件）。"""
+            if stopped is None:
+                return "⚪ 未启用"
+            return "✅ 已完成" if stopped else "⚠️ 未完成"
+
+        detail_rows.append(("🩺 连接健康采样", state_text(data.get("health_stopped"))))
+        detail_rows.append(
+            ("🔔 通知系统", state_text(data.get("notification_stopped")))
+        )
+        detail_rows.append(("💾 数据库", state_text(data.get("db_closed"))))
+        detail_rows.append(("🌍 浏览器", state_text(data.get("browser_closed"))))
+        detail_rows.append(("🔍 后台延迟检测", state_text(data.get("monitor_stopped"))))
+        detail_rows.append(("🌐 Web 管理端", state_text(data.get("web_stopped"))))
+        detail_rows.append(
+            ("📦 缓存已保存", "✅ 已保存" if data.get("cache_saved") else "⚪ 未保存")
+        )
 
         key_width = max(_display_width(k) for k, _ in detail_rows)
         value_width = inner - 1 - key_width - 2 - 1

--- a/utils/plugin_logger.py
+++ b/utils/plugin_logger.py
@@ -25,10 +25,20 @@ class PluginLogger:
 
     def __init__(self) -> None:
         self._config: dict[str, Any] | None = None
+        self._silence_checker = None
 
     def set_config(self, config: dict[str, Any]) -> None:
         """注入最新的插件配置。"""
         self._config = config
+
+    def set_silence_checker(self, checker) -> None:
+        """注入启动静默判定回调（通常绑定主服务的 is_silencing）。
+
+        静默期事件流日志抑制依赖该回调动态判断当前是否仍在静默期：
+        只有“配置开启 且 当前确实处于静默期”才会丢弃日志，
+        静默结束后立即恢复事件流日志打印。
+        """
+        self._silence_checker = checker
 
     def _resolve_stream_action(self, event_stream: str | None) -> str | None:
         """解析事件流日志级别覆盖，返回 "debug" / "mute" / None。
@@ -65,14 +75,55 @@ class PluginLogger:
 
         return None
 
+    def _is_currently_silencing(self) -> bool:
+        """当前是否处于启动静默期（委托主服务 is_silencing 回调）。"""
+        checker = self._silence_checker
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker())
+        except Exception:
+            return False
+
+    def _should_suppress_for_silence(self) -> bool:
+        """静默启动期间是否丢弃事件流日志。
+
+        两个条件必须同时满足才丢弃：
+        1. 配置 debug_config.silent_startup_mute_event_logs 开启（默认 true）；
+        2. 当前确实处于启动静默期（动态查询 is_silencing）。
+
+        静默结束后第 2 条自动变为 False，事件流日志立即恢复打印，
+        不会出现“静默结束后日志永远消失”的问题。
+        """
+        if not self._config or not hasattr(self._config, "get"):
+            return False
+        debug_config = self._config.get("debug_config", {})
+        if not hasattr(debug_config, "get"):
+            debug_config = {}
+        if not bool(debug_config.get("silent_startup_mute_event_logs", True)):
+            return False
+        return self._is_currently_silencing()
+
     def _should_suppress_or_downgrade(
-        self, is_event_linked: bool, event_stream: str | None = None
+        self,
+        is_event_linked: bool,
+        event_stream: str | None = None,
+        is_silent_window: bool | None = None,
     ) -> tuple[bool, str]:
         """
         判断是否需要对当前日志进行处理。
         返回 (是否拦截/降级, 具体行为: "debug" | "mute" | "none")
         """
-        if not is_event_linked or not self._config:
+        if not self._config:
+            return False, "none"
+
+        # 静默期抑制：仅对显式标记 is_silent_window=True 的事件流日志生效，
+        # 开启配置 且 当前确实处于静默期时整体丢弃（mute），不降级为 DEBUG。
+        # 静默结束后 _should_suppress_for_silence() 返回 False，日志立即恢复。
+        if is_silent_window is True and self._should_suppress_for_silence():
+            return True, "mute"
+
+        if not is_event_linked:
             return False, "none"
 
         # 优先检查事件流级别覆盖（独立于 log_mode 总开关）
@@ -107,6 +158,7 @@ class PluginLogger:
         *args: Any,
         is_event_linked: bool = False,
         event_stream: str | None = None,
+        is_silent_window: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """记录 INFO 级别日志。
@@ -115,9 +167,11 @@ class PluginLogger:
             is_event_linked: 标记为事件流相关日志，受日志降级控制。
             event_stream: 事件流类型标签（如 "weather_alarm"、"global_quake"），
                 用于细粒度日志级别覆盖。仅在 is_event_linked=True 时生效。
+            is_silent_window: 标记当前处于启动静默期。配合配置项
+                silent_startup_mute_event_logs 使用：开启后静默期事件流日志整体丢弃。
         """
         should_process, action = self._should_suppress_or_downgrade(
-            is_event_linked, event_stream
+            is_event_linked, event_stream, is_silent_window
         )
         if should_process:
             if action == "debug":
@@ -132,15 +186,17 @@ class PluginLogger:
         *args: Any,
         is_event_linked: bool = False,
         event_stream: str | None = None,
+        is_silent_window: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """记录 WARNING 级别日志。"""
         should_process, action = self._should_suppress_or_downgrade(
-            is_event_linked, event_stream
+            is_event_linked, event_stream, is_silent_window
         )
         if should_process:
             if action == "debug":
                 logger.debug(msg, *args, **kwargs)
+            # action == "mute" 则直接屏蔽
         else:
             logger.warning(msg, *args, **kwargs)
 

--- a/utils/plugin_logger.py
+++ b/utils/plugin_logger.py
@@ -204,9 +204,32 @@ class PluginLogger:
         """记录 ERROR 级别日志。错误日志由于其关键性，不受简洁模式限制。"""
         logger.error(msg, *args, **kwargs)
 
-    def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        """记录 DEBUG 级别日志。"""
-        logger.debug(msg, *args, **kwargs)
+    def debug(
+        self,
+        msg: str,
+        *args: Any,
+        is_event_linked: bool = False,
+        event_stream: str | None = None,
+        is_silent_window: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """记录 DEBUG 级别日志。
+
+        支持事件流覆盖参数（is_event_linked / event_stream / is_silent_window）：
+        与 info/warning 共用 _should_suppress_or_downgrade 判定，使事件流日志
+        即使在 DEBUG 级别下也能被"事件流屏蔽"（完全丢弃）控制。
+        默认情况（is_event_linked=False）行为与原先一致：直接打印 debug。
+        """
+        should_process, action = self._should_suppress_or_downgrade(
+            is_event_linked, event_stream, is_silent_window
+        )
+        if should_process:
+            # action == "mute" 时整体丢弃（插件自处理屏蔽）；
+            # action == "debug" 时保持 debug 级别输出。
+            if action != "mute":
+                logger.debug(msg, *args, **kwargs)
+        else:
+            logger.debug(msg, *args, **kwargs)
 
 
 # 全局单例对象


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

在插件初始化时引入启动横幅和启动/停止总结仪表板，优化台风和 CENC 强度的去重以及停用通知，并增加可配置的静默窗口日志抑制机制，使生命周期和基础设施日志更安静、停机行为更稳健。

New Features:
- 在插件初始化时显示 Pancakes-Labs ASCII 启动横幅。
- 在静默启动完成后显示启动总结仪表板，汇总连接、轮询、历史记录和数据库状态。
- 在灾害服务停止时显示停止总结仪表板，汇总资源清理和停机耗时。
- 支持在之前处于活动状态的风暴停止上报时发送明确的台风停用通知，并可通过配置进行控制。
- 在离线通知中暴露内部数据源显示名称而不是原始标识符，以便提供更清晰的面向用户的消息。

Bug Fixes:
- 对齐台风和 CENC 强度的去重逻辑，使轮询侧的预检查与主事件管线保持一致，避免推送统计不一致和重复投递。
- 确保台风停用事件即使在核心参数未变化时也被视为变更，防止漏发停用通知。
- 改进全球地震质量指标的提取逻辑，同时支持规范化和遗留负载格式，避免遗漏质量/位置误差字段。
- 防止启动静默窗口过滤器永久抑制事件流日志，通过绑定到动态静默检查器来控制抑制范围。

Enhancements:
- 添加静默窗口标志和共享静默检查器，以在启动期间选择性静音或降级事件流日志，同时保持运行时可见性。
- 将多处生命周期和基础设施日志从 INFO 降级为 DEBUG，使常规启动/停止和初始化消息更加安静。
- 优化台风轮询逻辑，跟踪活动 ID 并为每个风暴只发送一次停用通知，同时依赖共享去重缓存进行推送决策。
- 为 CENC 强度报告和其他事件添加只读优先级指纹检查，以便轮询路径可以进行过滤而不污染去重缓存。
- 记录最近一次成功的天气聚合刷写计数和目标会话，并在停止总结仪表板中展示。
- 改进 WebSocket、浏览器、通知、连接健康检查、数据库以及 Web 管理服务器的关闭流程，通过更优雅的超时与回退处理提升停机质量。
- 规范聚合和推送流程中的会话日志字符串，确保日志统一使用相同的人类可读会话标识。

Build:
- 添加用于 ASCII 艺术和总结面板渲染的横幅工具模块，不更改外部依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce startup banner and startup/stop summary dashboards, refine typhoon and CENC intensity de-duplication and deactivation notifications, and add configurable silent-window logging suppression while making lifecycle and infrastructure logging quieter and shutdown behavior more robust.

New Features:
- Display a Pancakes-Labs ASCII startup banner on plugin initialization.
- Show a startup summary dashboard when silent startup completes, aggregating connection, polling, history, and database status.
- Show a stop summary dashboard when the disaster service stops, summarizing resource cleanup and shutdown timing.
- Support explicit typhoon deactivation notifications when a previously active storm stops being reported, controlled by configuration.
- Expose internal data-source display names in offline notifications instead of raw identifiers for clearer user-facing messages.

Bug Fixes:
- Align typhoon and CENC intensity de-duplication so polling-side prechecks match the main event pipeline, avoiding inconsistent push statistics and duplicate deliveries.
- Ensure typhoon deactivation events are treated as changes even when core parameters are unchanged, preventing missed stop notifications.
- Improve global quake quality metric extraction to handle both normalized and legacy payload formats, avoiding missing quality/position error fields.
- Prevent startup silent-window filters from permanently suppressing event-stream logs by tying suppression to a dynamic silence checker.

Enhancements:
- Add silent-window flags and a shared silence checker to selectively mute or downgrade event-stream logs during startup while preserving runtime visibility.
- Quiet multiple lifecycle and infrastructure logs by switching from INFO to DEBUG for routine start/stop and initialization messages.
- Refine typhoon polling to track active IDs and emit a single deactivation notification per storm while relying on the shared deduplication cache for push decisions.
- Add read-only priority fingerprint checks for CENC intensity reports and other events so polling paths can filter without polluting dedup caches.
- Track the last successful weather aggregation flush count and target session for inclusion in the stop summary dashboard.
- Improve WebSocket, browser, notification, connection health, database, and web admin server shutdown flows with more graceful timeouts and fallback handling.
- Standardize session log strings in aggregation and push flows so logging consistently uses the same human-readable session identifiers.

Build:
- Add the banner utility module for ASCII art and summary panel rendering without changing external dependencies.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增台风停编通知开关，默认启用，支持首次停编时推送通知。
  * 启动期间支持静默事件日志，并新增启动与停止状态汇总面板。
  * 新增静默启动日志控制选项，支持丢弃事件流日志。

* **改进**
  * 优化服务优雅关闭、跨来源去重及停编台风重试处理。
  * 离线通知显示更易读的数据源名称。
  * 增强地震质量指标识别，兼容更多数据格式。

* **日志**
  * 降低启动、停止及后台运行日志噪声，静默期间减少无关输出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->