### PR TITLE
feat: 新增气象雷达查询功能

### DIFF
--- a/core/network/http/nmc_radar_client.py
+++ b/core/network/http/nmc_radar_client.py
@@ -66,12 +66,13 @@ class NmcRadarClient:
         self._page_base = str(page_base or PAGE_BASE).rstrip("/")
         self._concurrency = max(1, int(concurrency or 3))
         self._session: aiohttp.ClientSession | None = None
-        # 页面内容缓存为类级共享：page_path -> (urls, expires_at)。
+        # 页面内容缓存为类级共享：(page_base, page_path) -> (urls, expires_at)。
         # 命令侧每次请求都会新建实例，实例级缓存无法跨请求复用；
         # URL 序列是纯数据、不依赖会话，可安全跨实例共享。
+        # 键包含 page_base，避免不同基础地址的实例互相污染缓存。
         cls = type(self)
         if not hasattr(cls, "_page_cache"):
-            cls._page_cache: dict[str, tuple[list[str], float]] = {}
+            cls._page_cache: dict[tuple[str, str], tuple[list[str], float]] = {}
         self._page_cache = cls._page_cache
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
@@ -108,8 +109,9 @@ class NmcRadarClient:
         Returns:
             图片 URL 列表，最新一帧在前；失败或未解析到时返回空列表。
         """
+        cache_key = (self._page_base, page_path)
         if use_cache:
-            cached = self._page_cache.get(page_path)
+            cached = self._page_cache.get(cache_key)
             if cached is not None and time.time() < cached[1]:
                 return list(cached[0])
 
@@ -146,7 +148,7 @@ class NmcRadarClient:
             result.append(u)
 
         if use_cache:
-            self._page_cache[page_path] = (
+            self._page_cache[cache_key] = (
                 list(result),
                 time.time() + PAGE_CACHE_TTL_SEC,
             )

--- a/core/network/http/nmc_radar_client.py
+++ b/core/network/http/nmc_radar_client.py
@@ -1,0 +1,183 @@
+"""
+NMC 中央气象台雷达图 HTTP 客户端。
+
+负责：
+- 抓取雷达页面 HTML，解析 data-img 属性中的雷达图片 URL 序列
+- 并发下载 PNG 图片帧（用于单图与动图合成）
+- 复用 aiohttp 会话，伪装浏览器 UA 以兼容 CDN
+
+数据来源：https://www.nmc.cn/publish/radar/chinaall.html 及其分页
+图片 URL 结构（实测验证）：
+    https://image.nmc.cn/product/{YYYY}/{MM}/{DD}/RDCP/medium/SEVP_AOC_RDCP_SLDAS3_ECREF_{站点代码}_L88_PI_{YYYYMMDDHHMMSS00000}.PNG
+每个页面 data-img 属性携带该站点最近 N 帧（6 分钟/帧）：
+- 全国拼图约 239 帧
+- 区域拼图约 20 帧
+- 单站雷达约 6~22 帧
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import aiohttp
+
+from astrbot.api import logger
+
+PAGE_BASE = "https://www.nmc.cn"
+IMAGE_BASE = "https://image.nmc.cn"
+
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+_DATA_IMG_RE = re.compile(r'data-img="([^"]+)"')
+_CODE_RE = re.compile(r"ECREF_([A-Z0-9_]+)_L88")
+
+
+class NmcRadarClient:
+    """NMC 雷达图抓取客户端。"""
+
+    def __init__(
+        self,
+        *,
+        timeout_sec: float = 20.0,
+        concurrency: int = 3,
+        page_base: str = PAGE_BASE,
+    ) -> None:
+        """初始化客户端。
+
+        Args:
+            timeout_sec: 单次请求超时（秒）。
+            concurrency: 并发下载图片帧的信号量上限。
+            page_base: 页面基础地址，默认中央气象台官网。
+        """
+        self._timeout = aiohttp.ClientTimeout(total=timeout_sec)
+        self._page_base = str(page_base or PAGE_BASE).rstrip("/")
+        self._concurrency = max(1, int(concurrency or 3))
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """确保 aiohttp 会话可用（延迟初始化）。"""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=self._timeout,
+                headers={"User-Agent": _UA},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """关闭 HTTP 会话。"""
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def fetch_page_radar_urls(
+        self,
+        page_path: str,
+        *,
+        use_cache: bool = True,
+    ) -> list[str]:
+        """抓取雷达页面并解析 data-img 图片 URL 列表（按时间倒序）。
+
+        Args:
+            page_path: 雷达页面路径，如 /publish/radar/chinaall.html。
+            use_cache: 是否启用页面内容缓存（默认开启，页面结构基本不变）。
+
+        Returns:
+            图片 URL 列表，最新一帧在前；失败或未解析到时返回空列表。
+        """
+        url = f"{self._page_base}{page_path}"
+        session = await self._ensure_session()
+        try:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        f"[灾害预警] 雷达页面请求失败。状态码为 {resp.status} URL：{url}"
+                    )
+                    return []
+                html = await resp.text(encoding="utf-8", errors="ignore")
+        except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError) as e:
+            logger.warning(f"[灾害预警] 雷达页面请求异常: {type(e).__name__}: {e}")
+            return []
+
+        urls = _DATA_IMG_RE.findall(html)
+        # 去重并保持顺序（同帧可能重复出现）
+        seen: set[str] = set()
+        result: list[str] = []
+        for u in urls:
+            u = u.strip()
+            if u and u not in seen:
+                seen.add(u)
+                result.append(u)
+        return result
+
+    @staticmethod
+    def strip_medium(url: str) -> str:
+        """去掉图片 URL 中的 /medium 路径段，取原图。"""
+        return url.replace("/medium", "")
+
+    async def download_image(self, url: str) -> bytes | None:
+        """下载单帧雷达图片字节。
+
+        Args:
+            url: 图片完整 URL。
+
+        Returns:
+            图片字节；失败返回 None。
+        """
+        session = await self._ensure_session()
+        try:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        f"[灾害预警] 雷达图片下载失败，状态码为{resp.status} URL：{url[:120]}"
+                    )
+                    return None
+                data = await resp.read()
+                if not data:
+                    return None
+                return data
+        except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError) as e:
+            logger.warning(
+                f"[灾害预警] 雷达图片下载异常: {type(e).__name__}: {e} URL：{url[:120]}"
+            )
+            return None
+
+    async def download_images(self, urls: list[str]) -> list[bytes]:
+        """并发下载多帧图片字节，保持与输入顺序一致。
+
+        使用信号量限制并发，避免一次拉取过多连接打爆 CDN。
+
+        Args:
+            urls: 图片 URL 列表。
+
+        Returns:
+            下载成功的图片字节列表（跳过失败帧，顺序与输入一致）。
+        """
+        sem = asyncio.Semaphore(self._concurrency)
+
+        async def _one(u: str) -> bytes | None:
+            async with sem:
+                return await self.download_image(u)
+
+        if not urls:
+            return []
+        results = await asyncio.gather(*(_one(u) for u in urls))
+        return [d for d in results if d]
+
+    @staticmethod
+    def parse_code_from_url(url: str) -> str | None:
+        """从图片 URL 中提取站点代码（如 ACHN / AZ9010）。"""
+        m = _CODE_RE.search(url or "")
+        return m.group(1) if m else None
+
+    @staticmethod
+    def parse_time_from_url(url: str) -> str | None:
+        """从图片 URL 中提取时间戳字符串（如 20260808102400000）。"""
+        m = re.search(r"_PI_(\d{17})", url or "")
+        return m.group(1) if m else None
+
+
+__all__ = ["NmcRadarClient"]

--- a/core/network/http/nmc_radar_client.py
+++ b/core/network/http/nmc_radar_client.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -28,6 +29,7 @@ from astrbot.api import logger
 
 PAGE_BASE = "https://www.nmc.cn"
 IMAGE_BASE = "https://image.nmc.cn"
+_IMAGE_HOST = "image.nmc.cn"
 
 # 页面内容缓存 TTL（秒）。雷达帧每 6 分钟更新，缓存 90 秒既降低请求频率，
 # 又不会让用户看到明显过期的帧。
@@ -64,8 +66,13 @@ class NmcRadarClient:
         self._page_base = str(page_base or PAGE_BASE).rstrip("/")
         self._concurrency = max(1, int(concurrency or 3))
         self._session: aiohttp.ClientSession | None = None
-        # 页面内容缓存：page_path -> (urls, expires_at)
-        self._page_cache: dict[str, tuple[list[str], float]] = {}
+        # 页面内容缓存为类级共享：page_path -> (urls, expires_at)。
+        # 命令侧每次请求都会新建实例，实例级缓存无法跨请求复用；
+        # URL 序列是纯数据、不依赖会话，可安全跨实例共享。
+        cls = type(self)
+        if not hasattr(cls, "_page_cache"):
+            cls._page_cache: dict[str, tuple[list[str], float]] = {}
+        self._page_cache = cls._page_cache
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         """确保 aiohttp 会话可用（延迟初始化）。"""
@@ -77,11 +84,13 @@ class NmcRadarClient:
         return self._session
 
     async def close(self) -> None:
