### PR TITLE
refactor(core): 收编数据源展示名映射为唯一事实源，消除跨模块口径漂移

### DIFF
--- a/admin/js/components/status/ConnectionsGrid.jsx
+++ b/admin/js/components/status/ConnectionsGrid.jsx
@@ -323,7 +323,9 @@ function ConnectionsGrid() {
     };
 
     /**
-     * 内部子数据源 ID => 中文可读机构对照字典
+     * 内部子数据源 ID => 中文可读机构对照字典（子源列表场景投影）。
+     * 注意：这是连接面板子源明细的专用展示口径，与后端命令文本存在既有差异，属有意设计，
+     * 修改展示名时请同时核对 display_registry.py 与 plugin_admin_command_service.py 的投影表。
      */
     const getScopedSourceName = (sourceKey, connectionName) => {
         const rawKey = String(sourceKey || '').trim();

--- a/admin/js/utils/formatters.js
+++ b/admin/js/utils/formatters.js
@@ -1,6 +1,65 @@
 const JST_SOURCE_KEYWORDS = ['jma', 'p2p', 'wolfx_jma', 'japan'];
 
 /**
+ * 数据源展示元数据（唯一事实源）缓存。
+ * 由后端 /api/sources/meta 动态拉取，数据源别名与展示名的完整映射
+ * 只维护在后端 core/sources/display_registry.py（SOURCE_ALIAS_MAP /
+ * SOURCE_DISPLAY_MAP），前端不再复制完整映射表，新增/改名数据源时只需改后端一处。
+ *
+ * 前端仅保留极小的 SOURCE_DISPLAY_OVERRIDES 场景投影覆盖表：
+ * 子源列表口径有意剥掉通道后缀、以及后端未注册的前端专属文案，
+ * 属于既有展示设计，勿与后端强行对齐。
+ */
+let __SOURCE_DISPLAY_META__ = null;
+let __SOURCE_DISPLAY_META_LOADING__ = false;
+
+/**
+ * 从后端拉取数据源展示元数据（幂等）。
+ * 失败时静默置空；展示名/别名会回退为原始输入，不影响功能。
+ * 首次调用后缓存结果；并发调用会被 loading 标志去重。
+ * @returns {Promise<object>}
+ */
+function loadSourceDisplayMeta() {
+    if (__SOURCE_DISPLAY_META__ !== null || __SOURCE_DISPLAY_META_LOADING__) {
+        return Promise.resolve(__SOURCE_DISPLAY_META__);
+    }
+    __SOURCE_DISPLAY_META_LOADING__ = true;
+    return fetch('/api/sources/meta', { headers: { 'Accept': 'application/json' } })
+        .then((resp) => (resp && resp.ok) ? resp.json() : {})
+        .then((data) => {
+            __SOURCE_DISPLAY_META__ = (data && typeof data === 'object') ? data : {};
+            return __SOURCE_DISPLAY_META__;
+        })
+        .catch(() => {
+            __SOURCE_DISPLAY_META__ = {};
+            return __SOURCE_DISPLAY_META__;
+        })
+        .finally(() => {
+            __SOURCE_DISPLAY_META_LOADING__ = false;
+        });
+}
+
+/**
+ * 确保展示元数据已触发加载（懒加载兜底）。
+ * 页面加载时的预加载通常已就绪；若因网络抖动未完成，组件渲染时
+ * 调用 formatSourceName / normalizeSourceName 会再次触发加载，
+ * 避免整个会话都回退显示原始 key。
+ */
+function ensureSourceDisplayMetaLoaded() {
+    if (__SOURCE_DISPLAY_META__ === null && !__SOURCE_DISPLAY_META_LOADING__) {
+        loadSourceDisplayMeta();
+    }
+}
+
+// 页面加载时预热一次：管理端与后端同源部署，meta 为本地小体积接口，
+// 通常在首帧数据（status/events）返回前完成，供 formatSourceName /
+// normalizeSourceName 使用。
+if (typeof window !== 'undefined' && typeof fetch === 'function') {
+    window.__loadSourceDisplayMeta = loadSourceDisplayMeta;
+    loadSourceDisplayMeta();
+}
+
+/**
  * 判断数据源是否属于 UTC+9 (JST) 体系
  * @param {string} source - 数据源标识
  * @returns {boolean}
@@ -193,104 +252,22 @@ function getWeatherColorClass(description) {
 
 /**
  * 统一规范化后端重构后的数据源标识
- * - 新命名(source/source_id) 作为主体系
- * - 旧命名仅作为输入别名折叠到同一规范名
+ * 唯一事实源：后端 /api/sources/meta 的 source_alias_map
+ * （对应 core/sources/display_registry.py 的 SOURCE_ALIAS_MAP）。
+ * meta 未就绪或拉取失败时回退为小写标准形态，与历史行为一致。
  * @param {string} source
  * @returns {string}
  */
 function normalizeSourceName(source) {
+    ensureSourceDisplayMetaLoaded();
     if (!source) return 'unknown';
 
     const rawSource = String(source).trim();
     if (!rawSource) return 'unknown';
 
     const lowerSource = rawSource.toLowerCase();
-    const aliasMap = {
-        // 旧前端 key -> 新规范 key
-        'fan_studio_cenc': 'cenc_fanstudio',
-        'fan_studio_cenc_ir': 'cenc_ir_fanstudio',
-        'fan_studio_cea': 'cea_fanstudio',
-        'fan_studio_cea_pr': 'cea_pr_fanstudio',
-        'fan_studio_cwa': 'cwa_fanstudio',
-        'fan_studio_cwa_report': 'cwa_fanstudio_report',
-        'fan_studio_usgs': 'usgs_fanstudio',
-        'fan_studio_sa': 'sa_fanstudio',
-        'fan_studio_fssn_cmt': 'fssn_cmt_fanstudio',
-        'fan_studio_jma': 'jma_fanstudio',
-        'fan_studio_weather': 'china_weather_fanstudio',
-        'fan_studio_tsunami': 'china_tsunami_fanstudio',
-        'p2p_eew': 'jma_p2p',
-        'p2p_earthquake': 'jma_p2p_info',
-        'p2p_tsunami': 'jma_tsunami_p2p',
-        'eqsc_tsunami': 'jma_tsunami_eqsc',
-        'wolfx_jma_eew': 'jma_wolfx',
-        'wolfx_cenc_eew': 'cea_wolfx',
-        'wolfx_cwa_eew': 'cwa_wolfx',
-        'wolfx_cenc_eq': 'cenc_wolfx',
-        'wolfx_jma_eq': 'jma_wolfx_info',
-
-        // 配置项 / 子数据源 key -> 新规范展示 key
-        'china_earthquake_warning': 'cea_fanstudio',
-        'china_earthquake_warning_provincial': 'cea_pr_fanstudio',
-        'taiwan_cwa_earthquake': 'cwa_fanstudio',
-        'taiwan_cwa_report': 'cwa_fanstudio_report',
-        'china_cenc_earthquake': 'cenc_fanstudio',
-        'china_cenc_intensity_report': 'cenc_ir_fanstudio',
-        'cenc-ir': 'cenc_ir_fanstudio',
-        'cenc_ir': 'cenc_ir_fanstudio',
-        'usgs_earthquake': 'usgs_fanstudio',
-        'usa_shakealert': 'sa_fanstudio',
-        'sa': 'sa_fanstudio',
-        'shakealert': 'sa_fanstudio',
-        'fssn_cmt': 'fssn_cmt_fanstudio',
-        'fssn-cmt': 'fssn_cmt_fanstudio',
-        'china_weather_alarm': 'china_weather_fanstudio',
-        'openquake_cma': 'china_weather_openquake',
-        'cma_weather': 'china_weather_openquake',
-        'cma': 'china_weather_openquake',
-        'china_tsunami': 'china_tsunami_fanstudio',
-        'japan_jma_eew': 'jma_p2p',
-        'japan_jma_earthquake': 'jma_p2p_info',
-        'japan_jma_tsunami': 'jma_tsunami_p2p',
-        'china_cenc_eew': 'cea_wolfx',
-        'taiwan_cwa_eew': 'cwa_wolfx',
-
-        // 中文标签 -> 新规范 key
-        '中国气象局：气象预警': 'china_weather_fanstudio',
-        '中国气象局: 气象预警': 'china_weather_fanstudio',
-        '台湾中央气象署：强震即时警报': 'cwa_fanstudio',
-        '台湾中央气象署: 强震即时警报': 'cwa_fanstudio',
-        '台湾中央气象署：地震报告': 'cwa_fanstudio_report',
-        '台湾中央气象署: 地震报告': 'cwa_fanstudio_report',
-        '中国地震台网（cenc）': 'cenc_fanstudio',
-        '中国地震台网(cenc)': 'cenc_fanstudio',
-        '中国地震台网（cenc）：地震测定': 'cenc_fanstudio',
-        '中国地震台网(cenc)：地震测定': 'cenc_fanstudio',
-        '中国地震台网（cenc）：烈度速报': 'cenc_ir_fanstudio',
-        '中国地震台网(cenc)：烈度速报': 'cenc_ir_fanstudio',
-        '中国地震台网烈度速报': 'cenc_ir_fanstudio',
-        '中国地震预警网（cea）': 'cea_fanstudio',
-        '中国地震预警网(cea)': 'cea_fanstudio',
-        '中国地震预警网（省级）': 'cea_pr_fanstudio',
-        '中国地震预警网(省级)': 'cea_pr_fanstudio',
-        '日本气象厅：紧急地震速报': 'jma_fanstudio',
-        '日本气象厅: 紧急地震速报': 'jma_fanstudio',
-        '日本气象厅：地震情报': 'jma_p2p_info',
-        '日本气象厅: 地震情报': 'jma_p2p_info',
-        // 中文冒号全角/半角 + 预报/予报 历史写法都兼容
-        '日本气象厅：海啸预报': 'jma_tsunami_p2p',
-        '日本气象厅: 海啸预报': 'jma_tsunami_p2p',
-        '日本气象厅：海啸予报': 'jma_tsunami_p2p',
-        '日本气象厅: 海啸予报': 'jma_tsunami_p2p',
-        '日本气象厅：海啸予报 - P2P': 'jma_tsunami_p2p',
-        '日本气象厅: 海啸予报 - P2P': 'jma_tsunami_p2p',
-        '日本气象厅：海啸予报 - EQSC': 'jma_tsunami_eqsc',
-        '日本气象厅: 海啸予报 - EQSC': 'jma_tsunami_eqsc',
-        '日本气象厅：海啸预报 - EQSC': 'jma_tsunami_eqsc',
-        '日本气象厅: 海啸预报 - EQSC': 'jma_tsunami_eqsc',
-    };
-
-    return aliasMap[rawSource] || aliasMap[lowerSource] || lowerSource;
+    const metaAliasMap = (__SOURCE_DISPLAY_META__ && __SOURCE_DISPLAY_META__.source_alias_map) || {};
+    return metaAliasMap[rawSource] || metaAliasMap[lowerSource] || lowerSource;
 }
 
 /**
@@ -348,58 +325,33 @@ function formatSessionDisplayLabel(sessionOrUmo) {
 }
 
 /**
+ * 数据源展示名场景投影覆盖表（唯一真源之外的少量有意差异）。
+ * 前端仅在此覆盖个别场景展示口径：
+ * - cenc_ir_fanstudio：子源列表展示口径有意剥掉通道后缀 "- Fan"，
+ *   与后端完整通道名存在既有差异，勿强行对齐；
+ * - snet_msil：后端 SOURCE_DISPLAY_MAP 未注册该键，保留前端既有文案，
+ *   避免回退显示原始内部 key。
+ * 其余 key 全部由 meta 提供，新增/改名数据源只需改后端一处。
+ */
+const SOURCE_DISPLAY_OVERRIDES = {
+    'cenc_ir_fanstudio': '中国地震台网 (CENC) - 烈度速报',
+    'snet_msil': '日本海沟 S-Net 海底震度计',
+};
+
+/**
  * 将数据源代码转换为用户友好的显示名称
+ * 唯一事实源：后端 /api/sources/meta 的 source_display_map；
+ * 场景投影覆盖见 SOURCE_DISPLAY_OVERRIDES。
  * @param {string} source - 数据源代码
  * @returns {string} 友好的中文名称
  */
 function formatSourceName(source) {
+    ensureSourceDisplayMetaLoaded();
     const normalizedSource = normalizeSourceName(source);
-    const sourceMap = {
-        // Fan Studio (新规范)
-        'cenc_fanstudio': '中国地震台网 (CENC) - Fan',
-        'cenc_ir_fanstudio': '中国地震台网 (CENC) - 烈度速报',
-        'cea_fanstudio': '中国地震预警网 (CEA)',
-        'cea_pr_fanstudio': '中国地震预警网 (省级)',
-        'cwa_fanstudio': '台湾中央气象署: 强震即时警报 - Fan',
-        'cwa_fanstudio_report': '台湾中央气象署: 地震报告',
-        'usgs_fanstudio': '美国地质调查局 (USGS)',
-        'sa_fanstudio': '美国 ShakeAlert 地震预警',
-        'fssn_cmt_fanstudio': 'FSSN 矩心矩张量解 (CMT)',
-        'jma_fanstudio': '日本气象厅: 紧急地震速报 - Fan',
-        'china_weather_fanstudio': '中国气象局: 气象预警 - Fan',
-        'china_weather_openquake': '中国气象局: 气象预警 - OQ',
-        'china_tsunami_fanstudio': '自然资源部海啸预警中心',
-        // 贡献榜中性名：实时通道（fan + enriched）不强制带 - Fan
-        'typhoon_fanstudio': '中国气象局：实时活跃台风',
-        // EQSC 历史重建在贡献统计中单独成源
-        'typhoon_eqsc_rebuild': '中国气象局：台风历史 - EQSC',
-
-        // P2P (新规范)
-        'jma_p2p': '日本气象厅: 紧急地震速报 - P2P',
-        'jma_p2p_info': '日本气象厅: 地震情报 - P2P',
-        'jma_tsunami_p2p': '日本气象厅: 海啸予报 - P2P',
-
-        // EQSC (HTTP 海啸补充源)
-        'jma_tsunami_eqsc': '日本气象厅: 海啸予报 - EQSC',
-
-        // Wolfx (新规范)
-        'jma_wolfx': '日本气象厅: 紧急地震速报 - Wolfx',
-        'cea_wolfx': '中国地震预警网 (CEA) - Wolfx',
-        'cwa_wolfx': '台湾中央气象署: 强震即时警报 - Wolfx',
-        'cenc_wolfx': '中国地震台网地震测定 - Wolfx',
-        'jma_wolfx_info': '日本气象厅地震情报 - Wolfx',
-
-        // 其他
-        'global_quake': 'Global Quake',
-        'snet_msil': '日本海沟 S-Net 海底震度计',
-        'sc_eew': '四川地震局',
-        'fj_eew': '福建地震局',
-        'kma_earthquake': '韩国气象厅 (KMA)',
-        'emsc_earthquake': '欧洲地中海地震中心 (EMSC)',
-        'gfz_earthquake': '德国地学研究中心 (GFZ)',
-        'unknown': '未知来源'
-    };
-    return sourceMap[normalizedSource] || String(source || '').trim() || '未知来源';
+    const metaDisplayMap = (__SOURCE_DISPLAY_META__ && __SOURCE_DISPLAY_META__.source_display_map) || {};
+    return SOURCE_DISPLAY_OVERRIDES[normalizedSource]
+        || metaDisplayMap[normalizedSource]
+        || String(source || '').trim() || '未知来源';
 }
 
 /**

--- a/admin/js/utils/formatters.js
+++ b/admin/js/utils/formatters.js
@@ -11,32 +11,48 @@ const JST_SOURCE_KEYWORDS = ['jma', 'p2p', 'wolfx_jma', 'japan'];
  * 属于既有展示设计，勿与后端强行对齐。
  */
 let __SOURCE_DISPLAY_META__ = null;
-let __SOURCE_DISPLAY_META_LOADING__ = false;
+let __SOURCE_DISPLAY_META_PROMISE__ = null;
+let __SOURCE_DISPLAY_META_LAST_ATTEMPT__ = 0;
+// 拉取失败后的最小重试间隔，避免网络抖动时对后端接口密集请求。
+const SOURCE_DISPLAY_META_RETRY_MS = 30 * 1000;
 
 /**
- * 从后端拉取数据源展示元数据（幂等）。
- * 失败时静默置空；展示名/别名会回退为原始输入，不影响功能。
- * 首次调用后缓存结果；并发调用会被 loading 标志去重。
+ * 从后端拉取数据源展示元数据（幂等，并发去重）。
+ * 成功结果会缓存；失败时保持缓存为空并节流重试，展示名/别名会回退为原始输入，
+ * 待下次触发（如组件渲染或手动调用）再尝试拉取，不影响功能。
+ * 进行中的请求会被所有并发调用方共享同一个 Promise，只发出一次 fetch。
  * @returns {Promise<object>}
  */
 function loadSourceDisplayMeta() {
-    if (__SOURCE_DISPLAY_META__ !== null || __SOURCE_DISPLAY_META_LOADING__) {
+    // 已有缓存：直接返回。
+    if (__SOURCE_DISPLAY_META__ !== null) {
         return Promise.resolve(__SOURCE_DISPLAY_META__);
     }
-    __SOURCE_DISPLAY_META_LOADING__ = true;
-    return fetch('/api/sources/meta', { headers: { 'Accept': 'application/json' } })
+    // 已有进行中的请求：所有并发调用方共享同一个 in-flight Promise。
+    if (__SOURCE_DISPLAY_META_PROMISE__) {
+        return __SOURCE_DISPLAY_META_PROMISE__;
+    }
+    // 失败后的重试节流：距上次尝试不足间隔则不再发起请求。
+    if (Date.now() - __SOURCE_DISPLAY_META_LAST_ATTEMPT__ < SOURCE_DISPLAY_META_RETRY_MS) {
+        return Promise.resolve(__SOURCE_DISPLAY_META__);
+    }
+    __SOURCE_DISPLAY_META_LAST_ATTEMPT__ = Date.now();
+    __SOURCE_DISPLAY_META_PROMISE__ = fetch('/api/sources/meta', { headers: { 'Accept': 'application/json' } })
         .then((resp) => (resp && resp.ok) ? resp.json() : {})
         .then((data) => {
             __SOURCE_DISPLAY_META__ = (data && typeof data === 'object') ? data : {};
             return __SOURCE_DISPLAY_META__;
         })
         .catch(() => {
-            __SOURCE_DISPLAY_META__ = {};
+            // 失败不写入缓存（保持 null）：ensureSourceDisplayMetaLoaded
+            // 会在节流间隔后再次触发加载，避免整个会话回退显示原始 key。
+            __SOURCE_DISPLAY_META__ = null;
             return __SOURCE_DISPLAY_META__;
         })
         .finally(() => {
-            __SOURCE_DISPLAY_META_LOADING__ = false;
+            __SOURCE_DISPLAY_META_PROMISE__ = null;
         });
+    return __SOURCE_DISPLAY_META_PROMISE__;
 }
 
 /**
@@ -46,9 +62,20 @@ function loadSourceDisplayMeta() {
  * 避免整个会话都回退显示原始 key。
  */
 function ensureSourceDisplayMetaLoaded() {
-    if (__SOURCE_DISPLAY_META__ === null && !__SOURCE_DISPLAY_META_LOADING__) {
+    if (__SOURCE_DISPLAY_META__ === null && !__SOURCE_DISPLAY_META_PROMISE__) {
         loadSourceDisplayMeta();
     }
+}
+
+/**
+ * 仅读取对象自身的属性值，避免命中 Object.prototype 上继承的键
+ * （如 toString / constructor / __proto__），并消除裸下标读取的静态分析告警。
+ * @param {object} obj
+ * @param {string} key
+ * @returns {*}
+ */
+function pickOwn(obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
 }
 
 // 页面加载时预热一次：管理端与后端同源部署，meta 为本地小体积接口，
@@ -267,7 +294,7 @@ function normalizeSourceName(source) {
 
     const lowerSource = rawSource.toLowerCase();
     const metaAliasMap = (__SOURCE_DISPLAY_META__ && __SOURCE_DISPLAY_META__.source_alias_map) || {};
-    return metaAliasMap[rawSource] || metaAliasMap[lowerSource] || lowerSource;
+    return pickOwn(metaAliasMap, rawSource) || pickOwn(metaAliasMap, lowerSource) || lowerSource;
 }
 
 /**
@@ -349,8 +376,8 @@ function formatSourceName(source) {
     ensureSourceDisplayMetaLoaded();
     const normalizedSource = normalizeSourceName(source);
     const metaDisplayMap = (__SOURCE_DISPLAY_META__ && __SOURCE_DISPLAY_META__.source_display_map) || {};
-    return SOURCE_DISPLAY_OVERRIDES[normalizedSource]
-        || metaDisplayMap[normalizedSource]
+    return pickOwn(SOURCE_DISPLAY_OVERRIDES, normalizedSource)
+        || pickOwn(metaDisplayMap, normalizedSource)
         || String(source || '').trim() || '未知来源';
 }
 

--- a/core/app/runtime/disaster_service_notice.py
+++ b/core/app/runtime/disaster_service_notice.py
@@ -30,6 +30,8 @@ class DisasterServiceNoticeService:
     # （用户只需知道哪个通道离线，无需细分到子源），保留在此处。
     _SOURCE_GROUP_KEY_MAP: dict[str, str] = {
         "fan_studio_mixed": "fan_studio_all",
+        # cenc_ir_fanstudio 走独立连接（/cenc-ir），离线时折叠到烈度速报子通道展示名
+        "cenc_ir_fanstudio": "fan_studio_cenc_ir",
         "wolfx_mixed": "wolfx_all",
         "openquake_mixed": "openquake_api",
         "jma_p2p": "p2p_main",
@@ -42,10 +44,18 @@ class DisasterServiceNoticeService:
     }
 
     def _resolve_source_display(self, data_source: str) -> str:
-        """按离线通知场景把内部数据源代号解析为用户可读的通道展示名。"""
+        """按离线通知场景把内部数据源代号解析为用户可读的通道展示名。
+
+        折叠规则命中时返回通道级展示名；未命中则防御性地尝试直接按
+        data_source 查一次连接组展示名（覆盖未来新增的“连接级别” key），
+        最后才回退原始代号。
+        """
         group_key = self._SOURCE_GROUP_KEY_MAP.get(data_source)
-        if group_key:
+        if group_key is not None:
             return CONNECTION_DISPLAY_NAMES.get(group_key, group_key)
+        direct_display = CONNECTION_DISPLAY_NAMES.get(data_source)
+        if direct_display is not None:
+            return direct_display
         return data_source
 
     def __init__(self, service):

--- a/core/app/runtime/disaster_service_notice.py
+++ b/core/app/runtime/disaster_service_notice.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ...services.config.config_service import ConfigAccessor
 from ...services.config.config_validation_service import ConfigValidator
+from ...sources.display_registry import CONNECTION_DISPLAY_NAMES
 
 
 class DisasterServiceNoticeService:
@@ -23,21 +24,29 @@ class DisasterServiceNoticeService:
         "stop": "停止重连",
     }
 
-    # 连接内部数据源代号 -> 用户可读的展示名称。
-    # 与 SourceRuntimeQueryService._CONNECTION_DISPLAY_NAME 的展示口径保持一致，
-    # 避免把 openquake_mixed 这类内部代号直接暴露给用户。
-    _SOURCE_DISPLAY_MAP: dict[str, str] = {
-        "fan_studio_mixed": "FAN Studio",
-        "wolfx_mixed": "Wolfx",
-        "openquake_mixed": "OpenQuakeAPI",
-        "jma_p2p": "P2P地震情報",
-        "jma_p2p_info": "P2P地震情報",
-        "jma_tsunami_p2p": "P2P地震情報",
-        "jma_tsunami_eqsc": "EQSC API",
-        "cenc_ir_eqsc": "EQSC API",
-        "typhoon_eqsc": "EQSC API",
-        "snet_msil": "NIED S-Net",
+    # 离线通知场景投影：内部数据源代号折叠到"物理通道"粒度。
+    # 展示名统一从 display_registry.CONNECTION_DISPLAY_NAMES 派生，
+    # 避免通道展示名在各模块重复维护；折叠规则本身属于通知场景的有意设计
+    # （用户只需知道哪个通道离线，无需细分到子源），保留在此处。
+    _SOURCE_GROUP_KEY_MAP: dict[str, str] = {
+        "fan_studio_mixed": "fan_studio_all",
+        "wolfx_mixed": "wolfx_all",
+        "openquake_mixed": "openquake_api",
+        "jma_p2p": "p2p_main",
+        "jma_p2p_info": "p2p_main",
+        "jma_tsunami_p2p": "p2p_main",
+        "jma_tsunami_eqsc": "eqsc",
+        "cenc_ir_eqsc": "eqsc",
+        "typhoon_eqsc": "eqsc",
+        "snet_msil": "snet_msil",
     }
+
+    def _resolve_source_display(self, data_source: str) -> str:
+        """按离线通知场景把内部数据源代号解析为用户可读的通道展示名。"""
+        group_key = self._SOURCE_GROUP_KEY_MAP.get(data_source)
+        if group_key:
+            return CONNECTION_DISPLAY_NAMES.get(group_key, group_key)
+        return data_source
 
     def __init__(self, service):
         # 与生命周期服务类似，这里只保留主服务引用，便于共享配置、状态与消息发送能力。
@@ -137,7 +146,7 @@ class DisasterServiceNoticeService:
         # 阶段文案、重试次数和下一次重试时间会一起展示，
         # 目的是让使用者能在一条通知里快速判断当前处于“短时抖动”还是“长期离线”。
         # 数据源代号先映射为展示名，避免把内部标识暴露给用户。
-        source_display = self._SOURCE_DISPLAY_MAP.get(data_source, data_source)
+        source_display = self._resolve_source_display(data_source)
         stage_text = self._OFFLINE_STAGE_MAP.get(stage, stage)
         retry_part = (
             f"短时重试: {retry_count}" if retry_count is not None else "短时重试: 未知"

--- a/core/network/admin/api/utility_routes.py
+++ b/core/network/admin/api/utility_routes.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 from astrbot.api import logger
 
+from ....sources.display_registry import (
+    CONNECTION_DISPLAY_NAMES,
+    SOURCE_ALIAS_MAP,
+    SOURCE_DISPLAY_MAP,
+)
 from ..host.runtime_environment import is_running_in_docker
 from ..payloads.api_response import ApiResponse
 
@@ -176,6 +181,21 @@ def register_utility_routes(app, disaster_service, plugin_root: str):
             return candidate
         except ValueError:
             return None
+
+    @app.get("/api/sources/meta")
+    async def get_sources_meta():
+        """返回数据源展示元数据（事实层）。
+
+        供管理端前端动态拉取，用于补充本地映射表缺失的 key，
+        避免新增数据源后前端漏配展示名。只读接口，无副作用。
+        """
+        return ApiResponse.success(
+            {
+                "source_alias_map": SOURCE_ALIAS_MAP,
+                "source_display_map": SOURCE_DISPLAY_MAP,
+                "connection_display_names": CONNECTION_DISPLAY_NAMES,
+            }
+        )
 
     @app.get("/api/markdown-files")
     async def list_markdown_files():

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -12,13 +12,16 @@ from urllib.parse import urlparse
 
 from ....app.services.eqsc_channel_service import EqscChannelService
 from ....services.query.source_runtime_query_service import SourceRuntimeQueryService
+from ....sources.display_registry import CONNECTION_DISPLAY_NAMES
 
 
 class ConnectionsPayloadBuilder:
     """连接状态载荷构建器。"""
 
-    EQSC_DISPLAY_NAME = "EQSC API"
-    SNET_DISPLAY_NAME = "NIED S-Net"
+    # EQSC / S-Net 展示名统一从 display_registry 连接组展示名表派生，
+    # 避免与管理端 / 健康监控模块各自维护导致口径漂移。
+    EQSC_DISPLAY_NAME = CONNECTION_DISPLAY_NAMES["eqsc"]
+    SNET_DISPLAY_NAME = CONNECTION_DISPLAY_NAMES["snet_msil"]
     SNET_GROUP_KEY = "snet_msil"
 
     def __init__(

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -23,42 +23,17 @@ from ....utils.time_converter import TimeConverter
 from ...network.admin.payloads.connections_payload_builder import (
     ConnectionsPayloadBuilder,
 )
+from ...sources.display_registry import (
+    CONNECTION_DISPLAY_NAMES,
+    CONNECTION_GROUP_ORDER,
+    DISPLAY_NAME_ALIASES,
+)
 from ...storage.connection_health_repository import ConnectionHealthRepository
 from ..query.source_runtime_query_service import SourceRuntimeQueryService
 
-# 连接组展示顺序（与 ConnectionsGrid 列语义对齐）
-COMPONENT_ORDER: tuple[str, ...] = (
-    "fan_studio_all",
-    "fan_studio_cenc_ir",
-    "p2p_main",
-    "wolfx_all",
-    "openquake_api",
-    "snet_msil",
-    "eqsc",
-)
-
-COMPONENT_DISPLAY_NAMES: dict[str, str] = {
-    "fan_studio_all": "FAN Studio",
-    "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
-    "p2p_main": "P2P地震情報",
-    "wolfx_all": "Wolfx",
-    "openquake_api": "OpenQuakeAPI",
-    "snet_msil": "NIED S-Net",
-    "eqsc": "EQSC API",
-}
-
-# ConnectionsPayloadBuilder / SourceRuntimeQuery 可能使用的展示名别名
-DISPLAY_NAME_ALIASES: dict[str, str] = {
-    "FAN Studio": "fan_studio_all",
-    "FAN Studio 烈度速报": "fan_studio_cenc_ir",
-    "FAN Studio（烈度速报）": "fan_studio_cenc_ir",
-    "Fan Studio（烈度速报）": "fan_studio_cenc_ir",
-    "P2P地震情報": "p2p_main",
-    "Wolfx": "wolfx_all",
-    "OpenQuakeAPI": "openquake_api",
-    "NIED S-Net": "snet_msil",
-    "EQSC API": "eqsc",
-}
+# 连接组展示顺序 / 展示名 / 展示名反向别名已统一收编至
+# core/sources/display_registry.py（CONNECTION_GROUP_ORDER /
+# CONNECTION_DISPLAY_NAMES / DISPLAY_NAME_ALIASES），此处直接引用事实层常量。
 
 STATE_LABELS_ZH: dict[str, str] = {
     "operational": "正常",
@@ -189,7 +164,7 @@ class ConnectionHealthService:
         repo = self._ensure_repo()
         if repo is None:
             return
-        for group_key in COMPONENT_ORDER:
+        for group_key in CONNECTION_GROUP_ORDER:
             open_inc = await repo.get_open_incident(group_key)
             if open_inc is None:
                 continue
@@ -342,8 +317,8 @@ class ConnectionHealthService:
 
         # 第一遍：只收集 enabled/connected，用于提前结束建连宽限
         prelim: list[dict[str, Any]] = []
-        for group_key in COMPONENT_ORDER:
-            display_name = COMPONENT_DISPLAY_NAMES.get(group_key, group_key)
+        for group_key in CONNECTION_GROUP_ORDER:
+            display_name = CONNECTION_DISPLAY_NAMES.get(group_key, group_key)
             info = by_group.get(group_key) or by_display.get(display_name) or {}
             raw = raw_ws.get(group_key) or {}
 
@@ -656,7 +631,7 @@ class ConnectionHealthService:
         group_key = comp["group_key"]
         state = comp["state"]
         enabled = bool(comp["enabled"])
-        display_name = comp.get("display_name") or COMPONENT_DISPLAY_NAMES.get(
+        display_name = comp.get("display_name") or CONNECTION_DISPLAY_NAMES.get(
             group_key, group_key
         )
 
@@ -860,7 +835,7 @@ class ConnectionHealthService:
                 {
                     "group_key": group_key,
                     "name": comp.get("display_name")
-                    or COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                    or CONNECTION_DISPLAY_NAMES.get(group_key, group_key),
                     "current_state": state,
                     "current_label": comp.get("status_label")
                     or STATE_LABELS_ZH.get(state, state),
@@ -931,7 +906,7 @@ class ConnectionHealthService:
                 try:
                     day_rows = await repo.list_day_aggregates(
                         days=days,
-                        group_keys=list(COMPONENT_ORDER),
+                        group_keys=list(CONNECTION_GROUP_ORDER),
                         since_day=start_day,
                     )
                 except Exception as exc:
@@ -978,10 +953,10 @@ class ConnectionHealthService:
         components_out: list[dict[str, Any]] = []
         monitored_states: list[str] = []
 
-        for group_key in COMPONENT_ORDER:
+        for group_key in CONNECTION_GROUP_ORDER:
             live = live_by_key.get(group_key) or {
                 "group_key": group_key,
-                "display_name": COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                "display_name": CONNECTION_DISPLAY_NAMES.get(group_key, group_key),
                 "enabled": False,
                 "connected": False,
                 "state": "not_monitored",
@@ -1022,7 +997,7 @@ class ConnectionHealthService:
                 {
                     "group_key": group_key,
                     "name": live.get("display_name")
-                    or COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+                    or CONNECTION_DISPLAY_NAMES.get(group_key, group_key),
                     "current_state": current_state,
                     "current_label": live.get("status_label")
                     or STATE_LABELS_ZH.get(current_state, current_state),
@@ -1163,7 +1138,7 @@ class ConnectionHealthService:
         return {
             "id": inc.get("id"),
             "group_key": group_key,
-            "component_name": COMPONENT_DISPLAY_NAMES.get(group_key, group_key),
+            "component_name": CONNECTION_DISPLAY_NAMES.get(group_key, group_key),
             "severity": inc.get("severity"),
             "severity_label": STATE_LABELS_ZH.get(
                 str(inc.get("severity") or ""), str(inc.get("severity") or "")

--- a/core/services/query/source_runtime_query_service.py
+++ b/core/services/query/source_runtime_query_service.py
@@ -8,31 +8,16 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
+from ...sources.display_registry import CONNECTION_DISPLAY_NAMES, CONNECTION_GROUP_ALIAS
 from ...sources.source_catalog import SOURCE_CATALOG
-from ...sources.source_entry import ProviderFamily, SourceEntry
+from ...sources.source_entry import SourceEntry
 from ..config.config_service import ConfigAccessor
 
-# 物理连接到连接分组的键映射，统一在此集中配置，消除魔法硬编码字符串
-_CONNECTION_GROUP_ALIAS: dict[str, str] = {
-    ProviderFamily.FAN_STUDIO.value: "fan_studio_all",
-    ProviderFamily.P2P.value: "p2p_main",
-    ProviderFamily.WOLFX.value: "wolfx_all",
-    ProviderFamily.GLOBAL_QUAKE.value: "openquake_api",
-    ProviderFamily.DIRECT_HTTP.value: "snet_msil",
-}
-
-# 物理连接的友好展示名称，供管理后台和 API 使用
-_CONNECTION_DISPLAY_NAME: dict[str, str] = {
-    "fan_studio_all": "FAN Studio",
-    "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
-    "p2p_main": "P2P地震情報",
-    "wolfx_all": "Wolfx",
-    "openquake_api": "OpenQuakeAPI",
-    "snet_msil": "NIED S-Net",
-    # EQSC 为 HTTP 通道；展示名必须与 ConnectionsPayloadBuilder.EQSC_DISPLAY_NAME
-    # 完全一致，否则 catalog 占位会以原始键 "eqsc" 残留，前端误显示“未连接”。
-    "eqsc": "EQSC API",
-}
+# 物理连接到连接分组的键映射、物理连接的友好展示名称
+# 已统一收编至 core/sources/display_registry.py（CONNECTION_GROUP_ALIAS /
+# CONNECTION_DISPLAY_NAMES），此处直接引用事实层常量。
+# EQSC / S-Net 等 HTTP 通道展示名同样来自 CONNECTION_DISPLAY_NAMES，
+# 与 ConnectionsPayloadBuilder 派生自同一事实源，天然保持一致。
 
 
 class SourceRuntimeQueryService:
@@ -110,7 +95,7 @@ class SourceRuntimeQueryService:
         if explicit_group:
             return explicit_group
         # 降级使用静态定义的全局家族别名列表
-        return _CONNECTION_GROUP_ALIAS.get(
+        return CONNECTION_GROUP_ALIAS.get(
             entry.provider_family.value, entry.provider_family.value
         )
 
@@ -119,7 +104,7 @@ class SourceRuntimeQueryService:
         groups: dict[str, str] = {}
         for entry in SOURCE_CATALOG.values():
             group_key = self.get_connection_group_key(entry)
-            groups[group_key] = _CONNECTION_DISPLAY_NAME.get(group_key, group_key)
+            groups[group_key] = CONNECTION_DISPLAY_NAMES.get(group_key, group_key)
         return groups
 
     def get_connection_group_source_map(self) -> dict[str, list[str]]:

--- a/core/sources/__init__.py
+++ b/core/sources/__init__.py
@@ -3,6 +3,14 @@
 统一导出数据源目录、来源注册项与路由辅助能力。
 """
 
+from .display_registry import (
+    CONNECTION_DISPLAY_NAMES,
+    CONNECTION_GROUP_ALIAS,
+    CONNECTION_GROUP_ORDER,
+    DISPLAY_NAME_ALIASES,
+    SOURCE_ALIAS_MAP,
+    SOURCE_DISPLAY_MAP,
+)
 from .source_catalog import (
     SOURCE_CATALOG,
     get_source_entries,
@@ -30,6 +38,12 @@ __all__ = [
     "SourceEntry",
     "SourceType",
     "SOURCE_CATALOG",
+    "SOURCE_ALIAS_MAP",
+    "SOURCE_DISPLAY_MAP",
+    "CONNECTION_DISPLAY_NAMES",
+    "CONNECTION_GROUP_ALIAS",
+    "CONNECTION_GROUP_ORDER",
+    "DISPLAY_NAME_ALIASES",
     "get_source_entry",
     "get_source_entries",
     "get_source_ids_by_config_group",

--- a/core/sources/display_registry.py
+++ b/core/sources/display_registry.py
@@ -1,0 +1,231 @@
+"""
+数据源展示名称统一注册表（事实层）。
+
+设计原则：事实层 + 场景投影层 分离。
+- 事实层（本文件）：同一份数据只在唯一位置维护，供所有模块读取。
+  · SOURCE_ALIAS_MAP       数据源历史别名归一化表（alias -> 规范 source_id）
+  · SOURCE_DISPLAY_MAP     数据源通道展示名表（source_id -> 完整展示名）
+  · CONNECTION_DISPLAY_NAMES  物理连接组展示名表（连接组 key -> 展示名）
+  · CONNECTION_GROUP_ORDER    连接组展示顺序
+  · CONNECTION_GROUP_ALIAS    提供方家族 -> 连接组 key
+  · DISPLAY_NAME_ALIASES      展示名 -> 连接组 key 的反向别名（历史兼容）
+
+- 场景投影层：banner / 离线通知 / 管理命令 / 前端子源列表等场景会在事实
+  基础上追加自己的展示规则（加后缀、折叠到通道粒度、剥通道后缀等）。
+  这些投影属于有意设计，保留在各消费点，并注明与事实层的对应关系，
+  修改事实层时只需检查各投影点是否需要同步调整。
+
+历史背景：
+- 连接组展示名曾散落各个模块，内容完全一致却各自维护，改动容易漏改；现统一收编。
+- 历史别名表与展示名表曾内联在 core/storage/source_compat.py，现迁移至此，
+  source_compat.py 保留为兼容层门面（通过别名导入继续暴露同名数据）。
+
+同步契约：
+- 前端启动时经管理端 /api/sources/meta 动态拉取，仅保留极少量场景投影覆盖
+- 修改本文件别名或展示名时，后端会自动生效，前端无需改动。
+（新 key 自动补全；既有 key 若与投影覆盖冲突，以前端覆盖为准，修改时请核对前端覆盖表）
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# 1. 数据源历史别名归一化表
+# ---------------------------------------------------------------------------
+# 把旧来源名、展示名和外部兼容名统一折叠到规范 source_id。
+# 包含各种历史插件版本产生的 key 以及 WebSocket 连接中发送的 label。
+SOURCE_ALIAS_MAP: dict[str, str] = {
+    "fan_studio_cenc": "cenc_fanstudio",
+    "fan_studio_cenc_ir": "cenc_ir_fanstudio",
+    "fan_studio_cea": "cea_fanstudio",
+    "fan_studio_cea_pr": "cea_pr_fanstudio",
+    "fan_studio_cwa": "cwa_fanstudio",
+    "fan_studio_cwa_report": "cwa_fanstudio_report",
+    "fan_studio_usgs": "usgs_fanstudio",
+    "fan_studio_fssn_cmt": "fssn_cmt_fanstudio",
+    "fssn-cmt": "fssn_cmt_fanstudio",
+    "fssn_cmt": "fssn_cmt_fanstudio",
+    "fan_studio_sa": "sa_fanstudio",
+    "fan_studio_jma": "jma_fanstudio",
+    "fan_studio_weather": "china_weather_fanstudio",
+    "fan_studio_tsunami": "china_tsunami_fanstudio",
+    "p2p_eew": "jma_p2p",
+    "p2p_earthquake": "jma_p2p_info",
+    "p2p_tsunami": "jma_tsunami_p2p",
+    "eqsc_tsunami": "jma_tsunami_eqsc",
+    "eqsc_typhoon": "typhoon_eqsc",
+    "eqsc_cenc_ir": "cenc_ir_eqsc",
+    "cenc_ir_eqsc": "cenc_ir_eqsc",
+    "eqsc_intensity_report": "cenc_ir_eqsc",
+    "fan_studio_typhoon": "typhoon_fanstudio",
+    "wolfx_jma_eew": "jma_wolfx",
+    "wolfx_cenc_eew": "cea_wolfx",
+    "wolfx_cwa_eew": "cwa_wolfx",
+    "wolfx_cenc_eq": "cenc_wolfx",
+    "wolfx_jma_eq": "jma_wolfx_info",
+    "china_earthquake_warning": "cea_fanstudio",
+    "china_earthquake_warning_provincial": "cea_pr_fanstudio",
+    "taiwan_cwa_earthquake": "cwa_fanstudio",
+    "taiwan_cwa_report": "cwa_fanstudio_report",
+    "china_cenc_earthquake": "cenc_fanstudio",
+    "china_cenc_intensity_report": "cenc_ir_fanstudio",
+    "cenc-ir": "cenc_ir_fanstudio",
+    "cenc_ir": "cenc_ir_fanstudio",
+    "usgs_earthquake": "usgs_fanstudio",
+    "usa_shakealert": "sa_fanstudio",
+    "sa": "sa_fanstudio",
+    "shakealert": "sa_fanstudio",
+    "china_weather_alarm": "china_weather_fanstudio",
+    "openquake_cma": "china_weather_openquake",
+    "cma_weather": "china_weather_openquake",
+    "cma": "china_weather_openquake",
+    "china_tsunami": "china_tsunami_fanstudio",
+    "japan_jma_eew": "jma_p2p",
+    "japan_jma_earthquake": "jma_p2p_info",
+    "japan_jma_tsunami": "jma_tsunami_p2p",
+    "china_cenc_eew": "cea_wolfx",
+    "taiwan_cwa_eew": "cwa_wolfx",
+    "中国气象局：气象预警": "china_weather_fanstudio",
+    "中国气象局: 气象预警": "china_weather_fanstudio",
+    "台湾中央气象署：强震即时警报": "cwa_fanstudio",
+    "台湾中央气象署: 强震即时警报": "cwa_fanstudio",
+    "台湾中央气象署：地震报告": "cwa_fanstudio_report",
+    "台湾中央气象署: 地震报告": "cwa_fanstudio_report",
+    "中国地震台网（cenc）": "cenc_fanstudio",
+    "中国地震台网(cenc)": "cenc_fanstudio",
+    "中国地震台网（cenc）：地震测定": "cenc_fanstudio",
+    "中国地震台网(cenc)：地震测定": "cenc_fanstudio",
+    "中国地震台网（cenc）：烈度速报": "cenc_ir_fanstudio",
+    "中国地震台网(cenc)：烈度速报": "cenc_ir_fanstudio",
+    "中国地震台网烈度速报": "cenc_ir_fanstudio",
+    "中国地震预警网（cea）": "cea_fanstudio",
+    "中国地震预警网(cea)": "cea_fanstudio",
+    "中国地震预警网（省级）": "cea_pr_fanstudio",
+    "中国地震预警网(省级)": "cea_pr_fanstudio",
+    "日本气象厅：紧急地震速报": "jma_fanstudio",
+    "日本气象厅: 紧急地震速报": "jma_fanstudio",
+    "日本气象厅：地震情报": "jma_p2p_info",
+    "日本气象厅: 地震情报": "jma_p2p_info",
+    # 中文冒号全角/半角 + 预报/予报 历史写法都兼容
+    "日本气象厅：海啸预报": "jma_tsunami_p2p",
+    "日本气象厅: 海啸预报": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报": "jma_tsunami_p2p",
+    "日本气象厅: 海啸予报": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报 - P2P": "jma_tsunami_p2p",
+    "日本气象厅: 海啸予报 - P2P": "jma_tsunami_p2p",
+    "日本气象厅：海啸予报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅: 海啸予报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅：海啸预报 - EQSC": "jma_tsunami_eqsc",
+    "日本气象厅: 海啸预报 - EQSC": "jma_tsunami_eqsc",
+}
+
+# ---------------------------------------------------------------------------
+# 2. 数据源通道展示名表
+# ---------------------------------------------------------------------------
+# 把内部规范 key 转回更友好的前端展示标签。
+# 注意：这是"通道级完整展示名"；机构级短名（如"中国地震预警网"）由
+# source_catalog.py 的 SourceEntry.institution_display_name 维护，两者粒度不同。
+SOURCE_DISPLAY_MAP: dict[str, str] = {
+    "cenc_fanstudio": "中国地震台网 (CENC) - Fan",
+    "cenc_ir_fanstudio": "中国地震台网 (CENC) - 烈度速报 - Fan",
+    "cenc_ir_eqsc": "中国地震台网 (CENC) - 烈度速报 - EQSC",
+    "cea_fanstudio": "中国地震预警网 (CEA)",
+    "cea_pr_fanstudio": "中国地震预警网 (省级)",
+    "cwa_fanstudio": "台湾中央气象署: 强震即时警报 - Fan",
+    "cwa_fanstudio_report": "台湾中央气象署: 地震报告",
+    "usgs_fanstudio": "美国地质调查局 (USGS)",
+    "fssn_cmt_fanstudio": "FSSN 矩心矩张量解 (CMT)",
+    "sa_fanstudio": "美国 ShakeAlert 地震预警",
+    "jma_fanstudio": "日本气象厅: 紧急地震速报 - Fan",
+    "china_weather_fanstudio": "中国气象局: 气象预警 - Fan",
+    "china_weather_openquake": "中国气象局: 气象预警 - OQ",
+    "china_tsunami_fanstudio": "自然资源部海啸预警中心",
+    # 贡献榜默认中性名：实时通道不强制带后缀
+    "typhoon_fanstudio": "中国气象局：实时活跃台风",
+    "typhoon_eqsc": "中国气象局：实时活跃台风 - EQSC",
+    # 仅 EQSC 历史重建在贡献统计中单独成源
+    "typhoon_eqsc_rebuild": "中国气象局：台风历史 - EQSC",
+    "jma_p2p": "日本气象厅: 紧急地震速报 - P2P",
+    "jma_p2p_info": "日本气象厅: 地震情报 - P2P",
+    "jma_tsunami_p2p": "日本气象厅: 海啸予报 - P2P",
+    "jma_tsunami_eqsc": "日本气象厅: 海啸予报 - EQSC",
+    "jma_wolfx": "日本气象厅: 紧急地震速报 - Wolfx",
+    "cea_wolfx": "中国地震预警网 (CEA) - Wolfx",
+    "cwa_wolfx": "台湾中央气象署: 强震即时警报 - Wolfx",
+    "cenc_wolfx": "中国地震台网地震测定 - Wolfx",
+    "jma_wolfx_info": "日本气象厅地震情报 - Wolfx",
+    "global_quake": "Global Quake",
+    "sc_eew": "四川地震局",
+    "fj_eew": "福建地震局",
+    "kma_earthquake": "韩国气象厅 (KMA)",
+    "emsc_earthquake": "欧洲地中海地震中心 (EMSC)",
+    "gfz_earthquake": "德国地学研究中心 (GFZ)",
+    "unknown": "未知来源",
+}
+
+# ---------------------------------------------------------------------------
+# 3. 物理连接组展示名表
+# ---------------------------------------------------------------------------
+# 供管理后台、健康监控、连接载荷构建、离线通知等场景使用。
+CONNECTION_DISPLAY_NAMES: dict[str, str] = {
+    "fan_studio_all": "FAN Studio",
+    "fan_studio_cenc_ir": "FAN Studio（烈度速报）",
+    "p2p_main": "P2P地震情報",
+    "wolfx_all": "Wolfx",
+    "openquake_api": "OpenQuakeAPI",
+    "snet_msil": "NIED S-Net",
+    "eqsc": "EQSC API",
+}
+
+# ---------------------------------------------------------------------------
+# 4. 连接组展示顺序
+# ---------------------------------------------------------------------------
+# 与 ConnectionsGrid 列语义对齐，供健康监控按固定顺序遍历。
+CONNECTION_GROUP_ORDER: tuple[str, ...] = (
+    "fan_studio_all",
+    "fan_studio_cenc_ir",
+    "p2p_main",
+    "wolfx_all",
+    "openquake_api",
+    "snet_msil",
+    "eqsc",
+)
+
+# ---------------------------------------------------------------------------
+# 5. 提供方家族 -> 连接组 key
+# ---------------------------------------------------------------------------
+# 供 SourceRuntimeQueryService 在数据源未显式声明 connection_group 时，
+# 按 provider_family 解析默认连接分组。
+CONNECTION_GROUP_ALIAS: dict[str, str] = {
+    "fan_studio": "fan_studio_all",
+    "p2p": "p2p_main",
+    "wolfx": "wolfx_all",
+    "global_quake": "openquake_api",
+    "direct_http": "snet_msil",
+}
+
+# ---------------------------------------------------------------------------
+# 6. 展示名 -> 连接组 key 的反向别名（历史兼容）
+# ---------------------------------------------------------------------------
+# ConnectionsPayloadBuilder / SourceRuntimeQuery 可能使用的展示名别名，
+# 包含历史上出现过的括号/空格写法，用于把展示名归一化回连接组 key。
+DISPLAY_NAME_ALIASES: dict[str, str] = {
+    "FAN Studio": "fan_studio_all",
+    "FAN Studio 烈度速报": "fan_studio_cenc_ir",
+    "FAN Studio（烈度速报）": "fan_studio_cenc_ir",
+    "Fan Studio（烈度速报）": "fan_studio_cenc_ir",
+    "P2P地震情報": "p2p_main",
+    "Wolfx": "wolfx_all",
+    "OpenQuakeAPI": "openquake_api",
+    "NIED S-Net": "snet_msil",
+    "EQSC API": "eqsc",
+}
+
+
+__all__ = [
+    "SOURCE_ALIAS_MAP",
+    "SOURCE_DISPLAY_MAP",
+    "CONNECTION_DISPLAY_NAMES",
+    "CONNECTION_GROUP_ORDER",
+    "CONNECTION_GROUP_ALIAS",
+    "DISPLAY_NAME_ALIASES",
+]

--- a/core/sources/display_registry.py
+++ b/core/sources/display_registry.py
@@ -28,6 +28,8 @@
 
 from __future__ import annotations
 
+from .source_entry import ProviderFamily
+
 # ---------------------------------------------------------------------------
 # 1. 数据源历史别名归一化表
 # ---------------------------------------------------------------------------
@@ -195,12 +197,13 @@ CONNECTION_GROUP_ORDER: tuple[str, ...] = (
 # ---------------------------------------------------------------------------
 # 供 SourceRuntimeQueryService 在数据源未显式声明 connection_group 时，
 # 按 provider_family 解析默认连接分组。
+# key 直接取自 ProviderFamily 枚举值，避免与枚举定义静默漂移。
 CONNECTION_GROUP_ALIAS: dict[str, str] = {
-    "fan_studio": "fan_studio_all",
-    "p2p": "p2p_main",
-    "wolfx": "wolfx_all",
-    "global_quake": "openquake_api",
-    "direct_http": "snet_msil",
+    ProviderFamily.FAN_STUDIO.value: "fan_studio_all",
+    ProviderFamily.P2P.value: "p2p_main",
+    ProviderFamily.WOLFX.value: "wolfx_all",
+    ProviderFamily.GLOBAL_QUAKE.value: "openquake_api",
+    ProviderFamily.DIRECT_HTTP.value: "snet_msil",
 }
 
 # ---------------------------------------------------------------------------

--- a/core/storage/source_compat.py
+++ b/core/storage/source_compat.py
@@ -14,132 +14,11 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from ..domain.typhoon.typhoon_modes import resolve_data_mode
+from ..sources.display_registry import SOURCE_ALIAS_MAP, SOURCE_DISPLAY_MAP
 
-# 历史别名映射表：把旧来源名、展示名和外部兼容名统一折叠到规范 source_id
-# 包含各种历史插件版本产生的 key 以及 WebSocket 连接中发送的 label
-_ALIAS_MAP: dict[str, str] = {
-    "fan_studio_cenc": "cenc_fanstudio",
-    "fan_studio_cenc_ir": "cenc_ir_fanstudio",
-    "fan_studio_cea": "cea_fanstudio",
-    "fan_studio_cea_pr": "cea_pr_fanstudio",
-    "fan_studio_cwa": "cwa_fanstudio",
-    "fan_studio_cwa_report": "cwa_fanstudio_report",
-    "fan_studio_usgs": "usgs_fanstudio",
-    "fan_studio_fssn_cmt": "fssn_cmt_fanstudio",
-    "fssn-cmt": "fssn_cmt_fanstudio",
-    "fssn_cmt": "fssn_cmt_fanstudio",
-    "fan_studio_sa": "sa_fanstudio",
-    "fan_studio_jma": "jma_fanstudio",
-    "fan_studio_weather": "china_weather_fanstudio",
-    "fan_studio_tsunami": "china_tsunami_fanstudio",
-    "p2p_eew": "jma_p2p",
-    "p2p_earthquake": "jma_p2p_info",
-    "p2p_tsunami": "jma_tsunami_p2p",
-    "eqsc_tsunami": "jma_tsunami_eqsc",
-    "eqsc_typhoon": "typhoon_eqsc",
-    "eqsc_cenc_ir": "cenc_ir_eqsc",
-    "cenc_ir_eqsc": "cenc_ir_eqsc",
-    "eqsc_intensity_report": "cenc_ir_eqsc",
-    "fan_studio_typhoon": "typhoon_fanstudio",
-    "wolfx_jma_eew": "jma_wolfx",
-    "wolfx_cenc_eew": "cea_wolfx",
-    "wolfx_cwa_eew": "cwa_wolfx",
-    "wolfx_cenc_eq": "cenc_wolfx",
-    "wolfx_jma_eq": "jma_wolfx_info",
-    "china_earthquake_warning": "cea_fanstudio",
-    "china_earthquake_warning_provincial": "cea_pr_fanstudio",
-    "taiwan_cwa_earthquake": "cwa_fanstudio",
-    "taiwan_cwa_report": "cwa_fanstudio_report",
-    "china_cenc_earthquake": "cenc_fanstudio",
-    "china_cenc_intensity_report": "cenc_ir_fanstudio",
-    "cenc-ir": "cenc_ir_fanstudio",
-    "cenc_ir": "cenc_ir_fanstudio",
-    "usgs_earthquake": "usgs_fanstudio",
-    "usa_shakealert": "sa_fanstudio",
-    "sa": "sa_fanstudio",
-    "shakealert": "sa_fanstudio",
-    "china_weather_alarm": "china_weather_fanstudio",
-    "openquake_cma": "china_weather_openquake",
-    "cma_weather": "china_weather_openquake",
-    "cma": "china_weather_openquake",
-    "china_tsunami": "china_tsunami_fanstudio",
-    "japan_jma_eew": "jma_p2p",
-    "japan_jma_earthquake": "jma_p2p_info",
-    "japan_jma_tsunami": "jma_tsunami_p2p",
-    "china_cenc_eew": "cea_wolfx",
-    "taiwan_cwa_eew": "cwa_wolfx",
-    "中国气象局：气象预警": "china_weather_fanstudio",
-    "中国气象局: 气象预警": "china_weather_fanstudio",
-    "台湾中央气象署：强震即时警报": "cwa_fanstudio",
-    "台湾中央气象署: 强震即时警报": "cwa_fanstudio",
-    "台湾中央气象署：地震报告": "cwa_fanstudio_report",
-    "台湾中央气象署: 地震报告": "cwa_fanstudio_report",
-    "中国地震台网（cenc）": "cenc_fanstudio",
-    "中国地震台网(cenc)": "cenc_fanstudio",
-    "中国地震台网（cenc）：地震测定": "cenc_fanstudio",
-    "中国地震台网(cenc)：地震测定": "cenc_fanstudio",
-    "中国地震台网（cenc）：烈度速报": "cenc_ir_fanstudio",
-    "中国地震台网(cenc)：烈度速报": "cenc_ir_fanstudio",
-    "中国地震台网烈度速报": "cenc_ir_fanstudio",
-    "中国地震预警网（cea）": "cea_fanstudio",
-    "中国地震预警网(cea)": "cea_fanstudio",
-    "中国地震预警网（省级）": "cea_pr_fanstudio",
-    "中国地震预警网(省级)": "cea_pr_fanstudio",
-    "日本气象厅：紧急地震速报": "jma_fanstudio",
-    "日本气象厅: 紧急地震速报": "jma_fanstudio",
-    "日本气象厅：地震情报": "jma_p2p_info",
-    "日本气象厅: 地震情报": "jma_p2p_info",
-    # 中文冒号全角/半角 + 预报/予报 历史写法都兼容
-    "日本气象厅：海啸预报": "jma_tsunami_p2p",
-    "日本气象厅: 海啸预报": "jma_tsunami_p2p",
-    "日本气象厅：海啸予报": "jma_tsunami_p2p",
-    "日本气象厅: 海啸予报": "jma_tsunami_p2p",
-    "日本气象厅：海啸予报 - P2P": "jma_tsunami_p2p",
-    "日本气象厅: 海啸予报 - P2P": "jma_tsunami_p2p",
-    "日本气象厅：海啸予报 - EQSC": "jma_tsunami_eqsc",
-    "日本气象厅: 海啸予报 - EQSC": "jma_tsunami_eqsc",
-    "日本气象厅：海啸预报 - EQSC": "jma_tsunami_eqsc",
-    "日本气象厅: 海啸预报 - EQSC": "jma_tsunami_eqsc",
-}
-
-# 展示名称映射表：用于把内部规范 key 转回更友好的前端展示标签。
-_DISPLAY_MAP: dict[str, str] = {
-    "cenc_fanstudio": "中国地震台网 (CENC) - Fan",
-    "cenc_ir_fanstudio": "中国地震台网 (CENC) - 烈度速报 - Fan",
-    "cenc_ir_eqsc": "中国地震台网 (CENC) - 烈度速报 - EQSC",
-    "cea_fanstudio": "中国地震预警网 (CEA)",
-    "cea_pr_fanstudio": "中国地震预警网 (省级)",
-    "cwa_fanstudio": "台湾中央气象署: 强震即时警报 - Fan",
-    "cwa_fanstudio_report": "台湾中央气象署: 地震报告",
-    "usgs_fanstudio": "美国地质调查局 (USGS)",
-    "fssn_cmt_fanstudio": "FSSN 矩心矩张量解 (CMT)",
-    "sa_fanstudio": "美国 ShakeAlert 地震预警",
-    "jma_fanstudio": "日本气象厅: 紧急地震速报 - Fan",
-    "china_weather_fanstudio": "中国气象局: 气象预警 - Fan",
-    "china_weather_openquake": "中国气象局: 气象预警 - OQ",
-    "china_tsunami_fanstudio": "自然资源部海啸预警中心",
-    # 贡献榜默认中性名：实时通道不强制带后缀
-    "typhoon_fanstudio": "中国气象局：实时活跃台风",
-    "typhoon_eqsc": "中国气象局：实时活跃台风 - EQSC",
-    # 仅 EQSC 历史重建在贡献统计中单独成源
-    "typhoon_eqsc_rebuild": "中国气象局：台风历史 - EQSC",
-    "jma_p2p": "日本气象厅: 紧急地震速报 - P2P",
-    "jma_p2p_info": "日本气象厅: 地震情报 - P2P",
-    "jma_tsunami_p2p": "日本气象厅: 海啸予报 - P2P",
-    "jma_tsunami_eqsc": "日本气象厅: 海啸予报 - EQSC",
-    "jma_wolfx": "日本气象厅: 紧急地震速报 - Wolfx",
-    "cea_wolfx": "中国地震预警网 (CEA) - Wolfx",
-    "cwa_wolfx": "台湾中央气象署: 强震即时警报 - Wolfx",
-    "cenc_wolfx": "中国地震台网地震测定 - Wolfx",
-    "jma_wolfx_info": "日本气象厅地震情报 - Wolfx",
-    "global_quake": "Global Quake",
-    "sc_eew": "四川地震局",
-    "fj_eew": "福建地震局",
-    "kma_earthquake": "韩国气象厅 (KMA)",
-    "emsc_earthquake": "欧洲地中海地震中心 (EMSC)",
-    "gfz_earthquake": "德国地学研究中心 (GFZ)",
-    "unknown": "未知来源",
-}
+# 历史别名映射表与展示名称映射表已统一收编至
+# core/sources/display_registry.py（SOURCE_ALIAS_MAP / SOURCE_DISPLAY_MAP），
+# 本兼容层直接引用事实层常量，后续修改请前往 display_registry.py。
 
 
 def normalize_source_name(source: str) -> str:
@@ -150,14 +29,18 @@ def normalize_source_name(source: str) -> str:
         return "unknown"
     lower_source = raw_source.lower()
     # 先按原值匹配，再按小写匹配历史别名；若都未命中，则回退为小写标准形态。
-    return _ALIAS_MAP.get(raw_source) or _ALIAS_MAP.get(lower_source) or lower_source
+    return (
+        SOURCE_ALIAS_MAP.get(raw_source)
+        or SOURCE_ALIAS_MAP.get(lower_source)
+        or lower_source
+    )
 
 
 def format_source_name(source: str) -> str:
     """把来源标识格式化为更适合展示的中文标签。"""
     normalized = normalize_source_name(source)
     # 如果映射字典里找不到对应的漂亮展示名，则使用归一化后的去重字符串作为兜底
-    return _DISPLAY_MAP.get(normalized) or str(source or "").strip() or "未知来源"
+    return SOURCE_DISPLAY_MAP.get(normalized) or str(source or "").strip() or "未知来源"
 
 
 def is_cenc_intensity_report(
@@ -207,7 +90,7 @@ def is_earthquake_supplement_product(
 def fssn_cmt_report_source_keys() -> tuple[str, ...]:
     """返回可识别为 FSSN CMT 的 source/source_id 键集合。"""
     keys: set[str] = {"fssn_cmt_fanstudio"}
-    for alias, target in _ALIAS_MAP.items():
+    for alias, target in SOURCE_ALIAS_MAP.items():
         if target == "fssn_cmt_fanstudio":
             keys.add(str(alias).strip().lower())
     return tuple(sorted(keys))
@@ -252,7 +135,7 @@ def cenc_intensity_report_source_keys() -> tuple[str, ...]:
     统一折叠为 strip + lower 形态，避免大小写/空白导致 SQL 与 Python 分叉。
     """
     keys: set[str] = {"cenc_ir_fanstudio", "cenc_ir_eqsc"}
-    for alias, target in _ALIAS_MAP.items():
+    for alias, target in SOURCE_ALIAS_MAP.items():
         if target in {"cenc_ir_fanstudio", "cenc_ir_eqsc"}:
             keys.add(str(alias).strip().lower())
     return tuple(sorted(keys))
@@ -379,7 +262,7 @@ def expand_source_aliases(sources: Iterable[str]) -> list[str]:
         expanded.add(canonical)
         expanded.add(format_source_name(raw))
 
-    for alias, canonical in _ALIAS_MAP.items():
+    for alias, canonical in SOURCE_ALIAS_MAP.items():
         # 第二轮反向补全所有历史别名，尽量覆盖旧数据库中的遗留写法。
         if canonical in canonical_keys:
             expanded.add(alias)

--- a/plugin/commands/plugin_admin_command_service.py
+++ b/plugin/commands/plugin_admin_command_service.py
@@ -111,7 +111,12 @@ class PluginAdminCommandService(CommandTelemetryMixin):
             bot_id = event.get_self_id() or "0"
             bot_name = "灾害预警"
 
-            # 对应展示名称映射
+            # 对应展示名称映射（命令文本场景投影）。
+            # connection_label_map / source_group_label_map 的多数值与
+            # display_registry.CONNECTION_DISPLAY_NAMES 一致，但命令文本保留了两处
+            # 有意差异：fan_studio_cenc_ir 用空格（"FAN Studio 烈度速报"）而非括号；
+            # snet_msil 用"日本海沟 S-Net 海底震度计"。
+            # 修改展示名时请同时核对 display_registry.py 与下方各投影表。
             connection_label_map = OrderedDict(
                 [
                     ("fan_studio_all", "FAN Studio"),

--- a/utils/banner.py
+++ b/utils/banner.py
@@ -148,6 +148,9 @@ def print_banner() -> None:
 # 启动汇总大屏生成
 # ---------------------------------------------------------------------------
 # 连接分组名 -> 展示名（大屏连接明细用）
+# 场景投影：启动大屏为排版对齐做了微调（追加"数据源"后缀、空格分隔），
+# 与 display_registry.CONNECTION_DISPLAY_NAMES（管理端口径）存在有意差异，
+# 此处保留大屏专用文案，修改展示名时请同时检查两处。
 _CONNECTION_LABELS: dict[str, str] = {
     "fan_studio_all": "FAN Studio 数据源",
     "fan_studio_cenc_ir": "FAN Studio 烈度速报",


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

将数据源别名和显示名称映射集中到统一的后端注册表中，并通过 API 暴露给前端和其他服务使用，从而减少各模块之间的重复和偏差。

New Features:
- 提供新的 `/api/sources/meta` 端点，供管理后台 UI 在运行时获取规范化的数据源和连接显示元数据。

Enhancements:
- 重构后端的数据源兼容性检查和连接健康度逻辑，使其从共享的别名和显示注册表中获取数据，而不再依赖本地硬编码映射。
- 引入统一的显示注册表模块，对所有服务导出数据源别名、数据源显示名称以及连接分组元数据。
- 新增管理端工具 API 端点，为前端提供数据源和连接显示元数据，以支持动态解析。
- 更新通知、查询和连接负载相关服务，从共享注册表中派生连接显示名称和分组信息，使各场景的专用映射保持最小化并有文档说明。
- 在前端实现对新的 API 源显示元数据的按需加载和缓存，并通过轻量级覆盖表支持有意的 UI 差异。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize data source alias and display name mappings into a unified backend registry and expose them via an API for frontend and service consumers to use, reducing duplication and drift across modules.

New Features:
- Provide a new /api/sources/meta endpoint for the admin UI to fetch canonical source and connection display metadata at runtime.

Enhancements:
- Refactor backend source compatibility and connection health logic to consume shared alias and display registries instead of hardcoded local maps.
- Introduce a unified display registry module exporting source alias, source display, and connection group metadata for all services.
- Add a new admin utility API endpoint to serve source and connection display metadata to the frontend for dynamic resolution.
- Update notification, query, and connection payload services to derive connection display names and grouping from the shared registry, keeping scenarios-specific projections minimal and documented.
- Implement frontend lazy-loading and caching of source display metadata from the new API, with lightweight override tables for intentional UI differences.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 统一数据源别名、展示名称及连接分组信息，提升各界面显示一致性。
  * 管理端新增数据源元数据接口，支持动态获取并缓存名称映射。
  * 连接面板和离线通知支持更准确的连接分组及可读名称展示。

* **改进**
  * 元数据获取失败或无效时自动回退为原始数据源名称，增强显示稳定性。
  * 优化历史别名归一化及不同场景下的数据源名称兼容处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->