-        """关闭 HTTP 会话并清空缓存。"""
+        """关闭 HTTP 会话。
+
+        注意：不清理类级页面缓存，URL 序列不依赖会话可跨请求复用。
+        """
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = None
-        self._page_cache.clear()
 
     async def fetch_page_radar_urls(
         self,
@@ -119,12 +128,19 @@ class NmcRadarClient:
             return []
 
         urls = _DATA_IMG_RE.findall(html)
-        # 仅保留 image.nmc.cn 主机下的地址，避免页面被篡改后向任意主机发请求
+        # 仅保留 image.nmc.cn 主机下的 https 地址，避免页面被篡改后向任意主机发请求。
+        # 使用 urlsplit 精确校验主机名，防止 image.nmc.cn.evil.com 之类绕过 startswith。
         result: list[str] = []
         seen: set[str] = set()
         for u in urls:
             u = u.strip()
-            if not u or not u.startswith(IMAGE_BASE) or u in seen:
+            if not u or u in seen:
+                continue
+            try:
+                parts = urlsplit(u)
+            except ValueError:
+                continue
+            if parts.scheme != "https" or (parts.hostname or "").lower() != _IMAGE_HOST:
                 continue
             seen.add(u)
             result.append(u)
@@ -192,8 +208,19 @@ class NmcRadarClient:
                     return None
                 return (u, data)
 
-        results = await asyncio.gather(*(_one(u) for u in urls))
-        return [r for r in results if r is not None]
+        # return_exceptions=True：单帧异常只跳过该帧，不让整个 gather 中断，
+        # 避免剩余任务成为孤儿协程在已关闭会话上继续运行。
+        results = await asyncio.gather(
+            *(_one(u) for u in urls),
+            return_exceptions=True,
+        )
+        pairs: list[tuple[str, bytes]] = []
+        for r in results:
+            if isinstance(r, BaseException):
+                continue
+            if r is not None:
+                pairs.append(r)
+        return pairs
 
     @staticmethod
     def parse_code_from_url(url: str) -> str | None:

--- a/core/network/http/nmc_radar_client.py
+++ b/core/network/http/nmc_radar_client.py
@@ -5,6 +5,7 @@ NMC 中央气象台雷达图 HTTP 客户端。
 - 抓取雷达页面 HTML，解析 data-img 属性中的雷达图片 URL 序列
 - 并发下载 PNG 图片帧（用于单图与动图合成）
 - 复用 aiohttp 会话，伪装浏览器 UA 以兼容 CDN
+- 页面内容带 TTL 内存缓存（雷达帧 6 分钟更新，缓存 90 秒防抖）
 
 数据来源：https://www.nmc.cn/publish/radar/chinaall.html 及其分页
 图片 URL 结构（实测验证）：
@@ -19,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import time
 
 import aiohttp
 
@@ -27,6 +29,10 @@ from astrbot.api import logger
 PAGE_BASE = "https://www.nmc.cn"
 IMAGE_BASE = "https://image.nmc.cn"
 
+# 页面内容缓存 TTL（秒）。雷达帧每 6 分钟更新，缓存 90 秒既降低请求频率，
+# 又不会让用户看到明显过期的帧。
+PAGE_CACHE_TTL_SEC = 90.0
+
 _UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -34,6 +40,7 @@ _UA = (
 
 _DATA_IMG_RE = re.compile(r'data-img="([^"]+)"')
 _CODE_RE = re.compile(r"ECREF_([A-Z0-9_]+)_L88")
+_TIME_RE = re.compile(r"_PI_(\d{17})")
 
 
 class NmcRadarClient:
@@ -57,6 +64,8 @@ class NmcRadarClient:
         self._page_base = str(page_base or PAGE_BASE).rstrip("/")
         self._concurrency = max(1, int(concurrency or 3))
         self._session: aiohttp.ClientSession | None = None
+        # 页面内容缓存：page_path -> (urls, expires_at)
+        self._page_cache: dict[str, tuple[list[str], float]] = {}
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         """确保 aiohttp 会话可用（延迟初始化）。"""
@@ -68,10 +77,11 @@ class NmcRadarClient:
         return self._session
 
     async def close(self) -> None:
-        """关闭 HTTP 会话。"""
+        """关闭 HTTP 会话并清空缓存。"""
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = None
+        self._page_cache.clear()
 
     async def fetch_page_radar_urls(
         self,
@@ -83,11 +93,17 @@ class NmcRadarClient:
 
         Args:
             page_path: 雷达页面路径，如 /publish/radar/chinaall.html。
-            use_cache: 是否启用页面内容缓存（默认开启，页面结构基本不变）。
+            use_cache: 是否启用页面内容缓存（默认开启）。缓存 TTL 见
+                PAGE_CACHE_TTL_SEC，期间重复调用直接返回缓存结果。
 
         Returns:
             图片 URL 列表，最新一帧在前；失败或未解析到时返回空列表。
         """
+        if use_cache:
+            cached = self._page_cache.get(page_path)
+            if cached is not None and time.time() < cached[1]:
+                return list(cached[0])
+
         url = f"{self._page_base}{page_path}"
         session = await self._ensure_session()
         try:
@@ -103,20 +119,27 @@ class NmcRadarClient:
             return []
 
         urls = _DATA_IMG_RE.findall(html)
-        # 去重并保持顺序（同帧可能重复出现）
-        seen: set[str] = set()
+        # 仅保留 image.nmc.cn 主机下的地址，避免页面被篡改后向任意主机发请求
         result: list[str] = []
+        seen: set[str] = set()
         for u in urls:
             u = u.strip()
-            if u and u not in seen:
-                seen.add(u)
-                result.append(u)
+            if not u or not u.startswith(IMAGE_BASE) or u in seen:
+                continue
+            seen.add(u)
+            result.append(u)
+
+        if use_cache:
+            self._page_cache[page_path] = (
+                list(result),
+                time.time() + PAGE_CACHE_TTL_SEC,
+            )
         return result
 
     @staticmethod
     def strip_medium(url: str) -> str:
-        """去掉图片 URL 中的 /medium 路径段，取原图。"""
-        return url.replace("/medium", "")
+        """去掉图片 URL 中的 /medium 路径段（仅替换一次），取原图。"""
+        return url.replace("/medium", "", 1)
 
     async def download_image(self, url: str) -> bytes | None:
         """下载单帧雷达图片字节。
@@ -145,27 +168,32 @@ class NmcRadarClient:
             )
             return None
 
-    async def download_images(self, urls: list[str]) -> list[bytes]:
-        """并发下载多帧图片字节，保持与输入顺序一致。
+    async def download_frames(self, urls: list[str]) -> list[tuple[str, bytes]]:
+        """并发下载多帧图片，返回 (url, bytes) 配对列表。
 
         使用信号量限制并发，避免一次拉取过多连接打爆 CDN。
+        失败帧会被跳过，因此返回列表长度可能小于输入；配对保留 URL，
+        供上层按实际成功帧提取时间戳，避免时间标签与帧错位。
 
         Args:
             urls: 图片 URL 列表。
 
         Returns:
-            下载成功的图片字节列表（跳过失败帧，顺序与输入一致）。
+            下载成功的 (url, bytes) 配对列表，顺序与输入一致。
         """
-        sem = asyncio.Semaphore(self._concurrency)
-
-        async def _one(u: str) -> bytes | None:
-            async with sem:
-                return await self.download_image(u)
-
         if not urls:
             return []
+        sem = asyncio.Semaphore(self._concurrency)
+
+        async def _one(u: str) -> tuple[str, bytes] | None:
+            async with sem:
+                data = await self.download_image(u)
+                if data is None:
+                    return None
+                return (u, data)
+
         results = await asyncio.gather(*(_one(u) for u in urls))
-        return [d for d in results if d]
+        return [r for r in results if r is not None]
 
     @staticmethod
     def parse_code_from_url(url: str) -> str | None:
@@ -176,7 +204,7 @@ class NmcRadarClient:
     @staticmethod
     def parse_time_from_url(url: str) -> str | None:
         """从图片 URL 中提取时间戳字符串（如 20260808102400000）。"""
-        m = re.search(r"_PI_(\d{17})", url or "")
+        m = _TIME_RE.search(url or "")
         return m.group(1) if m else None
 
 

--- a/core/services/query/radar_query_service.py
+++ b/core/services/query/radar_query_service.py
@@ -1,0 +1,501 @@
+"""
+气象雷达查询服务。
+
+统一承接命令侧（/雷达 /雷达动图 /雷达列表）的查询编排：
+- 站点关键词匹配（城市/省份/区域拼图/拼音）
+- 抓取页面 data-img 序列，下载最新一帧或最近 N 帧
+- Pillow 合成循环 GIF（动图）
+- 格式化站点列表文本
+
+数据源：中央气象台雷达页面 https://www.nmc.cn/publish/radar/chinaall.html
+站点表：resources/radar_stations.json（8 区域拼图 + 181 单站）
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import re
+from datetime import datetime
+from typing import Any
+
+from PIL import Image
+
+from astrbot.api import logger
+
+from ...network.http.nmc_radar_client import NmcRadarClient
+
+# 本文件位于 core/services/query/ 下，向上 4 级到插件根目录
+_PLUGIN_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+_RESOURCE_PATH = os.path.join(_PLUGIN_ROOT, "resources", "radar_stations.json")
+
+# 动图默认帧数与并发
+DEFAULT_GIF_FRAMES = 20
+MAX_GIF_FRAMES = 512
+MIN_GIF_FRAMES = 3
+
+# 区域拼图别名 → 页面路径
+_PUZZLE_ALIASES = {
+    "全国": "chinaall",
+    "华北": "huabei",
+    "东北": "dongbei",
+    "华东": "huadong",
+    "华中": "huazhong",
+    "华南": "huanan",
+    "西南": "xinan",
+    "西北": "xibei",
+}
+
+# 省份名 → 省份拼音目录（用于按省份过滤/提示）
+_PROVINCE_DIRS = {
+    "北京": "bei-jing",
+    "天津": "tian-jin",
+    "河北": "he-bei",
+    "山西": "shan-xi",
+    "内蒙古": "nei-meng",
+    "辽宁": "liao-ning",
+    "吉林": "ji-lin",
+    "黑龙江": "hei-long-jiang",
+    "上海": "shang-hai",
+    "江苏": "jiang-su",
+    "浙江": "zhe-jiang",
+    "安徽": "an-hui",
+    "福建": "fu-jian",
+    "江西": "jiang-xi",
+    "山东": "shan-dong",
+    "河南": "he-nan",
+    "湖北": "hu-bei",
+    "湖南": "hu-nan",
+    "广东": "guang-dong",
+    "广西": "guang-xi",
+    "海南": "hai-nan",
+    "重庆": "chong-qing",
+    "四川": "si-chuan",
+    "贵州": "gui-zhou",
+    "云南": "yun-nan",
+    "西藏": "xi-cang",
+    "陕西": "shan-xi",
+    "甘肃": "gan-su",
+    "青海": "qing-hai",
+    "宁夏": "ning-xia",
+    "新疆": "xin-jiang",
+}
+
+
+def _load_stations() -> dict[str, Any]:
+    """加载雷达站点资源表；失败时返回空结构。"""
+    import json
+
+    try:
+        with open(_RESOURCE_PATH, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"[灾害预警] 雷达站点表加载失败: {e}")
+        return {"version": 1, "puzzles": {}, "stations": {}}
+
+
+_STATIONS_CACHE: dict[str, Any] | None = None
+
+
+def _get_stations() -> dict[str, Any]:
+    """站点表缓存。"""
+    global _STATIONS_CACHE
+    if _STATIONS_CACHE is None:
+        _STATIONS_CACHE = _load_stations()
+    return _STATIONS_CACHE
+
+
+def _norm_key(text: str) -> str:
+    """规范化关键词：去空格、去连字符、转小写。"""
+    return re.sub(r"[\s\-]+", "", str(text or "")).lower()
+
+
+def resolve_radar_target(
+    keyword: str,
+) -> dict[str, Any]:
+    """解析雷达查询关键词，返回目标信息。
+
+    支持匹配：
+    - 区域拼图：全国 / 华北 / 东北 / 华东 / 华中 / 华南 / 西南 / 西北
+    - 城市名：北京 / 大兴 / 石家庄 ...
+    - 省份名：河北 / 山西 ...（命中该省任一站点）
+    - 拼音：beijing / daxing / huabei ...
+
+    Returns:
+        dict 包含：matched(bool)、kind("puzzle"|"station")、name、province、path、code、
+        candidates(模糊匹配候选列表)。
+    """
+    data = _get_stations()
+    puzzles = data.get("puzzles") or {}
+    stations = data.get("stations") or {}
+    keyword = _norm_key(keyword)
+
+    if not keyword:
+        return {"matched": False, "reason": "empty", "candidates": []}
+
+    # 1. 区域拼图精确匹配（中文名或拼音文件名）
+    for name, info in puzzles.items():
+        info_dict = info if isinstance(info, dict) else {}
+        puzzle_path = str(info_dict.get("path", "") or "")
+        puzzle_key = _norm_key(name)
+        path_key = _norm_key(puzzle_path.rsplit("/", 1)[-1].replace(".html", ""))
+        if keyword == puzzle_key or keyword == path_key:
+            return {
+                "matched": True,
+                "kind": "puzzle",
+                "name": name,
+                "path": puzzle_path,
+                "code": str(info_dict.get("code", "") or ""),
+            }
+
+    # 2. 城市名精确匹配（含省份筛选）
+    exact = []
+    for city, info in stations.items():
+        info_list = info if isinstance(info, list) else [info]
+        for it in info_list:
+            if _norm_key(city) == keyword:
+                exact.append(
+                    {
+                        "city": city,
+                        "province": it.get("province", ""),
+                        "path": it.get("path", ""),
+                        "code": it.get("code", ""),
+                    }
+                )
+    if len(exact) == 1:
+        it = exact[0]
+        return {
+            "matched": True,
+            "kind": "station",
+            "name": it["city"],
+            "province": it["province"],
+            "path": it["path"],
+            "code": it["code"],
+        }
+    if len(exact) > 1:
+        return {
+            "matched": False,
+            "reason": "ambiguous",
+            "candidates": exact,
+        }
+
+    # 3. 省份名精确匹配（命中该省第一个站点）
+    if keyword in _PROVINCE_DIRS:
+        prov_dir = _PROVINCE_DIRS[keyword]
+        for city, info in stations.items():
+            info_list = info if isinstance(info, list) else [info]
+            for it in info_list:
+                if str(it.get("path", "")).startswith(f"/publish/radar/{prov_dir}/"):
+                    return {
+                        "matched": True,
+                        "kind": "station",
+                        "name": city,
+                        "province": keyword,
+                        "path": it.get("path", ""),
+                        "code": it.get("code", ""),
+                        "note": f"已匹配「{keyword}」省首个雷达站：{city}",
+                    }
+        return {"matched": False, "reason": "no_province_station", "keyword": keyword}
+
+    # 3a. 省份拼音目录匹配（如 beijing → bei-jing 目录下任一站点）
+    for prov_name, prov_dir in _PROVINCE_DIRS.items():
+        prov_dir_key = _norm_key(prov_dir)
+        # 仅允许：完全相等，或关键词是拼音前缀（避免长关键词误命中短拼音）
+        if keyword == prov_dir_key or (
+            len(keyword) >= 2 and prov_dir_key.startswith(keyword)
+        ):
+            for city, info in stations.items():
+                info_list = info if isinstance(info, list) else [info]
+                for it in info_list:
+                    if str(it.get("path", "")).startswith(
+                        f"/publish/radar/{prov_dir}/"
+                    ):
+                        return {
+                            "matched": True,
+                            "kind": "station",
+                            "name": city,
+                            "province": prov_name,
+                            "path": it.get("path", ""),
+                            "code": it.get("code", ""),
+                            "note": f"已匹配「{prov_name}」省首个雷达站：{city}",
+                        }
+    # 3b. 区域拼图拼音匹配（如 huabei → huabei.html）
+    for name, info in puzzles.items():
+        info_dict = info if isinstance(info, dict) else {}
+        puzzle_path = str(info_dict.get("path", "") or "")
+        path_key = _norm_key(puzzle_path.rsplit("/", 1)[-1].replace(".html", ""))
+        if keyword == path_key:
+            return {
+                "matched": True,
+                "kind": "puzzle",
+                "name": name,
+                "path": puzzle_path,
+                "code": str(info_dict.get("code", "") or ""),
+            }
+
+    # 4. 模糊匹配：收集所有候选
+    # 收紧规则：仅允许「关键词是站名/拼音的子串」（单向、关键词更短），
+    # 禁止「长关键词包含短站名」的反向匹配，避免「佛罗里达州」误命中「达州」。
+    candidates = []
+    # 4a. 拼音匹配：关键词是页面路径拼音的前缀或子串（关键词长度 >= 2）
+    if len(keyword) >= 2:
+        for city, info in stations.items():
+            info_list = info if isinstance(info, list) else [info]
+            for it in info_list:
+                path = str(it.get("path", ""))
+                path_pinyin = _norm_key(path.rsplit("/", 1)[-1].split(".")[0])
+                if len(path_pinyin) > len(keyword) and keyword in path_pinyin:
+                    candidates.append(
+                        {
+                            "city": city,
+                            "province": it.get("province", ""),
+                            "path": path,
+                            "code": it.get("code", ""),
+                        }
+                    )
+    # 4b. 中文包含匹配：关键词是站名的子串（关键词长度 >= 2）
+    if not candidates and len(keyword) >= 2:
+        for city, info in stations.items():
+            info_list = info if isinstance(info, list) else [info]
+            for it in info_list:
+                if keyword in _norm_key(city):
+                    candidates.append(
+                        {
+                            "city": city,
+                            "province": it.get("province", ""),
+                            "path": it.get("path", ""),
+                            "code": it.get("code", ""),
+                        }
+                    )
+    if len(candidates) == 1:
+        it = candidates[0]
+        return {
+            "matched": True,
+            "kind": "station",
+            "name": it["city"],
+            "province": it["province"],
+            "path": it["path"],
+            "code": it["code"],
+        }
+    if len(candidates) > 1:
+        return {
+            "matched": False,
+            "reason": "ambiguous",
+            "candidates": candidates,
+        }
+
+    return {"matched": False, "reason": "no_match", "keyword": keyword}
+
+
+def _format_time_label(raw_ts: str | None) -> str:
+    """把 URL 时间戳（如 20260808102400000）格式化为 YYYY-MM-DD HH:MM。"""
+    if not raw_ts:
+        return ""
+    try:
+        dt = datetime.strptime(str(raw_ts)[:14], "%Y%m%d%H%M%S")
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return ""
+
+
+def build_radar_image_result(
+    *,
+    target: dict[str, Any],
+    image_bytes: bytes,
+    url: str,
+) -> dict[str, Any]:
+    """构建单图查询结果。"""
+    label = f"{target.get('name', '')}" + (
+        f"（{target.get('province', '')}）" if target.get("province") else ""
+    )
+    return {
+        "success": True,
+        "kind": target.get("kind", "station"),
+        "name": label,
+        "time": _format_time_label(NmcRadarClient.parse_time_from_url(url)),
+        "image_base64": base64.b64encode(image_bytes).decode(),
+        "source_url": url,
+    }
+
+
+def build_radar_gif_result(
+    *,
+    target: dict[str, Any],
+    frames: list[bytes],
+    times: list[str],
+) -> dict[str, Any]:
+    """用多帧合成循环 GIF 并返回结果。"""
+    label = f"{target.get('name', '')}" + (
+        f"（{target.get('province', '')}）" if target.get("province") else ""
+    )
+    if not frames:
+        return {"success": False, "error": "无可用雷达图像帧"}
+    if len(frames) < MIN_GIF_FRAMES:
+        # 帧数过少，降级为单图
+        return {
+            "success": True,
+            "kind": target.get("kind", "station"),
+            "name": label,
+            "time": _format_time_label(times[0]) if times else "",
+            "image_base64": base64.b64encode(frames[0]).decode(),
+            "degraded": True,
+            "frames": len(frames),
+        }
+
+    pil_frames = []
+    for data in frames:
+        try:
+            img = Image.open(io.BytesIO(data))
+            img = img.convert("P", palette=Image.Palette.ADAPTIVE, colors=256)
+            pil_frames.append(img)
+        except Exception as e:
+            logger.warning(f"[灾害预警] 雷达帧解析失败: {e}")
+
+    if not pil_frames:
+        return {"success": False, "error": "雷达图像帧解析失败"}
+    if len(pil_frames) < MIN_GIF_FRAMES:
+        # 有效帧不足，仍降级单图
+        return {
+            "success": True,
+            "kind": target.get("kind", "station"),
+            "name": label,
+            "time": _format_time_label(times[0]) if times else "",
+            "image_base64": base64.b64encode(frames[0]).decode(),
+            "degraded": True,
+            "frames": len(frames),
+        }
+
+    buf = io.BytesIO()
+    # 统一各帧尺寸，保证 GIF 可正常播放
+    base_w, base_h = pil_frames[0].size
+    normalized = []
+    for img in pil_frames:
+        if img.size != (base_w, base_h):
+            img = img.resize((base_w, base_h), Image.Resampling.LANCZOS)
+        normalized.append(img)
+    normalized[0].save(
+        buf,
+        format="GIF",
+        save_all=True,
+        append_images=normalized[1:],
+        duration=500,
+        loop=0,
+        optimize=False,
+    )
+    gif_bytes = buf.getvalue()
+    return {
+        "success": True,
+        "kind": target.get("kind", "station"),
+        "name": label,
+        "time": _format_time_label(times[0]) if times else "",
+        "frames": len(pil_frames),
+        "image_base64": base64.b64encode(gif_bytes).decode(),
+    }
+
+
+def build_radar_list_text() -> str:
+    """构建雷达列表文本。"""
+    data = _get_stations()
+    puzzles = data.get("puzzles") or {}
+    stations = data.get("stations") or {}
+
+    lines = ["📡 气象雷达站点列表", ""]
+    lines.append("【区域拼图】")
+    for name in ["全国", "华北", "东北", "华东", "华中", "华南", "西南", "西北"]:
+        if name in puzzles:
+            lines.append(f"  • {name}")
+    lines.append("")
+
+    # 按省份分组
+    by_province: dict[str, list[str]] = {}
+    for city, info in stations.items():
+        info_list = info if isinstance(info, list) else [info]
+        for it in info_list:
+            prov = it.get("province", "其他")
+            by_province.setdefault(prov, []).append(city)
+    lines.append("【单站雷达】")
+    for prov in sorted(by_province.keys()):
+        cities = sorted(by_province[prov])
+        lines.append(f"  {prov}：{' '.join(cities)}")
+    return "\n".join(lines)
+
+
+def format_candidates_text(candidates: list[dict[str, Any]]) -> str:
+    """把候选站点列表格式化为提示文本。"""
+    if not candidates:
+        return ""
+    lines = ["🔍 找到多个候选雷达站，请指定具体名称："]
+    for i, c in enumerate(candidates[:10], 1):
+        prov = c.get("province", "")
+        city = c.get("city", "")
+        lines.append(f"  {i}. {city}（{prov}）")
+    if len(candidates) > 10:
+        lines.append(f"  ... 共 {len(candidates)} 个候选")
+    lines.append("例如：/雷达 北京 或 /雷达 大兴")
+    return "\n".join(lines)
+
+
+async def query_radar_image(
+    *,
+    client: NmcRadarClient,
+    target: dict[str, Any],
+) -> dict[str, Any]:
+    """查询最新一帧雷达图。"""
+    path = target.get("path", "")
+    if not path:
+        return {"success": False, "error": "站点页面路径缺失"}
+    urls = await client.fetch_page_radar_urls(path)
+    if not urls:
+        return {"success": False, "error": "未能获取雷达图片地址"}
+    # 取最新一帧（去掉 medium 取原图）
+    latest_url = client.strip_medium(urls[0])
+    data = await client.download_image(latest_url)
+    if not data:
+        return {"success": False, "error": "雷达图片下载失败"}
+    return build_radar_image_result(target=target, image_bytes=data, url=latest_url)
+
+
+async def query_radar_gif(
+    *,
+    client: NmcRadarClient,
+    target: dict[str, Any],
+    frames: int = DEFAULT_GIF_FRAMES,
+) -> dict[str, Any]:
+    """查询最近 N 帧并合成循环 GIF。"""
+    path = target.get("path", "")
+    if not path:
+        return {"success": False, "error": "站点页面路径缺失"}
+    urls = await client.fetch_page_radar_urls(path)
+    if not urls:
+        return {"success": False, "error": "未能获取雷达图片地址"}
+
+    frames = max(1, min(int(frames or DEFAULT_GIF_FRAMES), MAX_GIF_FRAMES))
+    # data-img 序列为时间倒序（最新帧在前），取最近 N 帧后反转，
+    # 使 GIF 按时间正序播放（从早到晚展示云系演变）。
+    selected = list(reversed(urls[:frames]))
+    # 统一取原图（去掉 medium）
+    selected = [client.strip_medium(u) for u in selected]
+    data_list = await client.download_images(selected)
+    if not data_list:
+        return {"success": False, "error": "雷达动图帧下载失败"}
+
+    times = [NmcRadarClient.parse_time_from_url(u) for u in selected]
+    return build_radar_gif_result(target=target, frames=data_list, times=times)
+
+
+async def query_radar_list() -> dict[str, Any]:
+    """查询雷达站点列表文本。"""
+    return {"success": True, "text": build_radar_list_text()}
+
+
+__all__ = [
+    "resolve_radar_target",
+    "query_radar_image",
+    "query_radar_gif",
+    "query_radar_list",
+    "format_candidates_text",
+    "build_radar_list_text",
+]

--- a/core/services/query/radar_query_service.py
+++ b/core/services/query/radar_query_service.py
@@ -8,7 +8,7 @@
 - 格式化站点列表文本
 
 数据源：中央气象台雷达页面 https://www.nmc.cn/publish/radar/chinaall.html
-站点表：resources/radar_stations.json（8 区域拼图 + 181 单站）
+站点表：resources/radar_stations.json（8 区域拼图 + 213 单站）
 """
 
 from __future__ import annotations

--- a/core/services/query/radar_query_service.py
+++ b/core/services/query/radar_query_service.py
@@ -201,7 +201,13 @@ def _match_province_pinyin(
     keyword: str,
     stations: dict[str, Any],
 ) -> dict[str, Any] | None:
-    """省份拼音匹配（如 beijing → 北京，命中该省首个站点）。"""
+    """省份拼音匹配（如 beijing → 北京，命中该省首个站点）。
+
+    收集全部命中的省份：山西/陕西拼音均为 shanxi，若只命中一个省份返回结果，
+    命中多个省份（如输入 shan 前缀命中山东/山西/陕西）返回 ambiguous 候选，
+    交由调用方提示用户选择，避免静默匹配到非预期省份。
+    """
+    matched: list[tuple[str, dict[str, Any]]] = []
     for prov_name, prov_dir in _PROVINCE_DIRS.items():
         prov_dir_key = _norm_key(prov_dir)
         # 仅允许：完全相等，或关键词是拼音前缀（避免长关键词误命中短拼音）
@@ -214,8 +220,22 @@ def _match_province_pinyin(
             stations,
             note="已匹配「{province}」省首个雷达站：{city}",
         )
-        if found:
-            return found
+        if found and found.get("matched"):
+            matched.append((prov_name, found))
+
+    if len(matched) == 1:
+        return matched[0][1]
+    if len(matched) > 1:
+        candidates = [
+            {
+                "city": found.get("name", ""),
+                "province": prov_name,
+                "path": found.get("path", ""),
+                "code": found.get("code", ""),
+            }
+            for prov_name, found in matched
+        ]
+        return {"matched": False, "reason": "ambiguous", "candidates": candidates}
     return None
 
 
@@ -386,7 +406,7 @@ def _degraded_single_result(
     target: dict[str, Any],
     image_bytes: bytes,
     label: str,
-    times: list[str],
+    times: list[str | None],
     frames_count: int,
 ) -> dict[str, Any]:
     """帧数不足时降级为单图结果（取最新一帧，即时间序列最后一个）。"""
@@ -445,7 +465,7 @@ async def build_radar_gif_result(
     *,
     target: dict[str, Any],
     frames: list[bytes],
-    times: list[str],
+    times: list[str | None],
 ) -> dict[str, Any]:
     """用多帧合成循环 GIF 并返回结果。
 

--- a/core/services/query/radar_query_service.py
+++ b/core/services/query/radar_query_service.py
@@ -8,13 +8,17 @@
 - 格式化站点列表文本
 
 数据源：中央气象台雷达页面 https://www.nmc.cn/publish/radar/chinaall.html
-站点表：resources/radar_stations.json（8 区域拼图 + 213 单站）
+站点表：resources/radar_stations.json（8 区域拼图 + 213 单站雷达）
+省份匹配统一按站点表的 province 字段判定，避免依赖路径前缀导致
+山西/陕西（NMC 拼音同为 shan-xi）互相串号。
 """
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
+import json
 import os
 import re
 from datetime import datetime
@@ -37,19 +41,7 @@ DEFAULT_GIF_FRAMES = 20
 MAX_GIF_FRAMES = 512
 MIN_GIF_FRAMES = 3
 
-# 区域拼图别名 → 页面路径
-_PUZZLE_ALIASES = {
-    "全国": "chinaall",
-    "华北": "huabei",
-    "东北": "dongbei",
-    "华东": "huadong",
-    "华中": "huazhong",
-    "华南": "huanan",
-    "西南": "xinan",
-    "西北": "xibei",
-}
-
-# 省份名 → 省份拼音目录（用于按省份过滤/提示）
+# 省份名（仅用于省份拼音目录匹配提示；省份精确匹配走站点表 province 字段）
 _PROVINCE_DIRS = {
     "北京": "bei-jing",
     "天津": "tian-jin",
@@ -87,8 +79,6 @@ _PROVINCE_DIRS = {
 
 def _load_stations() -> dict[str, Any]:
     """加载雷达站点资源表；失败时返回空结构。"""
-    import json
-
     try:
         with open(_RESOURCE_PATH, encoding="utf-8") as f:
             return json.load(f)
@@ -113,30 +103,8 @@ def _norm_key(text: str) -> str:
     return re.sub(r"[\s\-]+", "", str(text or "")).lower()
 
 
-def resolve_radar_target(
-    keyword: str,
-) -> dict[str, Any]:
-    """解析雷达查询关键词，返回目标信息。
-
-    支持匹配：
-    - 区域拼图：全国 / 华北 / 东北 / 华东 / 华中 / 华南 / 西南 / 西北
-    - 城市名：北京 / 大兴 / 石家庄 ...
-    - 省份名：河北 / 山西 ...（命中该省任一站点）
-    - 拼音：beijing / daxing / huabei ...
-
-    Returns:
-        dict 包含：matched(bool)、kind("puzzle"|"station")、name、province、path、code、
-        candidates(模糊匹配候选列表)。
-    """
-    data = _get_stations()
-    puzzles = data.get("puzzles") or {}
-    stations = data.get("stations") or {}
-    keyword = _norm_key(keyword)
-
-    if not keyword:
-        return {"matched": False, "reason": "empty", "candidates": []}
-
-    # 1. 区域拼图精确匹配（中文名或拼音文件名）
+def _match_puzzle_exact(keyword: str, puzzles: dict[str, Any]) -> dict[str, Any] | None:
+    """区域拼图精确匹配（中文名或拼音文件名）。"""
     for name, info in puzzles.items():
         info_dict = info if isinstance(info, dict) else {}
         puzzle_path = str(info_dict.get("path", "") or "")
@@ -150,21 +118,25 @@ def resolve_radar_target(
                 "path": puzzle_path,
                 "code": str(info_dict.get("code", "") or ""),
             }
+    return None
 
-    # 2. 城市名精确匹配（含省份筛选）
+
+def _match_city_exact(keyword: str, stations: dict[str, Any]) -> dict[str, Any] | None:
+    """城市名精确匹配（含省份信息）。"""
     exact = []
     for city, info in stations.items():
         info_list = info if isinstance(info, list) else [info]
+        if _norm_key(city) != keyword:
+            continue
         for it in info_list:
-            if _norm_key(city) == keyword:
-                exact.append(
-                    {
-                        "city": city,
-                        "province": it.get("province", ""),
-                        "path": it.get("path", ""),
-                        "code": it.get("code", ""),
-                    }
-                )
+            exact.append(
+                {
+                    "city": city,
+                    "province": it.get("province", ""),
+                    "path": it.get("path", ""),
+                    "code": it.get("code", ""),
+                }
+            )
     if len(exact) == 1:
         it = exact[0]
         return {
@@ -176,53 +148,81 @@ def resolve_radar_target(
             "code": it["code"],
         }
     if len(exact) > 1:
-        return {
-            "matched": False,
-            "reason": "ambiguous",
-            "candidates": exact,
-        }
+        return {"matched": False, "reason": "ambiguous", "candidates": exact}
+    return None
 
-    # 3. 省份名精确匹配（命中该省第一个站点）
-    if keyword in _PROVINCE_DIRS:
-        prov_dir = _PROVINCE_DIRS[keyword]
-        for city, info in stations.items():
-            info_list = info if isinstance(info, list) else [info]
-            for it in info_list:
-                if str(it.get("path", "")).startswith(f"/publish/radar/{prov_dir}/"):
-                    return {
-                        "matched": True,
-                        "kind": "station",
-                        "name": city,
-                        "province": keyword,
-                        "path": it.get("path", ""),
-                        "code": it.get("code", ""),
-                        "note": f"已匹配「{keyword}」省首个雷达站：{city}",
-                    }
-        return {"matched": False, "reason": "no_province_station", "keyword": keyword}
 
-    # 3a. 省份拼音目录匹配（如 beijing → bei-jing 目录下任一站点）
+def _first_station_of_province(
+    province: str,
+    stations: dict[str, Any],
+    *,
+    note: str,
+) -> dict[str, Any] | None:
+    """按站点表 province 字段匹配，返回该省首个站点。
+
+    不依赖路径前缀，规避山西/陕西（NMC 拼音均为 shan-xi）以及
+    hunan/ 目录等路径命名不一致导致的串号/漏匹配。
+    """
+    for city, info in stations.items():
+        info_list = info if isinstance(info, list) else [info]
+        for it in info_list:
+            if str(it.get("province", "")) != province:
+                continue
+            return {
+                "matched": True,
+                "kind": "station",
+                "name": city,
+                "province": province,
+                "path": it.get("path", ""),
+                "code": it.get("code", ""),
+                "note": note.format(province=province, city=city),
+            }
+    return None
+
+
+def _match_province_exact(
+    keyword: str,
+    stations: dict[str, Any],
+) -> dict[str, Any] | None:
+    """省份名精确匹配（按 province 字段）。"""
+    if keyword not in _PROVINCE_DIRS:
+        return None
+    found = _first_station_of_province(
+        keyword,
+        stations,
+        note="已匹配「{province}」省首个雷达站：{city}",
+    )
+    if found:
+        return found
+    return {"matched": False, "reason": "no_province_station", "keyword": keyword}
+
+
+def _match_province_pinyin(
+    keyword: str,
+    stations: dict[str, Any],
+) -> dict[str, Any] | None:
+    """省份拼音匹配（如 beijing → 北京，命中该省首个站点）。"""
     for prov_name, prov_dir in _PROVINCE_DIRS.items():
         prov_dir_key = _norm_key(prov_dir)
         # 仅允许：完全相等，或关键词是拼音前缀（避免长关键词误命中短拼音）
-        if keyword == prov_dir_key or (
+        if keyword != prov_dir_key and not (
             len(keyword) >= 2 and prov_dir_key.startswith(keyword)
         ):
-            for city, info in stations.items():
-                info_list = info if isinstance(info, list) else [info]
-                for it in info_list:
-                    if str(it.get("path", "")).startswith(
-                        f"/publish/radar/{prov_dir}/"
-                    ):
-                        return {
-                            "matched": True,
-                            "kind": "station",
-                            "name": city,
-                            "province": prov_name,
-                            "path": it.get("path", ""),
-                            "code": it.get("code", ""),
-                            "note": f"已匹配「{prov_name}」省首个雷达站：{city}",
-                        }
-    # 3b. 区域拼图拼音匹配（如 huabei → huabei.html）
+            continue
+        found = _first_station_of_province(
+            prov_name,
+            stations,
+            note="已匹配「{province}」省首个雷达站：{city}",
+        )
+        if found:
+            return found
+    return None
+
+
+def _match_puzzle_pinyin(
+    keyword: str, puzzles: dict[str, Any]
+) -> dict[str, Any] | None:
+    """区域拼图拼音匹配（如 huabei → 华北）。"""
     for name, info in puzzles.items():
         info_dict = info if isinstance(info, dict) else {}
         puzzle_path = str(info_dict.get("path", "") or "")
@@ -235,12 +235,19 @@ def resolve_radar_target(
                 "path": puzzle_path,
                 "code": str(info_dict.get("code", "") or ""),
             }
+    return None
 
-    # 4. 模糊匹配：收集所有候选
+
+def _match_fuzzy(
+    keyword: str,
+    stations: dict[str, Any],
+) -> dict[str, Any] | None:
+    """模糊匹配（拼音子串 / 中文子串），返回首个命中或候选列表。"""
     # 收紧规则：仅允许「关键词是站名/拼音的子串」（单向、关键词更短），
     # 禁止「长关键词包含短站名」的反向匹配，避免「佛罗里达州」误命中「达州」。
-    candidates = []
-    # 4a. 拼音匹配：关键词是页面路径拼音的前缀或子串（关键词长度 >= 2）
+    candidates: list[dict[str, Any]] = []
+
+    # 4a. 拼音匹配：关键词是页面路径拼音的子串（关键词长度 >= 2）
     if len(keyword) >= 2:
         for city, info in stations.items():
             info_list = info if isinstance(info, list) else [info]
@@ -260,16 +267,18 @@ def resolve_radar_target(
     if not candidates and len(keyword) >= 2:
         for city, info in stations.items():
             info_list = info if isinstance(info, list) else [info]
+            if keyword not in _norm_key(city):
+                continue
             for it in info_list:
-                if keyword in _norm_key(city):
-                    candidates.append(
-                        {
-                            "city": city,
-                            "province": it.get("province", ""),
-                            "path": it.get("path", ""),
-                            "code": it.get("code", ""),
-                        }
-                    )
+                candidates.append(
+                    {
+                        "city": city,
+                        "province": it.get("province", ""),
+                        "path": it.get("path", ""),
+                        "code": it.get("code", ""),
+                    }
+                )
+
     if len(candidates) == 1:
         it = candidates[0]
         return {
@@ -281,11 +290,62 @@ def resolve_radar_target(
             "code": it["code"],
         }
     if len(candidates) > 1:
-        return {
-            "matched": False,
-            "reason": "ambiguous",
-            "candidates": candidates,
-        }
+        return {"matched": False, "reason": "ambiguous", "candidates": candidates}
+    return None
+
+
+def resolve_radar_target(
+    keyword: str,
+) -> dict[str, Any]:
+    """解析雷达查询关键词，返回目标信息。
+
+    支持匹配（按优先级）：
+    - 区域拼图：全国 / 华北 / 东北 / 华东 / 华中 / 华南 / 西南 / 西北（含拼音）
+    - 城市名：北京 / 大兴 / 石家庄 ...
+    - 省份名：河北 / 山西 / 陕西 ...（按站点表 province 字段精确匹配）
+    - 拼音：beijing / daxing / huabei ...
+
+    Returns:
+        dict 包含：matched(bool)、kind("puzzle"|"station")、name、province、path、code、
+        candidates(模糊匹配候选列表)。
+    """
+    data = _get_stations()
+    puzzles = data.get("puzzles") or {}
+    stations = data.get("stations") or {}
+    keyword = _norm_key(keyword)
+
+    if not keyword:
+        return {"matched": False, "reason": "empty", "candidates": []}
+
+    # 1. 区域拼图精确匹配（中文名或拼音文件名）
+    hit = _match_puzzle_exact(keyword, puzzles)
+    if hit is not None:
+        return hit
+
+    # 2. 城市名精确匹配
+    hit = _match_city_exact(keyword, stations)
+    if hit is not None:
+        return hit
+
+    # 3. 省份名精确匹配（按 province 字段）
+    hit = _match_province_exact(keyword, stations)
+    if hit is not None:
+        return hit
+
+    # 3a. 省份拼音目录匹配
+    hit = _match_province_pinyin(keyword, stations)
+    if hit is not None:
+        return hit
+
+    # 3b. 区域拼图拼音匹配
+    hit = _match_puzzle_pinyin(keyword, puzzles)
+    if hit is not None:
+        return hit
+
+    # 4. 模糊匹配（拼音子串 / 中文子串）
+    hit = _match_fuzzy(keyword, stations)
+    if hit is not None:
+        return hit
 
     return {"matched": False, "reason": "no_match", "keyword": keyword}
 
@@ -321,30 +381,30 @@ def build_radar_image_result(
     }
 
 
-def build_radar_gif_result(
+def _degraded_single_result(
     *,
     target: dict[str, Any],
-    frames: list[bytes],
+    image_bytes: bytes,
+    label: str,
     times: list[str],
+    frames_count: int,
 ) -> dict[str, Any]:
-    """用多帧合成循环 GIF 并返回结果。"""
-    label = f"{target.get('name', '')}" + (
-        f"（{target.get('province', '')}）" if target.get("province") else ""
-    )
-    if not frames:
-        return {"success": False, "error": "无可用雷达图像帧"}
-    if len(frames) < MIN_GIF_FRAMES:
-        # 帧数过少，降级为单图
-        return {
-            "success": True,
-            "kind": target.get("kind", "station"),
-            "name": label,
-            "time": _format_time_label(times[0]) if times else "",
-            "image_base64": base64.b64encode(frames[0]).decode(),
-            "degraded": True,
-            "frames": len(frames),
-        }
+    """帧数不足时降级为单图结果（取最新一帧，即时间序列最后一个）。"""
+    return {
+        "success": True,
+        "kind": target.get("kind", "station"),
+        "name": label,
+        "time": _format_time_label(times[-1]) if times else "",
+        "image_base64": base64.b64encode(image_bytes).decode(),
+        "degraded": True,
+        "frames": frames_count,
+    }
 
+
+def _render_gif_sync(
+    frames: list[bytes],
+) -> bytes | None:
+    """在独立线程中同步合成循环 GIF（Pillow CPU 密集操作）。"""
     pil_frames = []
     for data in frames:
         try:
@@ -353,20 +413,8 @@ def build_radar_gif_result(
             pil_frames.append(img)
         except Exception as e:
             logger.warning(f"[灾害预警] 雷达帧解析失败: {e}")
-
     if not pil_frames:
-        return {"success": False, "error": "雷达图像帧解析失败"}
-    if len(pil_frames) < MIN_GIF_FRAMES:
-        # 有效帧不足，仍降级单图
-        return {
-            "success": True,
-            "kind": target.get("kind", "station"),
-            "name": label,
-            "time": _format_time_label(times[0]) if times else "",
-            "image_base64": base64.b64encode(frames[0]).decode(),
-            "degraded": True,
-            "frames": len(frames),
-        }
+        return None
 
     buf = io.BytesIO()
     # 统一各帧尺寸，保证 GIF 可正常播放
@@ -385,13 +433,57 @@ def build_radar_gif_result(
         loop=0,
         optimize=False,
     )
-    gif_bytes = buf.getvalue()
+    return buf.getvalue()
+
+
+async def _render_gif(frames: list[bytes]) -> bytes | None:
+    """异步包装 GIF 合成，避免阻塞事件循环线程。"""
+    return await asyncio.to_thread(_render_gif_sync, frames)
+
+
+async def build_radar_gif_result(
+    *,
+    target: dict[str, Any],
+    frames: list[bytes],
+    times: list[str],
+) -> dict[str, Any]:
+    """用多帧合成循环 GIF 并返回结果。
+
+    times 与 frames 必须按同一帧序对应（由调用方保证）。
+    降级单图时取最新一帧（时间序列最后一个）。
+    """
+    label = f"{target.get('name', '')}" + (
+        f"（{target.get('province', '')}）" if target.get("province") else ""
+    )
+    if not frames:
+        return {"success": False, "error": "无可用雷达图像帧"}
+    if len(frames) < MIN_GIF_FRAMES:
+        return _degraded_single_result(
+            target=target,
+            image_bytes=frames[-1],
+            label=label,
+            times=times,
+            frames_count=len(frames),
+        )
+
+    gif_bytes = await _render_gif(frames)
+    if gif_bytes is None:
+        # 有效帧不足，降级为单图（取最新帧）
+        return _degraded_single_result(
+            target=target,
+            image_bytes=frames[-1],
+            label=label,
+            times=times,
+            frames_count=len(frames),
+        )
+
+    # GIF 由 frames 合成，时间标签取序列最后一个（最新时次）
     return {
         "success": True,
         "kind": target.get("kind", "station"),
         "name": label,
-        "time": _format_time_label(times[0]) if times else "",
-        "frames": len(pil_frames),
+        "time": _format_time_label(times[-1]) if times else "",
+        "frames": len(frames),
         "image_base64": base64.b64encode(gif_bytes).decode(),
     }
 
@@ -404,8 +496,9 @@ def build_radar_list_text() -> str:
 
     lines = ["📡 气象雷达站点列表", ""]
     lines.append("【区域拼图】")
-    for name in ["全国", "华北", "东北", "华东", "华中", "华南", "西南", "西北"]:
-        if name in puzzles:
+    for name, info in puzzles.items():
+        info_dict = info if isinstance(info, dict) else {}
+        if info_dict.get("path"):
             lines.append(f"  • {name}")
     lines.append("")
 
@@ -478,12 +571,14 @@ async def query_radar_gif(
     selected = list(reversed(urls[:frames]))
     # 统一取原图（去掉 medium）
     selected = [client.strip_medium(u) for u in selected]
-    data_list = await client.download_images(selected)
-    if not data_list:
+    # 下载帧并保留 URL 配对，避免失败帧导致时间标签错位
+    pairs = await client.download_frames(selected)
+    if not pairs:
         return {"success": False, "error": "雷达动图帧下载失败"}
 
-    times = [NmcRadarClient.parse_time_from_url(u) for u in selected]
-    return build_radar_gif_result(target=target, frames=data_list, times=times)
+    data_list = [d for _, d in pairs]
+    times = [NmcRadarClient.parse_time_from_url(u) for u, _ in pairs]
+    return await build_radar_gif_result(target=target, frames=data_list, times=times)
 
 
 async def query_radar_list() -> dict[str, Any]:

--- a/main.py
+++ b/main.py
@@ -157,6 +157,9 @@ class DisasterWarningPlugin(Star):
 • /灾害预警统计 - 查看详细的事件统计报告
 • /灾害预警统计清除 - 清除所有统计信息 (仅管理员)
 • /灾害预警推送开关 - 开启或关闭当前会话的推送 (仅管理员)
+• /雷达 <名称> - 查询最新一帧气象雷达图（如：/雷达 北京、/雷达 全国）
+• /雷达动图 <名称> - 查询最近多帧合成循环动图（如：/雷达动图 北京）
+• /雷达列表 - 查看全部雷达站点列表
 • /灾害预警模拟 <纬度> <经度> <震级> [深度] [数据源] - 模拟地震事件
 • /灾害预警配置 查看 [全局|当前|会话UMO] - 查看配置（会话模式返回差异覆写）(仅管理员)
 • /灾害预警日志 - 查看原始消息日志统计摘要 (仅管理员)
@@ -401,6 +404,28 @@ class DisasterWarningPlugin(Star):
             strike=strike,
             dip=dip,
             rake=rake,
+        ):
+            yield result
+
+    @filter.command("雷达列表")
+    async def radar_list(self, event: AstrMessageEvent):
+        """查看全部气象雷达站点列表"""
+        async for result in self._query_command_service.handle_query_radar_list(event):
+            yield result
+
+    @filter.command("雷达")
+    async def radar_image(self, event: AstrMessageEvent, name: str = None):
+        """查询最新一帧气象雷达图"""
+        async for result in self._query_command_service.handle_query_radar(
+            event, name=name
+        ):
+            yield result
+
+    @filter.command("雷达动图")
+    async def radar_gif(self, event: AstrMessageEvent, name: str = None):
+        """查询最近多帧合成循环动图"""
+        async for result in self._query_command_service.handle_query_radar_gif(
+            event, name=name
         ):
             yield result
 

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -29,6 +29,7 @@ from ...core.message.presenters.weather_alarm_code_map import (
 from ...core.message.push.message_build_service import MessageBuildService
 from ...core.message.render.beachball_renderer import BeachballRenderer
 from ...core.message.render.jma_hypo_renderer import JmaHypoRenderer
+from ...core.network.http.nmc_radar_client import NmcRadarClient
 from ...core.services.query.jma_hypo_query_presenter import (
     build_jma_hypo_list_text,
     build_jma_hypo_plot_caption,
@@ -36,6 +37,13 @@ from ...core.services.query.jma_hypo_query_presenter import (
 from ...core.services.query.jma_hypo_query_service import (
     query_jma_hypo_list,
     query_jma_hypo_plot,
+)
+from ...core.services.query.radar_query_service import (
+    format_candidates_text,
+    query_radar_gif,
+    query_radar_image,
+    query_radar_list,
+    resolve_radar_target,
 )
 from ...core.services.query.typhoon_query_parser import DETAIL_CURRENT, DETAIL_FULL
 from ...core.services.query.typhoon_query_presenter import attach_summary_text
@@ -1258,3 +1266,167 @@ class PluginQueryCommandService(CommandTelemetryMixin):
         except Exception as e:
             logger.error(f"[灾害预警] /snet 查询失败: {e}\n{traceback.format_exc()}")
             yield _quoted_plain_result(f"❌ S-Net 查询失败: {e}")
+
+    async def handle_query_radar(
+        self,
+        event,
+        name: str | None = None,
+    ):
+        """处理 /雷达 <名称> 命令：查询最新一帧雷达图。
+
+        支持关键词：区域拼图（全国/华北等）、城市名、省份名、拼音。
+        """
+        try:
+            if not name or not str(name).strip():
+                yield quoted_plain_result(
+                    self.plugin,
+                    event,
+                    "用法：/雷达 <雷达名称>\n示例：/雷达 北京、/雷达 全国\n可用站点见 /雷达列表",
+                )
+                return
+
+            target = resolve_radar_target(str(name).strip())
+            if not target.get("matched"):
+                reason = target.get("reason", "")
+                if reason == "ambiguous":
+                    yield quoted_plain_result(
+                        self.plugin,
+                        event,
+                        format_candidates_text(target.get("candidates") or []),
+                    )
+                else:
+                    yield quoted_plain_result(
+                        self.plugin,
+                        event,
+                        f"❌ 未找到匹配的雷达站「{name}」，可用 /雷达列表 查看全部站点。",
+                    )
+                return
+
+            client = NmcRadarClient()
+            try:
+                result = await query_radar_image(client=client, target=target)
+            finally:
+                await client.close()
+
+            if not result.get("success"):
+                yield quoted_plain_result(
+                    self.plugin,
+                    event,
+                    f"❌ 雷达图查询失败：{result.get('error', '未知错误')}",
+                )
+                return
+
+            image_comp = Comp.Image.fromBase64(result["image_base64"])
+
+            await self._track_command_feature(
+                "command_query_radar",
+                {
+                    "success": True,
+                    "keyword": str(name).strip(),
+                    "target": result.get("name"),
+                },
+            )
+
+            # 只发送雷达图片，不附带文字说明
+            yield event.chain_result(
+                self.plugin._with_quote_reply(
+                    event,
+                    [image_comp],
+                )
+            )
+        except Exception as e:
+            logger.error(f"[灾害预警] /雷达 查询失败: {e}\n{traceback.format_exc()}")
+            yield quoted_plain_result(self.plugin, event, f"❌ 雷达图查询失败: {e}")
+
+    async def handle_query_radar_gif(
+        self,
+        event,
+        name: str | None = None,
+    ):
+        """处理 /雷达动图 <名称> 命令：查询最近多帧并合成循环 GIF。"""
+        try:
+            if not name or not str(name).strip():
+                yield quoted_plain_result(
+                    self.plugin,
+                    event,
+                    "用法：/雷达动图 <雷达名称>\n示例：/雷达动图 北京、/雷达动图 全国",
+                )
+                return
+
+            target = resolve_radar_target(str(name).strip())
+            if not target.get("matched"):
+                reason = target.get("reason", "")
+                if reason == "ambiguous":
+                    yield quoted_plain_result(
+                        self.plugin,
+                        event,
+                        format_candidates_text(target.get("candidates") or []),
+                    )
+                else:
+                    yield quoted_plain_result(
+                        self.plugin,
+                        event,
+                        f"❌ 未找到匹配的雷达站「{name}」，可用 /雷达列表 查看全部站点。",
+                    )
+                return
+
+            client = NmcRadarClient()
+            try:
+                result = await query_radar_gif(client=client, target=target)
+            finally:
+                await client.close()
+
+            if not result.get("success"):
+                yield quoted_plain_result(
+                    self.plugin,
+                    event,
+                    f"❌ 雷达动图查询失败：{result.get('error', '未知错误')}",
+                )
+                return
+
+            image_comp = Comp.Image.fromBase64(result["image_base64"])
+
+            await self._track_command_feature(
+                "command_query_radar_gif",
+                {
+                    "success": True,
+                    "keyword": str(name).strip(),
+                    "frames": result.get("frames"),
+                },
+            )
+
+            # 只发送雷达动图，不附带文字说明
+            yield event.chain_result(
+                self.plugin._with_quote_reply(
+                    event,
+                    [image_comp],
+                )
+            )
+        except Exception as e:
+            logger.error(
+                f"[灾害预警] /雷达动图 查询失败: {e}\n{traceback.format_exc()}"
+            )
+            yield quoted_plain_result(self.plugin, event, f"❌ 雷达动图查询失败: {e}")
+
+    async def handle_query_radar_list(self, event):
+        """处理 /雷达列表 命令：输出全部雷达站点。"""
+        try:
+            result = await query_radar_list()
+            if not result.get("success"):
+                yield quoted_plain_result(
+                    self.plugin,
+                    event,
+                    f"❌ 雷达列表查询失败：{result.get('error', '未知错误')}",
+                )
+                return
+
+            await self._track_command_feature(
+                "command_query_radar_list",
+                {"success": True},
+            )
+            yield quoted_plain_result(self.plugin, event, result.get("text", ""))
+        except Exception as e:
+            logger.error(
+                f"[灾害预警] /雷达列表 查询失败: {e}\n{traceback.format_exc()}"
+            )
+            yield quoted_plain_result(self.plugin, event, f"❌ 雷达列表查询失败: {e}")

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -1322,8 +1322,7 @@ class PluginQueryCommandService(CommandTelemetryMixin):
                 "command_query_radar",
                 {
                     "success": True,
-                    "keyword": str(name).strip(),
-                    "target": result.get("name"),
+                    "kind": result.get("kind", "station"),
                 },
             )
 
@@ -1390,8 +1389,9 @@ class PluginQueryCommandService(CommandTelemetryMixin):
                 "command_query_radar_gif",
                 {
                     "success": True,
-                    "keyword": str(name).strip(),
+                    "kind": result.get("kind", "station"),
                     "frames": result.get("frames"),
+                    "degraded": bool(result.get("degraded")),
                 },
             )
 

--- a/resources/radar_stations.json
+++ b/resources/radar_stations.json
@@ -1,0 +1,1104 @@
+{
+  "version": 1,
+  "puzzles": {
+    "全国": {
+      "path": "/publish/radar/chinaall.html",
+      "code": "ACHN"
+    },
+    "东北": {
+      "path": "/publish/radar/dongbei.html",
+      "code": "ANEC"
+    },
+    "华中": {
+      "path": "/publish/radar/huazhong.html",
+      "code": "ACCN"
+    },
+    "华东": {
+      "path": "/publish/radar/huadong.html",
+      "code": "AECN"
+    },
+    "西北": {
+      "path": "/publish/radar/xibei.html",
+      "code": "ANWC"
+    },
+    "华南": {
+      "path": "/publish/radar/huanan.html",
+      "code": "ASCN"
+    },
+    "华北": {
+      "path": "/publish/radar/huabei.html",
+      "code": "ANCN"
+    },
+    "西南": {
+      "path": "/publish/radar/xinan.html",
+      "code": "ASWC"
+    }
+  },
+  "stations": {
+    "大兴": {
+      "province": "北京",
+      "path": "/publish/radar/bei-jing/da-xing.htm",
+      "code": "AZ9010"
+    },
+    "塘沽": {
+      "province": "天津",
+      "path": "/publish/radar/tian-jin/tian-jin.htm",
+      "code": "AZ9220"
+    },
+    "石家庄": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/shi-jia-zhuang.htm",
+      "code": "AZ9311"
+    },
+    "太原": {
+      "province": "山西",
+      "path": "/publish/radar/shan-xi/tai-yuan.htm",
+      "code": "AZ9351"
+    },
+    "鄂尔多斯": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/e-er-duo-si.htm",
+      "code": "AZ9477"
+    },
+    "沈阳": {
+      "province": "辽宁",
+      "path": "/publish/radar/liao-ning/shen-yang.htm",
+      "code": "AZ9240"
+    },
+    "长春": {
+      "province": "吉林",
+      "path": "/publish/radar/ji-lin/chang-chun.htm",
+      "code": "AZ9431"
+    },
+    "哈尔滨": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/ha-er-bin.htm",
+      "code": "AZ9451"
+    },
+    "青浦": {
+      "province": "上海",
+      "path": "/publish/radar/shang-hai/qing-pu.htm",
+      "code": "AZ9002"
+    },
+    "南京": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/nan-jing.htm",
+      "code": "AZ9250"
+    },
+    "杭州": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/hang-zhou.htm",
+      "code": "AZ9571"
+    },
+    "合肥": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/he-fei.htm",
+      "code": "AZ9551"
+    },
+    "福州": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/fu-zhou.htm",
+      "code": "AZ9591"
+    },
+    "南昌": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/nan-chang.htm",
+      "code": "AZ9791"
+    },
+    "济南": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/ji-nan.htm",
+      "code": "AZ9531"
+    },
+    "商丘": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/shang-qiu.htm",
+      "code": "AZ9370"
+    },
+    "武汉": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/wu-han.htm",
+      "code": "AZ9270"
+    },
+    "长沙": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/chang-sha.htm",
+      "code": "AZ9731"
+    },
+    "桂林": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/gui-lin.htm",
+      "code": "AZ9773"
+    },
+    "海口": {
+      "province": "海南",
+      "path": "/publish/radar/hai-nan/hai-kou.htm",
+      "code": "AZ9898"
+    },
+    "重庆": {
+      "province": "重庆",
+      "path": "/publish/radar/chong-qing/chong-qing.htm",
+      "code": "AZ9230"
+    },
+    "成都": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/cheng-du.htm",
+      "code": "AZ9280"
+    },
+    "贵阳": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/gui-yang.htm",
+      "code": "AZ9851"
+    },
+    "拉萨": {
+      "province": "西藏",
+      "path": "/publish/radar/xi-cang/la-sa.htm",
+      "code": "AZ9891"
+    },
+    "西安": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/xi-an.htm",
+      "code": "AZ9290"
+    },
+    "兰州": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/lan-zhou.htm",
+      "code": "AZ9931"
+    },
+    "西宁": {
+      "province": "青海",
+      "path": "/publish/radar/qing-hai/xi-ning.htm",
+      "code": "AZ9971"
+    },
+    "银川": {
+      "province": "宁夏",
+      "path": "/publish/radar/ning-xia/yin-chuan.htm",
+      "code": "AZ9951"
+    },
+    "三明": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/san-ming.htm",
+      "code": "AZ9598"
+    },
+    "齐齐哈尔": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/qi-qi-ha-er.htm",
+      "code": "AZ9452"
+    },
+    "郴州": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/chen-zhou.htm",
+      "code": "AZ9735"
+    },
+    "黔江": {
+      "province": "重庆",
+      "path": "/publish/radar/chong-qing/qian-jiang.htm",
+      "code": "AZ9091"
+    },
+    "滨州": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/bin-zhou.htm",
+      "code": "AZ9543"
+    },
+    "丽水": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/li-shui.htm",
+      "code": "AZ9578"
+    },
+    "建阳": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/jian-yang.htm",
+      "code": "AZ9599"
+    },
+    "九江": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/jiu-jiang.htm",
+      "code": "AZ9792"
+    },
+    "邯郸": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/han-dan.htm",
+      "code": "AZ9310"
+    },
+    "阿尔山": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/aershan.html",
+      "code": "AZ9023"
+    },
+    "临汾": {
+      "province": "山西",
+      "path": "/publish/radar/shan-xi/lin-fen.htm",
+      "code": "AZ9357"
+    },
+    "佳木斯": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/jia-mu-si.htm",
+      "code": "AZ9454"
+    },
+    "泉州": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/quan-zhou.htm",
+      "code": "AZ9595"
+    },
+    "常德": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/chang-de.htm",
+      "code": "AZ9736"
+    },
+    "万州": {
+      "province": "重庆",
+      "path": "/publish/radar/chong-qing/wan-zhou.htm",
+      "code": "AZ9090"
+    },
+    "漳州": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/zhang-zhou.htm",
+      "code": "AZ9596"
+    },
+    "崇左": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/chong-zuo.html",
+      "code": "AZ9075"
+    },
+    "锡林浩特": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/xilinhaote.html",
+      "code": "AZ9479"
+    },
+    "黔东南": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/qian-dong-nan.htm",
+      "code": "AZ9855"
+    },
+    "营口": {
+      "province": "辽宁",
+      "path": "/publish/radar/liao-ning/ying-kou.htm",
+      "code": "AZ9417"
+    },
+    "平顶山": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/ping-ding-shan.htm",
+      "code": "AZ9375"
+    },
+    "盐城": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/yan-cheng.htm",
+      "code": "AZ9515"
+    },
+    "黑河": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/hei-he.htm",
+      "code": "AZ9456"
+    },
+    "徐州": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/xu-zhou.htm",
+      "code": "AZ9516"
+    },
+    "建三江": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/jian-san-jiang.htm",
+      "code": "AZ9085"
+    },
+    "黑瞎子岛": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/hei-xia-zi-dao.htm",
+      "code": "AZ9012"
+    },
+    "南充": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/nan-chong.htm",
+      "code": "AZ9817"
+    },
+    "厦门": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/xia-men.htm",
+      "code": "AZ9592"
+    },
+    "潍坊": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/wei-fang.htm",
+      "code": "AZ9536"
+    },
+    "恩施": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/en-shi.htm",
+      "code": "AZ9718"
+    },
+    "长治": {
+      "province": "山西",
+      "path": "/publish/radar/shan-xi/chang-zhi.htm",
+      "code": "AZ9355"
+    },
+    "吕梁": {
+      "province": "山西",
+      "path": "/publish/radar/shan-xi/lv-liang.htm",
+      "code": "AZ9358"
+    },
+    "南阳": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/nan-yang.htm",
+      "code": "AZ9377"
+    },
+    "吴忠": {
+      "province": "宁夏",
+      "path": "/publish/radar/ning-xia/wu-zhong.htm",
+      "code": "AZ9953"
+    },
+    "铜陵": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/tong-ling.htm",
+      "code": "AZ9562"
+    },
+    "荆州": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/jing-zhou.htm",
+      "code": "AZ9716"
+    },
+    "湘潭": {
+      "province": "湖南",
+      "path": "/publish/radar/hunan/xiangtan.html",
+      "code": "AZ9732"
+    },
+    "张掖": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/zhang-ye.htm",
+      "code": "AZ9936"
+    },
+    "濮阳": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/pu-yang.htm",
+      "code": "AZ9393"
+    },
+    "景德镇": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/jing-de-zhen.htm",
+      "code": "AZ9798"
+    },
+    "商洛": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/shang-luo.htm",
+      "code": "AZ9914"
+    },
+    "辽源": {
+      "province": "吉林",
+      "path": "/publish/radar/ji-lin/liao-yuan.htm",
+      "code": "AZ9437"
+    },
+    "舟山": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/zhou-shan.htm",
+      "code": "AZ9580"
+    },
+    "白山": {
+      "province": "吉林",
+      "path": "/publish/radar/ji-lin/bai-shan.htm",
+      "code": "AZ9439"
+    },
+    "沧州": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/cang-zhou.htm",
+      "code": "AZ9317"
+    },
+    "大连": {
+      "province": "辽宁",
+      "path": "/publish/radar/liao-ning/da-lian.htm",
+      "code": "AZ9411"
+    },
+    "临河": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/lin-he.htm",
+      "code": "AZ9478"
+    },
+    "衢州": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/qu-zhou.htm",
+      "code": "AZ9570"
+    },
+    "抚州": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/fu-zhou.htm",
+      "code": "AZ9794"
+    },
+    "宁德": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/ning-de.htm",
+      "code": "AZ9593"
+    },
+    "永州": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/yong-zhou.htm",
+      "code": "AZ9746"
+    },
+    "西峰": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/xi-feng.htm",
+      "code": "AZ9934"
+    },
+    "宜宾": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/yi-bin.htm",
+      "code": "AZ9831"
+    },
+    "驻马店": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/zhu-ma-dian.htm",
+      "code": "AZ9396"
+    },
+    "烟台": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/yan-tai.htm",
+      "code": "AZ9535"
+    },
+    "河池": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/he-chi.htm",
+      "code": "AZ9778"
+    },
+    "日喀则": {
+      "province": "西藏",
+      "path": "/publish/radar/xi-cang/ri-ka-ze.htm",
+      "code": "AZ9892"
+    },
+    "都匀": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/dou-yun.htm",
+      "code": "AZ9854"
+    },
+    "六盘水": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/liu-pan-shui.htm",
+      "code": "AZ9858"
+    },
+    "信阳": {
+      "province": "河南",
+      "path": "/publish/radar/henan/xinyang.html",
+      "code": "AZ9376"
+    },
+    "金华": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/jin-hua.htm",
+      "code": "AZ9579"
+    },
+    "涪陵": {
+      "province": "重庆",
+      "path": "/publish/radar/chong-qing/pei-ling.htm",
+      "code": "AZ9093"
+    },
+    "嵊泗": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/cheng-si.htm",
+      "code": "AZ9041"
+    },
+    "永川": {
+      "province": "重庆",
+      "path": "/publish/radar/chong-qing/yong-chuan.htm",
+      "code": "AZ9092"
+    },
+    "天水": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/tian-shui.htm",
+      "code": "AZ9938"
+    },
+    "朝阳": {
+      "province": "辽宁",
+      "path": "/publish/radar/liao-ning/chao-yang.htm",
+      "code": "AZ9421"
+    },
+    "宝鸡": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/bao-ji.htm",
+      "code": "AZ9917"
+    },
+    "衡阳": {
+      "province": "湖南",
+      "path": "/publish/radar/hunan/hengyang.html",
+      "code": "AZ9734"
+    },
+    "那曲": {
+      "province": "西藏",
+      "path": "/publish/radar/xi-cang/na-qu.htm",
+      "code": "AZ9896"
+    },
+    "岳阳": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/yue-yang.htm",
+      "code": "AZ9730"
+    },
+    "马鞍山": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/ma-an-shan.htm",
+      "code": "AZ9555"
+    },
+    "遵义": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/zun-yi.htm",
+      "code": "AZ9852"
+    },
+    "兴义": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/xing-yi.htm",
+      "code": "AZ9859"
+    },
+    "毕节": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/bi-jie.htm",
+      "code": "AZ9857"
+    },
+    "汉中": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/han-zhong.htm",
+      "code": "AZ9916"
+    },
+    "三沙": {
+      "province": "海南",
+      "path": "/publish/radar/hai-nan/san-sha.htm",
+      "code": "AZ9071"
+    },
+    "铜仁": {
+      "province": "贵州",
+      "path": "/publish/radar/gui-zhou/tong-ren.htm",
+      "code": "AZ9856"
+    },
+    "南汇": {
+      "province": "上海",
+      "path": "/publish/radar/shang-hai/nan-hui.htm",
+      "code": "AZ9210"
+    },
+    "呼和浩特": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/hu-he-hao-te.htm",
+      "code": "AZ9471"
+    },
+    "临沂": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/lin-yi.htm",
+      "code": "AZ9539"
+    },
+    "雅安": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/ya-an.htm",
+      "code": "AZ9835"
+    },
+    "西昌": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/xi-chang.htm",
+      "code": "AZ9834"
+    },
+    "上饶": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/shang-rao.htm",
+      "code": "AZ9793"
+    },
+    "麻城": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/ma-cheng.htm",
+      "code": "AZ9713"
+    },
+    "赣州": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/gan-zhou.htm",
+      "code": "AZ9797"
+    },
+    "十堰": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/shi-yan.htm",
+      "code": "AZ9719"
+    },
+    "柳州": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/liu-zhou.htm",
+      "code": "AZ9772"
+    },
+    "南宁": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/nan-ning.htm",
+      "code": "AZ9771"
+    },
+    "安庆": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/an-qing.htm",
+      "code": "AZ9556"
+    },
+    "林芝": {
+      "province": "西藏",
+      "path": "/publish/radar/xi-cang/lin-zhi.htm",
+      "code": "AZ9894"
+    },
+    "宜昌": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/yi-chang.htm",
+      "code": "AZ9717"
+    },
+    "随州": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/sui-zhou.htm",
+      "code": "AZ9722"
+    },
+    "青岛": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/qing-dao.htm",
+      "code": "AZ9532"
+    },
+    "达州": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/da-zhou.htm",
+      "code": "AZ9818"
+    },
+    "通辽": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/tong-liao.htm",
+      "code": "AZ9475"
+    },
+    "邵阳": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/shao-yang.htm",
+      "code": "AZ9739"
+    },
+    "北海": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/bei-hai.htm",
+      "code": "AZ9779"
+    },
+    "湖州": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/hu-zhou.htm",
+      "code": "AZ9572"
+    },
+    "广元": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/guang-yuan.htm",
+      "code": "AZ9839"
+    },
+    "宁波": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/ning-bo.htm",
+      "code": "AZ9574"
+    },
+    "泰山": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/tai-shan.htm",
+      "code": "AZ9538"
+    },
+    "满洲里": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/man-zhou-li.htm",
+      "code": "AZ9021"
+    },
+    "固原": {
+      "province": "宁夏",
+      "path": "/publish/radar/ning-xia/gu-yuan.htm",
+      "code": "AZ9954"
+    },
+    "嘉峪关": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/jia-yu-guan.htm",
+      "code": "AZ9937"
+    },
+    "连云港": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/lian-yun-gang.htm",
+      "code": "AZ9518"
+    },
+    "常州": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/chang-zhou.htm",
+      "code": "AZ9519"
+    },
+    "襄阳": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/xiang-yang.htm",
+      "code": "AZ9710"
+    },
+    "张家口": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/zhang-jia-kou.htm",
+      "code": "AZ9313"
+    },
+    "怀化": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/huai-hua.htm",
+      "code": "AZ9745"
+    },
+    "洛阳": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/luo-yang.htm",
+      "code": "AZ9379"
+    },
+    "龙岩": {
+      "province": "福建",
+      "path": "/publish/radar/fu-jian/long-yan.htm",
+      "code": "AZ9597"
+    },
+    "安康": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/an-kang.htm",
+      "code": "AZ9915"
+    },
+    "乐山": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/le-shan.htm",
+      "code": "AZ9833"
+    },
+    "百色": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/bai-se.htm",
+      "code": "AZ9776"
+    },
+    "阜阳": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/fu-yang.htm",
+      "code": "AZ9558"
+    },
+    "承德": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/cheng-de.htm",
+      "code": "AZ9314"
+    },
+    "防城港": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/fang-cheng-gang.htm",
+      "code": "AZ9770"
+    },
+    "郑州": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/zheng-zhou.htm",
+      "code": "AZ9371"
+    },
+    "济宁": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/ji-ning.html",
+      "code": "AZ9537"
+    },
+    "牡丹江": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/mu-dan-jiang.htm",
+      "code": "AZ9453"
+    },
+    "三门峡": {
+      "province": "河南",
+      "path": "/publish/radar/he-nan/san-men-xia.htm",
+      "code": "AZ9398"
+    },
+    "荣成": {
+      "province": "山东",
+      "path": "/publish/radar/shan-dong/rong-cheng.htm",
+      "code": "AZ9631"
+    },
+    "玉林": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/yu-lin.htm",
+      "code": "AZ9775"
+    },
+    "神农架": {
+      "province": "湖北",
+      "path": "/publish/radar/hu-bei/shen-nong-jia.htm",
+      "code": "AZ9060"
+    },
+    "吉安": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/ji-an.htm",
+      "code": "AZ9796"
+    },
+    "泰州": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/tai-zhou.htm",
+      "code": "AZ9523"
+    },
+    "温州": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/wen-zhou.htm",
+      "code": "AZ9577"
+    },
+    "延吉": {
+      "province": "吉林",
+      "path": "/publish/radar/ji-lin/yan-ji.htm",
+      "code": "AZ9433"
+    },
+    "蚌埠": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/beng-bu.htm",
+      "code": "AZ9552"
+    },
+    "南通": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/nan-tong.htm",
+      "code": "AZ9513"
+    },
+    "张家界": {
+      "province": "湖南",
+      "path": "/publish/radar/hu-nan/zhang-jia-jie.htm",
+      "code": "AZ9744"
+    },
+    "伊春": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/yi-chun.htm",
+      "code": "AZ9458"
+    },
+    "淮安": {
+      "province": "江苏",
+      "path": "/publish/radar/jiang-su/huai-an.htm",
+      "code": "AZ9517"
+    },
+    "秦皇岛": {
+      "province": "河北",
+      "path": "/publish/radar/he-bei/qin-huang-dao.htm",
+      "code": "AZ9335"
+    },
+    "白城": {
+      "province": "吉林",
+      "path": "/publish/radar/ji-lin/bai-cheng.htm",
+      "code": "AZ9436"
+    },
+    "大同": {
+      "province": "山西",
+      "path": "/publish/radar/shan-xi/da-tong.htm",
+      "code": "AZ9352"
+    },
+    "加格达奇": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/jia-ge-da-qi.htm",
+      "code": "AZ9457"
+    },
+    "宜春": {
+      "province": "江西",
+      "path": "/publish/radar/jiang-xi/yi-chun.htm",
+      "code": "AZ9795"
+    },
+    "梧州": {
+      "province": "广西",
+      "path": "/publish/radar/guang-xi/wu-zhou.htm",
+      "code": "AZ9774"
+    },
+    "绵阳": {
+      "province": "四川",
+      "path": "/publish/radar/si-chuan/mian-yang.htm",
+      "code": "AZ9816"
+    },
+    "甘南": {
+      "province": "甘肃",
+      "path": "/publish/radar/gan-su/gan-nan.htm",
+      "code": "AZ9941"
+    },
+    "延安": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/yan-an.htm",
+      "code": "AZ9911"
+    },
+    "海北": {
+      "province": "青海",
+      "path": "/publish/radar/qing-hai/hai-bei.htm",
+      "code": "AZ9970"
+    },
+    "赤峰": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/chi-feng.htm",
+      "code": "AZ9476"
+    },
+    "集宁": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/jining.html",
+      "code": "AZ9474"
+    },
+    "九三": {
+      "province": "黑龙江",
+      "path": "/publish/radar/hei-long-jiang/jiu-san.htm",
+      "code": "AZ9084"
+    },
+    "黄山": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/huang-shan.htm",
+      "code": "AZ9559"
+    },
+    "海拉尔": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/hai-la-er.htm",
+      "code": "AZ9470"
+    },
+    "霍林郭勒": {
+      "province": "内蒙古",
+      "path": "/publish/radar/nei-meng/huo-lin-guo-le.htm",
+      "code": "AZ9020"
+    },
+    "三亚": {
+      "province": "海南",
+      "path": "/publish/radar/hai-nan/san-ya.htm",
+      "code": "AZ9070"
+    },
+    "榆林": {
+      "province": "陕西",
+      "path": "/publish/radar/shan-xi/yu-lin.htm",
+      "code": "AZ9912"
+    },
+    "宣城": {
+      "province": "安徽",
+      "path": "/publish/radar/an-hui/xuancheng.html",
+      "code": "AZ9563"
+    },
+    "台州": {
+      "province": "浙江",
+      "path": "/publish/radar/zhe-jiang/tai-zhou.htm",
+      "code": "AZ9576"
+    },
+    "广州": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/guang-zhou.htm",
+      "code": "AZ9200"
+    },
+    "梅州": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/mei-zhou.htm",
+      "code": "AZ9753"
+    },
+    "汕头": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/shan-tou.htm",
+      "code": "AZ9754"
+    },
+    "汕尾": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/shan-wei.htm",
+      "code": "AZ9660"
+    },
+    "河源": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/he-yuan.htm",
+      "code": "AZ9762"
+    },
+    "深圳": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/shen-zhen.htm",
+      "code": "AZ9755"
+    },
+    "湛江": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/zhan-jiang.htm",
+      "code": "AZ9759"
+    },
+    "肇庆": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/zhao-qing.htm",
+      "code": "AZ9758"
+    },
+    "茂名": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/mao-ming.htm",
+      "code": ""
+    },
+    "连州": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/lian-zhou.htm",
+      "code": "AZ9763"
+    },
+    "阳江": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/yang-jiang.htm",
+      "code": "AZ9662"
+    },
+    "韶关": {
+      "province": "广东",
+      "path": "/publish/radar/guang-dong/shao-guan.htm",
+      "code": "AZ9751"
+    },
+    "丽江": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/li-jiang.htm",
+      "code": "AZ9888"
+    },
+    "大理": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/da-li.htm",
+      "code": "AZ9872"
+    },
+    "德宏": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/de-hong.htm",
+      "code": "AZ9692"
+    },
+    "思茅": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/si-mao.htm",
+      "code": "AZ9879"
+    },
+    "文山": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/wen-shan.htm",
+      "code": "AZ9876"
+    },
+    "昆明": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/kun-ming.htm",
+      "code": "AZ9871"
+    },
+    "昭通": {
+      "province": "云南",
+      "path": "/publish/radar/yun-nan/zhao-tong.htm",
+      "code": "AZ9870"
+    },
+    "乌鲁木齐": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/wu-lu-mu-qi.htm",
+      "code": "AZ9991"
+    },
+    "五家渠": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/wu-jia-qu.htm",
+      "code": "AZ9081"
+    },
+    "伊宁": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/yi-ning.htm",
+      "code": "AZ9999"
+    },
+    "克拉玛依": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/ke-la-ma-yi.htm",
+      "code": "AZ9990"
+    },
+    "和田": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/he-tian.htm",
+      "code": "AZ9903"
+    },
+    "喀什": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/ka-shen.htm",
+      "code": "AZ9998"
+    },
+    "图木舒克": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/tu-mu-shu-ke.htm",
+      "code": "AZ9082"
+    },
+    "塔斯尔海": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/si-ta-er-hai.htm",
+      "code": "AZ9083"
+    },
+    "奎屯": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/kui-tun.htm",
+      "code": "AZ9080"
+    },
+    "库尔勒": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/ku-er-le.htm",
+      "code": "AZ9996"
+    },
+    "石河子": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/shi-he-zi.htm",
+      "code": "AZ9993"
+    },
+    "阿克苏": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/a-ke-su.htm",
+      "code": "AZ9997"
+    },
+    "阿拉尔": {
+      "province": "新疆",
+      "path": "/publish/radar/xin-jiang/a-la-er.htm",
+      "code": "AZ9086"
+    }
+  }
+}


### PR DESCRIPTION
## 📝 描述 / Description

feat #42 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

在灾害预警插件中新增气象雷达查询功能，包括图片、动图以及站点列表命令，这些功能由全新的 NMC 雷达客户端和查询服务提供支持。

New Features:
- 引入 `/雷达`、`/雷达动图` 和 `/雷达列表` 命令，用于查询最新雷达图像、近期雷达帧生成的 GIF 动画，以及可用的雷达站列表。
- 添加雷达查询服务，用于将用户输入的关键词解析为具体雷达站或区域拼图，并负责图像/GIF 获取以及站点列表的生成。
- 提供面向 NMC 雷达页面的 HTTP 客户端，用于获取雷达图像 URL，并下载各帧以生成单张图片或动图输出。
- 提供雷达站点元数据资源，定义区域拼图和单站条目，用于关键词解析和站点列表展示。

Enhancements:
- 扩展灾害预警帮助信息输出，记录并说明新的雷达相关命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add meteorological radar querying capabilities integrated into the disaster warning plugin, including image, animation, and station listing commands backed by a new NMC radar client and query service.

New Features:
- Introduce /雷达, /雷达动图, and /雷达列表 commands to query latest radar imagery, recent-frame GIF animations, and available radar stations.
- Add a radar query service that resolves user keywords to radar stations or regional mosaics and orchestrates image/GIF retrieval and station listing.
- Provide an HTTP client for the NMC radar pages to fetch radar image URLs and download frames for single-image and animated output.
- Ship a radar station metadata resource defining regional mosaics and single-station entries used for keyword resolution and listing.

Enhancements:
- Extend the disaster warning help output to document the new radar-related commands.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `/雷达`，支持按城市、省份或拼音查询最新雷达图。
  - 新增 `/雷达动图`，支持查看多帧雷达循环图。
  - 新增 `/雷达列表`，提供可查询的雷达站点清单。
  - 支持全国及各区域雷达拼图、模糊匹配和候选提示，并扩大站点覆盖范围。

- **体验优化**
  - 查询失败、站点不明确或图片不足时提供友好提示。
  - 动图生成条件不足或失败时自动返回最新单帧雷达图。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->