### PR TITLE
refactor: 简化配置项、增强浏览器 HTTPS 容错与日志降噪，优化行内导入情况

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,9 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
 - **浏览器页面池大小 (`browser_pool_size`)**:
   - **默认值**: `2`
   - **说明**: 控制后台同时存在的浏览器页面数量。增大此值可提高并发处理能力，但会显著增加内存占用。建议在内存充足 (>2GB) 的服务器上适当调大 (3-5)。
+- **忽略浏览器 HTTPS 证书错误 (`browser_ignore_https_errors`)**:
+  - **默认值**: `false`
+  - **说明**: 仅本地模式生效。当地图瓦片源（如 FAN Studio）证书过期导致底图加载失败（控制台出现 `ERR_CERT_DATE_INVALID`）时，开启后可继续加载底图；注意这会信任自签/过期证书，存在安全风险，请谨慎使用。
 
 ```json
 "message_format": {
@@ -750,7 +753,8 @@ https://obs.nmefc.cn/Warning/TsunamiAdvice/202607111826_2_file/Earthquake_Pos.jp
   "detailed_jma_intensity": false,             // 是否显示全部 JMA 震度区域
   "use_global_quake_card": false,              // 是否启用 GQ 卡片渲染
   "global_quake_template": "Aurora",           // GQ 卡片视觉主题
-  "browser_pool_size": 2                       // 浏览器页面池大小 (默认2)
+  "browser_pool_size": 2,                      // 浏览器页面池大小 (默认2)
+  "browser_ignore_https_errors": false         // 是否忽略瓦片源 HTTPS 证书错误（默认关闭）
 }
 ```
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -45,12 +45,6 @@
             "default": false,
             "hint": "启用后将连接 FAN Studio WebSocket。需配置下方 appId 与 API Key，否则会跳过建连。"
           },
-          "app_id": {
-            "description": "FAN Studio 应用 ID",
-            "type": "string",
-            "default": "97b68b51-ec96-42c3-80d7-83d2bff70d99",
-            "hint": "一般情况下保持默认配置即可，请勿修改。"
-          },
           "api_key": {
             "description": "FAN Studio API Key",
             "type": "string",
@@ -245,12 +239,6 @@
             "default": true,
             "hint": "控制 EQSC 通道是否启用（鉴权、连通性、后续子能力入口）。关闭后所有 EQSC 子能力均不可用。"
           },
-          "base_url": {
-            "description": "EQSC API 基础地址",
-            "type": "string",
-            "default": "https://equake.top",
-            "hint": "EQSC API 的基础URL，默认为官方地址"
-          },
           "refresh_token": {
             "description": "EQSC 访问令牌 (RefreshToken)",
             "type": "string",
@@ -258,84 +246,40 @@
             "hint": "从 EQuake 设置界面获取的访问令牌（以 ARh. 开头），用于创建 AccessToken。请妥善保管，不要泄露。",
             "hidden": true
           },
-          "typhoon": {
-            "description": "启用台风轮询",
-            "type": "bool",
-            "default": true,
-            "hint": "启用后由 EQSC HTTP 独立轮询活跃台风并推送"
-          },
-          "typhoon_poll_interval_seconds": {
-            "description": "台风轮询间隔（秒）",
+          "poll_interval_seconds": {
+            "description": "EQSC 统一轮询间隔（秒）",
             "type": "int",
             "default": 120,
-            "hint": "单位：秒。EQSC 台风列表轮询间隔。",
+            "hint": "单位：秒。EQSC 所有子数据源共用的轮询间隔。建议 60~180 秒，过短可能增加对 EQSC 服务器的请求压力。",
             "slider": {
               "min": 30,
               "max": 600,
               "step": 10
             }
           },
-          "cache_ttl": {
-            "description": "台风数据缓存时间",
-            "type": "int",
-            "hint": "单位：秒。EQSC台风数据的内存缓存有效期，与EQSC更新频率（约5分钟）一致。",
-            "default": 300,
-            "slider": {
-              "min": 60,
-              "max": 3600,
-              "step": 30
-            }
+          "typhoon": {
+            "description": "启用台风轮询",
+            "type": "bool",
+            "default": true,
+            "hint": "启用后由 EQSC HTTP 独立轮询活跃台风并推送。"
           },
           "jma_tsunami": {
             "description": "日本气象厅：津波予報（EQSC）",
             "type": "bool",
             "default": true,
-            "hint": "通过 EQSC HTTP 轮询获取日本气象厅海啸情报，作为 P2P 津波予報的高优先级补充。字段更完整（eventID、震中、区域波高/初波状态等）。"
-          },
-          "jma_tsunami_poll_interval_seconds": {
-            "description": "海啸轮询间隔（秒）",
-            "type": "int",
-            "default": 60,
-            "hint": "单位：秒。EQSC 海啸快照轮询间隔。海啸更新不频繁，建议 30~120 秒。",
-            "slider": {
-              "min": 15,
-              "max": 300,
-              "step": 10
-            }
+            "hint": "通过 EQSC HTTP 轮询获取日本气象厅海啸情报。"
           },
           "jma_tsunami_include_training": {
             "description": "接收海啸训练报",
             "type": "bool",
             "default": false,
-            "hint": "是否推送 EQSC 标记为训练报（isTraining）的海啸情报。默认忽略。"
-          },
-          "tsunami_cache_ttl": {
-            "description": "海啸数据缓存时间",
-            "type": "int",
-            "hint": "单位：秒。EQSC 海啸快照内存缓存有效期，用于短时并发复用；轮询本身会绕过缓存强制刷新。",
-            "default": 60,
-            "slider": {
-              "min": 15,
-              "max": 300,
-              "step": 15
-            }
+            "hint": "是否推送 EQSC 标记为训练报的海啸情报。默认忽略。"
           },
           "china_cenc_intensity_report": {
             "description": "中国地震台网（CENC）：烈度速报（EQSC）",
             "type": "bool",
             "default": true,
             "hint": "通过 EQSC HTTP 轮询获取 CENC 烈度速报。"
-          },
-          "cenc_ir_poll_interval_seconds": {
-            "description": "烈度速报轮询间隔（秒）",
-            "type": "int",
-            "default": 90,
-            "hint": "单位：秒。EQSC CENC 烈度速报列表轮询间隔。速报更新不频繁，建议 60~180 秒。",
-            "slider": {
-              "min": 30,
-              "max": 600,
-              "step": 10
-            }
           }
         }
       },
@@ -349,6 +293,12 @@
             "type": "bool",
             "default": false,
             "hint": "开启后将每分钟轮询 MSIL 瓦片；无触发测站时不会推送"
+          },
+          "include_station_map": {
+            "description": "包含测站分布图",
+            "type": "bool",
+            "default": true,
+            "hint": "开启后将在 S-Net 推送消息中附加测站分布图卡片（需 Playwright）。未安装浏览器时自动降级为纯文本。"
           },
           "poll_interval_seconds": {
             "description": "轮询间隔（秒）",
@@ -917,6 +867,12 @@
           "step": 1
         }
       },
+      "browser_ignore_https_errors": {
+        "description": "忽略浏览器 HTTPS 证书错误（仅本地模式）",
+        "type": "bool",
+        "hint": "默认关闭。当地图瓦片源（如 FAN Studio）证书过期导致底图加载失败时，开启后可继续加载底图；注意这会信任自签/过期证书，存在安全风险，请谨慎使用。",
+        "default": false
+      },
       "detailed_jma_intensity": {
         "description": "详细显示JMA区域震度",
         "type": "bool",
@@ -1077,6 +1033,12 @@
     "type": "object",
     "hint": "配置台风推送的强度、气压、距离与预报路径逼近过滤。",
     "items": {
+      "include_track_map": {
+        "description": "包含台风路径图",
+        "type": "bool",
+        "default": true,
+        "hint": "开启后将在台风推送消息中附加路径图卡片（需 Playwright）。未安装浏览器时自动降级为纯文本。"
+      },
       "show_local_estimation": {
         "description": "显示本地预估信息",
         "type": "bool",
@@ -1495,12 +1457,6 @@
         "type": "bool",
         "hint": "用于分析所有数据源的消息格式",
         "default": false
-      },
-      "raw_message_log_path": {
-        "description": "原始消息日志文件路径",
-        "type": "string",
-        "hint": "相对于插件数据目录",
-        "default": "raw_messages.log"
       },
       "log_max_size_mb": {
         "description": "日志文件最大大小",

--- a/admin/js/components/config/ConfigField.jsx
+++ b/admin/js/components/config/ConfigField.jsx
@@ -26,8 +26,11 @@ function ConfigField({
     // 拼接得到当前字段在配置树中的绝对路径路径标识
     const currentPath = path ? `${path}.${fieldKey}` : fieldKey;
 
-    // 特殊安全防护设计：允许 'web_admin.password' 密码字段即使标记为 hidden 也照常在页面上渲染，但会被强制转换为 password 输入框
-    const allowHiddenPasswordField = currentPath === 'web_admin.password';
+    // 特殊安全防护设计：允许 'web_admin.password' 与 'data_sources.eqsc.refresh_token' 敏感字段
+    // 即使标记为 hidden 也照常在页面上渲染，但会被强制转换为 password 输入框（掩码显示，防泄露）
+    const allowHiddenPasswordField =
+        currentPath === 'web_admin.password' ||
+        currentPath === 'data_sources.eqsc.refresh_token';
     
     // 如果 Schema 不存在，或者是隐藏字段且非受信任的密码字段，则返回 null 不渲染
     if (!schema || (schema.hidden && !allowHiddenPasswordField)) return null;

--- a/admin/js/utils/configSchemaUtils.js
+++ b/admin/js/utils/configSchemaUtils.js
@@ -11,15 +11,18 @@
     // 仅允许全局配置修改的嵌套路径（会话模式隐藏且保存时剥离）
     // S-Net 轮询间隔、EQSC 通道鉴权参数影响全局运行态；
     // eqsc.typhoon 允许会话差异（部分会话只要 Fan，部分要 EQSC 富化）。
+    // 允许会话级覆盖，会话级关闭仅屏蔽该会话内全部子源，不影响全局通道建连。
     const CONFIG_SESSION_GLOBAL_ONLY_PATHS = [
         ['data_sources', 'snet', 'poll_interval_seconds'],
-        ['data_sources', 'eqsc', 'enabled'],
-        ['data_sources', 'eqsc', 'base_url'],
         ['data_sources', 'eqsc', 'refresh_token'],
-        ['data_sources', 'eqsc', 'cache_ttl'],
+        // EQSC 统一轮询间隔影响全局运行态，会话模式隐藏且保存时剥离
+        ['data_sources', 'eqsc', 'poll_interval_seconds'],
         // FAN Studio 鉴权影响全局 WebSocket 建连，会话模式隐藏且保存时剥离
-        ['data_sources', 'fan_studio', 'app_id'],
         ['data_sources', 'fan_studio', 'api_key'],
+        // 浏览器页面池大小影响全局运行态，会话模式隐藏且保存时剥离
+        ['message_format', 'browser_pool_size'],
+        // 是否忽略 HTTPS 证书错误是浏览器启动级配置，会话模式隐藏且保存时剥离
+        ['message_format', 'browser_ignore_https_errors'],
     ];
 
     /**

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -20,14 +20,15 @@ from astrbot.api.star import StarTools
 if TYPE_CHECKING:
     from ..services.telemetry.telemetry_service import TelemetryManager
 
+from ...utils.plugin_logger import plugin_logger
 from ..domain.event_models import EventEnvelope
 from ..message.message_logger import MessageLogger
 from ..message.message_manager import MessagePushManager
-from ..message.push.weather_aggregation_service import WeatherAggregationService
 from ..message.presenters.presenter_registry import (
     get_presenter,
     get_text_presenter_keys,
 )
+from ..message.push.weather_aggregation_service import WeatherAggregationService
 from ..network.event_ingress_dispatch_service import EventIngressDispatchService
 from ..network.source_ingress_side_effect_service import SourceIngressSideEffectService
 from ..network.source_message_router import SourceMessageRouter
@@ -56,7 +57,6 @@ from ..sources.source_catalog import SOURCE_CATALOG
 from ..sources.source_institution_catalog import get_institution_catalog
 from ..storage.session_config_manager import SessionConfigManager
 from ..storage.statistics_manager import StatisticsManager
-from ...utils.plugin_logger import plugin_logger
 from .pipeline.event_pipeline import EventPipeline
 from .runtime.disaster_service_cache import DisasterServiceCacheService
 from .runtime.disaster_service_lifecycle import DisasterServiceLifecycleService

--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 from ..domain.event_models import EventEnvelope
 from ..message.message_logger import MessageLogger
 from ..message.message_manager import MessagePushManager
+from ..message.push.weather_aggregation_service import WeatherAggregationService
 from ..message.presenters.presenter_registry import (
     get_presenter,
     get_text_presenter_keys,
@@ -55,6 +56,7 @@ from ..sources.source_catalog import SOURCE_CATALOG
 from ..sources.source_institution_catalog import get_institution_catalog
 from ..storage.session_config_manager import SessionConfigManager
 from ..storage.statistics_manager import StatisticsManager
+from ...utils.plugin_logger import plugin_logger
 from .pipeline.event_pipeline import EventPipeline
 from .runtime.disaster_service_cache import DisasterServiceCacheService
 from .runtime.disaster_service_lifecycle import DisasterServiceLifecycleService
@@ -205,8 +207,6 @@ class DisasterWarningService:
         self.message_logger.set_silence_checker(self.is_silencing)
         # 静默期事件流日志抑制也需要感知"当前是否处于静默期"，
         # 这样静默结束后事件流日志能立即恢复打印，不会被永久屏蔽。
-        from ...utils.plugin_logger import plugin_logger
-
         plugin_logger.set_silence_checker(self.is_silencing)
         # WebSocket 连接成功日志同样复用静默判定：启动静默期降级为 DEBUG，
         # 静默结束后恢复 INFO，避免建连阶段刷屏同时保留重连成功反馈。
@@ -218,10 +218,6 @@ class DisasterWarningService:
         # 以下服务分别承接事件流水线、生命周期、运行时调度、缓存、状态整理、通知、重连与接入旁路编排，主服务本身只保留高层协调职责。
         self.event_pipeline = EventPipeline(self)  # 事件流处理流水线
         # 气象预警聚合推送服务，注入到事件流水线
-        from ..message.push.weather_aggregation_service import (
-            WeatherAggregationService,
-        )
-
         self._weather_aggregation_service = WeatherAggregationService(self.config)
         self.event_pipeline.set_weather_aggregation_service(
             self._weather_aggregation_service

--- a/core/app/runtime/disaster_service_cache.py
+++ b/core/app/runtime/disaster_service_cache.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -152,8 +153,6 @@ class DisasterServiceCacheService:
             and self.service.statistics_manager._db_initialized
         ):
             try:
-                import asyncio
-
                 loop = asyncio.get_running_loop()
                 loop.create_task(self._restore_eew_query_state_from_db_recent_events())
             except RuntimeError:

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -18,6 +18,7 @@ EQSC 通道级能力（鉴权、保活、健康、熔断）由 EqscChannelServic
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any
 
 from ....utils.plugin_logger import plugin_logger as logger
@@ -167,8 +168,6 @@ class TyphoonEnrichmentService:
     @staticmethod
     def _coerce_datetime(value: Any):
         """尽力把时间字段转换为 datetime，失败则返回 None。"""
-        from datetime import datetime
-
         if value is None:
             return None
         if isinstance(value, datetime):

--- a/core/app/services/typhoon_history_rebuild_service.py
+++ b/core/app/services/typhoon_history_rebuild_service.py
@@ -13,6 +13,7 @@ from astrbot.api import logger
 
 from ...domain.event_models import TyphoonEvent
 from ...domain.typhoon import build_typhoon_event_envelope
+from ...domain.typhoon.typhoon_values import clean_text, to_float
 from ...storage.stats.event_record_factory import EventRecordFactory
 
 
@@ -139,8 +140,6 @@ class TyphoonHistoryRebuildService:
         包含 time / level / wind_speed / pressure / latitude / longitude 等字段。
         节点按时间升序排列（最旧在前），与 event_updates 的 recorded_at ASC 一致。
         """
-        from ...domain.typhoon.typhoon_values import clean_text, to_float
-
         history_track = (
             typhoon.get("historyTrack") or typhoon.get("history_track") or []
         )

--- a/core/message/message_logger.py
+++ b/core/message/message_logger.py
@@ -37,6 +37,9 @@ from .logging.support.p2p_area_mapping_loader import P2PAreaMappingLoader
 class MessageLogger:
     """原始消息格式记录器。"""
 
+    # 原始消息日志文件名（硬编码，不再暴露为用户配置项）。
+    RAW_MESSAGE_LOG_FILE_NAME = "raw_messages.log"
+
     def __init__(self, config: dict[str, Any], plugin_name: str):
         # 消息记录器负责装配日志子系统，并持有共享配置与运行时状态。
         self.config = config
@@ -48,11 +51,9 @@ class MessageLogger:
         )  # 载入 P2P 气象预警区域代码对应表
         debug_config = self.config_accessor.debug_config()
 
-        # 是否启用、文件名、轮转大小与保留份数都由调试配置控制。
+        # 是否启用、轮转大小与保留份数都由调试配置控制。
         self.enabled = debug_config.get("enable_raw_message_logging", False)
-        self.log_file_name = debug_config.get(
-            "raw_message_log_path", "raw_messages.log"
-        )
+        self.log_file_name = self.RAW_MESSAGE_LOG_FILE_NAME
         self.max_size_mb = debug_config.get(
             "log_max_size_mb", 50
         )  # 单个日志文件最大 MB 数

--- a/core/message/presenters/earthquake_presenter.py
+++ b/core/message/presenters/earthquake_presenter.py
@@ -14,6 +14,7 @@ from datetime import timezone as dt_timezone
 
 from ....utils.converters import ScaleConverter
 from ....utils.time_converter import TimeConverter
+from ...domain.earthquake.cmt_normalize import format_fault_type_label
 from ...domain.event_context import EarthquakeDisplayContext
 from ...services.geo.cn_district_intensity_service import (
     CnDistrictIntensityService,
@@ -840,7 +841,6 @@ class FssnCmtPresenter(BasePresenter):
         # 两个节面断层走向、倾角与滑动角
         plane1 = meta.get("nodal_plane1")
         plane2 = meta.get("nodal_plane2")
-        from ...domain.earthquake.cmt_normalize import format_fault_type_label
 
         if plane1:
             lines.append(

--- a/core/message/presenters/weather_constants.py
+++ b/core/message/presenters/weather_constants.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+from .weather_alarm_code_map import resolve_weather_icon_code
+
 WEATHER_EMOJI_MAP = {
     # 一、国家级标准预警（14类）
     "台风": "🌀",
@@ -202,8 +204,6 @@ def _resolve_emoji_from_code(texts) -> str | None:
     Returns:
         精确匹配到的 Emoji；无编码或未命中返回 None。
     """
-    from .weather_alarm_code_map import resolve_weather_icon_code
-
     for item in texts:
         text = str(item or "").strip()
         if not text:

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -215,6 +215,10 @@ class MessageBuildService:
             "map_source": config.get("map_source", "PetalMap矢量图亮"),
             "map_zoom_level": config.get("map_zoom_level", 5),
             "playwright_mode": config.get("playwright_mode", "local"),
+            # 是否忽略 HTTPS 证书错误会直接影响底图能否加载，纳入缓存键避免切换后误用旧图。
+            "ignore_https_errors": bool(
+                config.get("browser_ignore_https_errors", False)
+            ),
             "event_caption": event_caption or "",
         }
         return json.dumps(key_obj, sort_keys=True, ensure_ascii=False)
@@ -371,6 +375,10 @@ class MessageBuildService:
             "map_source": message_format_config.get("map_source", "PetalMap矢量图亮"),
             "map_zoom_level": message_format_config.get("map_zoom_level", 5),
             "playwright_mode": message_format_config.get("playwright_mode", "local"),
+            # 是否忽略 HTTPS 证书错误会直接影响底图能否加载，纳入缓存键避免切换后误用旧图。
+            "ignore_https_errors": bool(
+                message_format_config.get("browser_ignore_https_errors", False)
+            ),
             "timezone": display_timezone,
         }
         return json.dumps(key_obj, sort_keys=True, ensure_ascii=False)
@@ -498,12 +506,15 @@ class MessageBuildService:
         )
 
         # S-Net 测站分布图（替代通用地图）
-        await self._append_snet_map_if_needed(chain, event, source_id=source_id)
+        await self._append_snet_map_if_needed(
+            chain, event, source_id=source_id, active_config=active_config
+        )
         # 台风路径图（EQSC 富化轨迹）
         await self._append_typhoon_map_if_needed(
             chain,
             event,
             message_format_config=message_format_config,
+            active_config=active_config,
         )
         # 地图渲染与插入（S-Net、CMT 跳过，避免重复或误附加通用地图）
         if source_id not in ("snet_msil", "fssn_cmt_fanstudio"):
@@ -640,9 +651,21 @@ class MessageBuildService:
         event: EventEnvelope,
         *,
         source_id: str,
+        active_config: dict[str, Any],
     ) -> None:
         """为 S-Net 事件附加测站分布图（走 RenderImageCache，避免重复截图）。"""
         if source_id != "snet_msil":
+            return
+        # 检查会话/全局配置是否启用测站分布图
+        data_sources = (
+            active_config.get("data_sources", {})
+            if isinstance(active_config, dict)
+            else {}
+        )
+        snet_cfg = (
+            data_sources.get("snet", {}) if isinstance(data_sources, dict) else {}
+        )
+        if not snet_cfg.get("include_station_map", True):
             return
         renderer = getattr(self.manager, "snet_map_renderer", None)
         if renderer is None:
@@ -683,10 +706,20 @@ class MessageBuildService:
         event: EventEnvelope,
         *,
         message_format_config: dict[str, Any],
+        active_config: dict[str, Any],
     ) -> None:
         """为台风事件附加路径图（需 history_track，走 RenderImageCache）。"""
         domain_event = self._get_domain_event(event)
         if not isinstance(domain_event, TyphoonEvent):
+            return
+
+        # 检查会话/全局配置是否启用台风路径图
+        typhoon_config = (
+            active_config.get("typhoon_config", {})
+            if isinstance(active_config, dict)
+            else {}
+        )
+        if not typhoon_config.get("include_track_map", True):
             return
 
         renderer = getattr(self.manager, "typhoon_map_renderer", None)

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -273,7 +273,20 @@ class PushExecutionService:
                         "show_local_estimation": typhoon_config.get(
                             "show_local_estimation", False
                         ),
+                        # 台风路径图附件开关影响消息是否附加路径图卡片，
+                        # 必须纳入缓存键，否则不同会话会误复用彼此的渲染结果。
+                        "include_track_map": bool(
+                            typhoon_config.get("include_track_map", True)
+                        ),
                         "typhoon": typhoon_enrichment,
+                    },
+                    # S-Net 测站分布图附件开关同理，纳入缓存键避免跨会话误复用。
+                    "snet": {
+                        "include_station_map": bool(
+                            data_sources.get("snet", {}).get(
+                                "include_station_map", True
+                            )
+                        ),
                     },
                     # 本地监控配置差异会导致地震正文附带不同的本地预估，
                     # 缺失时会使不同会话误共享同一份渲染结果。

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -238,6 +238,13 @@ class PushExecutionService:
                         "playwright_mode": message_format_config.get(
                             "playwright_mode", "local"
                         ),
+                        # 是否忽略 HTTPS 证书错误直接影响地图底图能否加载，
+                        # 纳入缓存键避免切换开关后误复用旧渲染结果。
+                        "browser_ignore_https_errors": bool(
+                            message_format_config.get(
+                                "browser_ignore_https_errors", False
+                            )
+                        ),
                         "use_global_quake_card": message_format_config.get(
                             "use_global_quake_card", False
                         ),

--- a/core/message/push/weather_aggregation_service.py
+++ b/core/message/push/weather_aggregation_service.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from ....utils.plugin_logger import plugin_logger
 from ...domain.event_models import EventEnvelope, WeatherEvent
+from ...services.identity.event_identity import resolve_event_time_aware
 
 # 气象预警颜色级别 → 数值（用于排序，数值越大优先级越高）
 _COLOR_LEVEL_MAP: dict[str, int] = {
@@ -157,8 +158,6 @@ class WeatherAggregationService:
         超过时效的事件直接交回常规推送路径，由规则链统一兜底拦截。
         """
         try:
-            from ...services.identity.event_identity import resolve_event_time_aware
-
             event_time = resolve_event_time_aware(event)
             if event_time is None:
                 # 无时间信息时放行，交给后续规则链兜底

--- a/core/message/runtime/bootstrap_service.py
+++ b/core/message/runtime/bootstrap_service.py
@@ -77,11 +77,15 @@ class MessageManagerBootstrapService:
 
         playwright_mode = msg_config.get("playwright_mode", "local")
         playwright_server_url = msg_config.get("playwright_server_url", "")
+        # 仅本地模式生效：部分瓦片源（如 FAN Studio）证书过期时，
+        # 开启后可继续加载底图；会信任自签/过期证书，默认关闭。
+        ignore_https_errors = bool(msg_config.get("browser_ignore_https_errors", False))
         self.manager.browser_manager = BrowserManager(
             pool_size=pool_size,
             telemetry=telemetry,
             mode=playwright_mode,
             server_url=playwright_server_url,
+            ignore_https_errors=ignore_https_errors,
         )
 
         # 只有本地浏览器模式且确实需要图形渲染时才后台预热，
@@ -105,15 +109,34 @@ class MessageManagerBootstrapService:
         need_browser = (
             msg_config.get("include_map", False)
             or msg_config.get("use_global_quake_card", False)
-            or bool(isinstance(snet_cfg, dict) and snet_cfg.get("enabled", False))
-            # 台风路径图查询/推送也依赖 Playwright，启用台风源时一并预热。
-            or bool(
-                isinstance(fan_studio_cfg, dict)
-                and fan_studio_cfg.get("china_typhoon", False)
+            or (
+                bool(isinstance(snet_cfg, dict) and snet_cfg.get("enabled", False))
+                and bool(snet_cfg.get("include_station_map", True))
             )
-            or bool(
-                isinstance(eqsc_cfg, dict)
-                and EqscChannelService.resolve_eqsc_flags(eqsc_cfg) == (True, True)
+            # 台风路径图查询/推送也依赖 Playwright，启用台风源且开启路径图时一并预热。
+            or (
+                bool(
+                    isinstance(fan_studio_cfg, dict)
+                    and fan_studio_cfg.get("china_typhoon", False)
+                )
+                and bool(
+                    isinstance(self.manager.config.get("typhoon_config", {}), dict)
+                    and self.manager.config.get("typhoon_config", {}).get(
+                        "include_track_map", True
+                    )
+                )
+            )
+            or (
+                bool(
+                    isinstance(eqsc_cfg, dict)
+                    and EqscChannelService.resolve_eqsc_flags(eqsc_cfg) == (True, True)
+                )
+                and bool(
+                    isinstance(self.manager.config.get("typhoon_config", {}), dict)
+                    and self.manager.config.get("typhoon_config", {}).get(
+                        "include_track_map", True
+                    )
+                )
             )
         )
         # 是否需要在合适的时机后台预热浏览器：只登记标志，真正预热推迟到

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -31,13 +31,25 @@ class BrowserManager:
         telemetry=None,
         mode: str = "local",
         server_url: str = "",
+        ignore_https_errors: bool = False,
     ):
-        """初始化浏览器管理器。"""
+        """初始化浏览器管理器。
+
+        Args:
+            pool_size: 页面池大小。
+            telemetry: 遥测服务实例。
+            mode: 运行模式，local 或 remote。
+            server_url: 远程浏览器服务地址。
+            ignore_https_errors: 是否忽略 HTTPS 证书错误（仅本地模式生效）。
+                默认关闭。某些地图瓦片源（如 FAN Studio ）证书过期时，
+                开启后底图可继续加载；但会信任自签/过期证书，请谨慎使用。
+        """
         self.pool_size = pool_size
         self._browser: Browser | None = None
         self._playwright = None
         # 远程连接场景下可能需要保留上下文对象引用。
         self._context = None
+        self._ignore_https_errors = bool(ignore_https_errors)
         self._page_pool: asyncio.Queue = asyncio.Queue(maxsize=pool_size)
         # 信号量用于限制同时渲染数量，页面创建锁与初始化锁用于避免并发竞争。
         self._semaphore = asyncio.Semaphore(pool_size)
@@ -134,6 +146,28 @@ class BrowserManager:
             return False
         return cls._is_map_tile_url(url)
 
+    @staticmethod
+    def _dedupe_failures(entries: list[str]) -> list[str]:
+        """按条目内容去重并保持首次出现顺序，供汇总日志使用。
+
+        Args:
+            entries: 原始失败条目列表（如 "GET https://... -> net::ERR_CERT_DATE_INVALID"）。
+
+        Returns:
+            去重后的条目列表；若输入为空则返回空列表。
+        """
+        if not entries:
+            return []
+        seen: set[str] = set()
+        result: list[str] = []
+        for entry in entries:
+            key = str(entry).strip()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            result.append(entry)
+        return result
+
     def _truncate_debug_text(self, value, limit: int = 240) -> str:
         """截断浏览器侧日志文本，避免单条日志过长。"""
         text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
@@ -214,14 +248,32 @@ class BrowserManager:
                 await self._cleanup()
                 return False
 
-    async def _create_local_page(self) -> Page:
-        """创建本地页面池中的新页面。"""
+    async def _ensure_local_context(self):
+        """确保本地浏览器共享上下文就绪。"""
         if not self._browser:
             raise RuntimeError("浏览器未就绪，无法创建页面")
-        return await self._browser.new_page(
+        if self._context is not None:
+            try:
+                # 轻量探测：context 已失效时会抛出异常，此时重建。
+                _ = self._context.browser
+                return self._context
+            except Exception:
+                self._context = None
+        self._context = await self._browser.new_context(
             viewport=dict(self.DEFAULT_VIEWPORT),
             device_scale_factor=2,
+            ignore_https_errors=self._ignore_https_errors,
         )
+        if self._ignore_https_errors:
+            logger.debug(
+                "[灾害预警] 已启用忽略 HTTPS 证书错误（仅对瓦片等资源加载生效）"
+            )
+        return self._context
+
+    async def _create_local_page(self) -> Page:
+        """创建本地页面池中的新页面。"""
+        context = await self._ensure_local_context()
+        return await context.new_page()
 
     async def _put_page_into_pool(self, page: Page) -> bool:
         """非阻塞入池；池满时关闭多余页面，避免 put 永久阻塞。"""
@@ -509,14 +561,11 @@ class BrowserManager:
 
     async def _initialize_local_page_pool(self):
         """初始化本地浏览器的页面池"""
+        # 统一走共享 context 创建页面，以支持 ignore_https_errors 等上下文级配置。
+        context = await self._ensure_local_context()
         for i in range(self.pool_size):
             try:
-                page = await asyncio.wait_for(
-                    self._browser.new_page(
-                        viewport=dict(self.DEFAULT_VIEWPORT), device_scale_factor=2
-                    ),
-                    timeout=10.0,
-                )
+                page = await asyncio.wait_for(context.new_page(), timeout=10.0)
                 if not await self._put_page_into_pool(page):
                     break
                 logger.debug(f"[灾害预警] 页面 {i + 1}/{self.pool_size} 已创建")
@@ -642,6 +691,8 @@ class BrowserManager:
         console_messages: list[str] = []
         page_errors: list[str] = []
         request_failures: list[str] = []
+        # 瓦片类资源失败：方案A降级为 debug 收集，末尾统一去重汇总。
+        tile_request_failures: list[str] = []
         benign_request_failures: list[str] = []
         listeners_attached = False
         _record_console = None
@@ -673,7 +724,35 @@ class BrowserManager:
                                 f" @ {location.get('url', '')}:{location.get('lineNumber', '')}:{location.get('columnNumber', '')}"
                             )
                             console_messages.append(entry)
-                            if msg.type in {"error", "warning"}:
+                            if msg.type not in {"error", "warning"}:
+                                return
+                            text_lower = str(msg.text or "").lower()
+                            # 方案A：瓦片资源加载失败时，requestfailed 事件已精确记录
+                            # URL 与错误码，此处浏览器侧 console 的 "Failed to load resource"
+                            # 是同一事件的重复上报。降级为 debug，避免每条瓦片刷两条 WARN。
+                            is_dup_resource_log = (
+                                "failed to load resource" in text_lower
+                                and any(
+                                    marker in text_lower
+                                    for marker in (
+                                        "tilemap.fanstudio.tech",
+                                        "/petallight/",
+                                        "/petaldark/",
+                                        "/arcwi/",
+                                        "/arcwob/",
+                                        "/arcwh/",
+                                        "/geovis/",
+                                        "tile.openstreetmap",
+                                        "tiles.",
+                                        "/tiles/",
+                                    )
+                                )
+                            )
+                            if is_dup_resource_log:
+                                logger.debug(
+                                    f"[灾害预警] 忽略与资源请求失败重复的控制台日志: {entry}"
+                                )
+                            else:
                                 logger.warning(f"[灾害预警] 页面控制台{entry}")
                         except Exception as hook_err:
                             logger.debug(f"[灾害预警] 记录控制台日志失败: {hook_err}")
@@ -706,12 +785,21 @@ class BrowserManager:
                                 f"{req.method} {req.url} -> "
                                 f"{self._truncate_debug_text(failure_text or 'unknown failure')}"
                             )
+                            is_tile = self._is_map_tile_url(getattr(req, "url", None))
+                            # 方案A：瓦片类失败（含证书过期/中止等）一律降级为 debug，
+                            # 仅在末尾统一汇总一条，避免每张瓦片刷屏。
+                            if is_tile:
+                                tile_request_failures.append(entry)
+                                logger.debug(
+                                    f"[灾害预警] 瓦片资源请求失败(已降级为debug): {entry}"
+                                )
+                                return
                             if self._is_benign_request_failure(
                                 url=getattr(req, "url", None),
                                 failure_text=failure_text,
                                 resource_type=resource_type,
                             ):
-                                # 瓦片重试/视野更新导致的中止请求：仅 debug，避免刷屏。
+                                # 非瓦片但属于重试/视野更新导致的中止请求：仅 debug。
                                 benign_request_failures.append(entry)
                                 logger.debug(
                                     f"[灾害预警] 忽略可预期的资源中止: {entry}"
@@ -828,12 +916,23 @@ class BrowserManager:
                     elapsed = time.time() - start_time
 
                     if os.path.exists(output_path):
+                        # 方案B：瓦片类失败按 URL->错误码 去重后汇总输出，避免逐条刷屏。
+                        tile_summary = self._dedupe_failures(tile_request_failures)
                         if request_failures:
                             logger.warning(
                                 f"[灾害预警] {label}渲染虽成功，但捕获到资源请求失败: "
                                 f"{' | '.join(request_failures[-5:])}"
                             )
-                        elif benign_request_failures:
+                        if tile_summary:
+                            logger.warning(
+                                f"[灾害预警] {label}渲染虽成功，但有 {len(tile_request_failures)} 个瓦片请求失败"
+                                f"（去重后 {len(tile_summary)} 项）: {' | '.join(tile_summary[-5:])}"
+                            )
+                        if (
+                            not request_failures
+                            and not tile_summary
+                            and benign_request_failures
+                        ):
                             logger.debug(
                                 f"[灾害预警] {label}渲染成功，已忽略 "
                                 f"{len(benign_request_failures)} 条可预期资源中止"
@@ -1162,7 +1261,18 @@ class BrowserManager:
             cleanup_errors.append(f"清理页面池失败: {e}")
             logger.warning(f"[灾害预警] 清理页面池时发生异常: {e}")
 
-        # 步骤 2: 关闭浏览器
+        # 步骤 2: 关闭共享 context（与页面池同生命周期，先于浏览器关闭）
+        if self._context is not None:
+            try:
+                await self._context.close()
+            except Exception as e:
+                cleanup_errors.append(f"关闭浏览器上下文失败: {e}")
+                logger.debug(f"[灾害预警] 关闭浏览器上下文失败: {e}")
+            finally:
+                # 无论成败都置空，避免重建路径残留旧 context 引用。
+                self._context = None
+
+        # 步骤 3: 关闭浏览器
         try:
             if self._browser:
                 await self._browser.close()
@@ -1173,7 +1283,7 @@ class BrowserManager:
             # 即使关闭失败,也强制置空引用,防止后续误用
             self._browser = None
 
-        # 步骤 3: 停止 Playwright
+        # 步骤 4: 停止 Playwright
         try:
             if self._playwright:
                 await self._playwright.stop()

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -795,23 +795,25 @@ class BrowserManager:
                                 f"{self._truncate_debug_text(failure_text or 'unknown failure')}"
                             )
                             is_tile = self._is_map_tile_url(getattr(req, "url", None))
-                            # 方案A：瓦片类失败（含证书过期/中止等）一律降级为 debug，
-                            # 仅在末尾统一汇总一条，避免每张瓦片刷屏。
-                            if is_tile:
-                                tile_request_failures.append(entry)
-                                logger.debug(
-                                    f"[灾害预警] 瓦片资源请求失败(已降级为debug): {entry}"
-                                )
-                                return
+                            # 先判断良性中止（瓦片重试/视野更新/截图收尾导致的
+                            # net::ERR_ABORTED）：这类噪声直接忽略，不进瓦片汇总，
+                            # 避免出图成功时被 WARN 汇总刷屏。
                             if self._is_benign_request_failure(
                                 url=getattr(req, "url", None),
                                 failure_text=failure_text,
                                 resource_type=resource_type,
                             ):
-                                # 非瓦片但属于重试/视野更新导致的中止请求：仅 debug。
                                 benign_request_failures.append(entry)
                                 logger.debug(
                                     f"[灾害预警] 忽略可预期的资源中止: {entry}"
+                                )
+                                return
+                            # 方案A：瓦片类失败（如证书过期等真实错误）一律降级为 debug，
+                            # 仅在末尾统一去重汇总一条，避免每张瓦片刷屏。
+                            if is_tile:
+                                tile_request_failures.append(entry)
+                                logger.debug(
+                                    f"[灾害预警] 瓦片资源请求失败(已降级为debug): {entry}"
                                 )
                                 return
                             request_failures.append(entry)

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -49,6 +49,11 @@ class BrowserManager:
         self._playwright = None
         # 远程连接场景下可能需要保留上下文对象引用。
         self._context = None
+        # 共享 context 是否已关闭（由 _cleanup 联动维护，不依赖属性探测）。
+        self._context_closed = False
+        # 共享 context 创建/关闭互斥锁：_create_local_page 可能在
+        # 补池、应急建页等多协程路径并发调用，不加锁会重复创建 context 造成泄漏。
+        self._context_lock = asyncio.Lock()
         self._ignore_https_errors = bool(ignore_https_errors)
         self._page_pool: asyncio.Queue = asyncio.Queue(maxsize=pool_size)
         # 信号量用于限制同时渲染数量，页面创建锁与初始化锁用于避免并发竞争。
@@ -249,26 +254,30 @@ class BrowserManager:
                 return False
 
     async def _ensure_local_context(self):
-        """确保本地浏览器共享上下文就绪。"""
+        """确保本地浏览器共享上下文就绪。
+
+        并发安全：context 的重新创建受 _context_lock 保护，避免
+        补池/应急建页等多协程路径并发进入时各自创建 context 造成泄漏。
+        存活性以 _context_closed 显式标志为准（由 _cleanup 联动维护），
+        不依赖 .browser 属性探测——该属性在 close() 后仍可访问，无法可靠识别已关闭的 context。
+        """
         if not self._browser:
             raise RuntimeError("浏览器未就绪，无法创建页面")
-        if self._context is not None:
-            try:
-                # 轻量探测：context 已失效时会抛出异常，此时重建。
-                _ = self._context.browser
+        async with self._context_lock:
+            # double-check：锁内再次确认，避免重复创建。
+            if self._context is not None and not self._context_closed:
                 return self._context
-            except Exception:
-                self._context = None
-        self._context = await self._browser.new_context(
-            viewport=dict(self.DEFAULT_VIEWPORT),
-            device_scale_factor=2,
-            ignore_https_errors=self._ignore_https_errors,
-        )
-        if self._ignore_https_errors:
-            logger.debug(
-                "[灾害预警] 已启用忽略 HTTPS 证书错误（仅对瓦片等资源加载生效）"
+            self._context = await self._browser.new_context(
+                viewport=dict(self.DEFAULT_VIEWPORT),
+                device_scale_factor=2,
+                ignore_https_errors=self._ignore_https_errors,
             )
-        return self._context
+            self._context_closed = False
+            if self._ignore_https_errors:
+                logger.debug(
+                    "[灾害预警] 已启用忽略 HTTPS 证书错误（仅对瓦片等资源加载生效）"
+                )
+            return self._context
 
     async def _create_local_page(self) -> Page:
         """创建本地页面池中的新页面。"""
@@ -1262,15 +1271,21 @@ class BrowserManager:
             logger.warning(f"[灾害预警] 清理页面池时发生异常: {e}")
 
         # 步骤 2: 关闭共享 context（与页面池同生命周期，先于浏览器关闭）
-        if self._context is not None:
-            try:
-                await self._context.close()
-            except Exception as e:
-                cleanup_errors.append(f"关闭浏览器上下文失败: {e}")
-                logger.debug(f"[灾害预警] 关闭浏览器上下文失败: {e}")
-            finally:
-                # 无论成败都置空，避免重建路径残留旧 context 引用。
-                self._context = None
+        # 加锁防止与 _ensure_local_context 的并发创建交错；并联动维护
+        # _context_closed 标志，供存活判断使用。
+        async with self._context_lock:
+            if self._context is not None:
+                try:
+                    await self._context.close()
+                except Exception as e:
+                    cleanup_errors.append(f"关闭浏览器上下文失败: {e}")
+                    logger.debug(f"[灾害预警] 关闭浏览器上下文失败: {e}")
+                finally:
+                    # 无论成败都置空，避免重建路径残留旧 context 引用。
+                    self._context = None
+            # 显式标记已关闭：.browser 属性在 close() 后仍可访问，
+            # 不能依赖属性探测判断存活，改由标志与清理路径联动。
+            self._context_closed = True
 
         # 步骤 3: 关闭浏览器
         try:

--- a/core/network/admin/host/web_server_runtime_service.py
+++ b/core/network/admin/host/web_server_runtime_service.py
@@ -6,6 +6,8 @@ Web 管理端运行时服务。
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import secrets
 from datetime import datetime
@@ -151,8 +153,6 @@ class WebServerRuntimeService:
                 return
             while True:
                 try:
-                    import json
-
                     data = await websocket.receive_text()
                     msg = json.loads(data)
                     # 响应心跳
@@ -207,8 +207,6 @@ class WebServerRuntimeService:
         """后台广播循环。"""
         while True:
             try:
-                import asyncio
-
                 await asyncio.sleep(interval_seconds)
                 # 周期性定时广播最新数据，保证前端界面状态最终一致
                 await self.broadcast_data()

--- a/core/network/admin/payloads/connections_payload_builder.py
+++ b/core/network/admin/payloads/connections_payload_builder.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import time
 from datetime import datetime
 from typing import Any
-from urllib.parse import urlparse
 
 from ....app.services.eqsc_channel_service import EqscChannelService
 from ....services.query.source_runtime_query_service import SourceRuntimeQueryService
@@ -40,27 +39,13 @@ class ConnectionsPayloadBuilder:
         )
         self.latency_cache = latency_cache if latency_cache is not None else {}
 
+    # EQSC 官方域名（硬编码，base_url 已不再暴露为用户配置项）。
+    EQSC_HOST = "equake.top"
+
     @staticmethod
     def resolve_eqsc_host(config: dict[str, Any] | None) -> str:
-        """从配置解析 EQSC 探测主机名，失败时回退官方域名。"""
-        eqsc_cfg = {}
-        if isinstance(config, dict):
-            data_sources = config.get("data_sources", {})
-            if isinstance(data_sources, dict):
-                raw = data_sources.get("eqsc", {})
-                if isinstance(raw, dict):
-                    eqsc_cfg = raw
-        base_url = str(eqsc_cfg.get("base_url", "") or "").strip()
-        if base_url:
-            try:
-                parsed = urlparse(
-                    base_url if "://" in base_url else f"https://{base_url}"
-                )
-                if parsed.hostname:
-                    return parsed.hostname
-            except Exception:
-                pass
-        return "equake.top"
+        """返回 EQSC 探测主机名（硬编码官方域名）。"""
+        return ConnectionsPayloadBuilder.EQSC_HOST
 
     def _build_eqsc_connection_info(self) -> dict[str, Any]:
         """构建 EQSC HTTP 辅助通道的连接状态条目。"""

--- a/core/network/http/eqsc_cenc_intensity_client.py
+++ b/core/network/http/eqsc_cenc_intensity_client.py
@@ -52,9 +52,10 @@ class EqscCencIntensityClient(EqscHttpClient):
             config,
             message_logger=message_logger,
             owns_token_manager=owns_token_manager,
-            # 详情相对稳定；默认 10 分钟缓存，减少重复大包下载
+            # 详情相对稳定；默认 10 分钟缓存，减少重复大包下载。
+            # cenc_ir_cache_ttl 配置项已从配置契约移除：传入 None 完全禁用配置读取，避免任何残留键覆盖默认值。
             default_cache_ttl=600,
-            cache_ttl_config_key="cenc_ir_cache_ttl",
+            cache_ttl_config_key=None,
         )
         # 列表缓存：(items, expires_at)
         self._list_cache: tuple[list[dict[str, Any]], float] | None = None

--- a/core/network/http/eqsc_http_client.py
+++ b/core/network/http/eqsc_http_client.py
@@ -38,7 +38,7 @@ class EqscHttpClient:
         *,
         owns_token_manager: bool = True,
         default_cache_ttl: int = 300,
-        cache_ttl_config_key: str = "cache_ttl",
+        cache_ttl_config_key: str | None = "cache_ttl",
     ):
         """初始化公共 HTTP 能力。
 
@@ -49,16 +49,21 @@ class EqscHttpClient:
             owns_token_manager: close() 时是否关闭 token_manager。
                 共享同一 token_manager 的附属客户端应设为 False。
             default_cache_ttl: 缓存 TTL 默认值（秒）。
-            cache_ttl_config_key: 从 config 读取 TTL 的键名。
+            cache_ttl_config_key: 从 config 读取 TTL 的键名；传 None
+                表示禁用配置读取（始终使用 default_cache_ttl 硬编码）。
         """
         self._token_manager = token_manager
         self._base_url = self.EQSC_BASE_URL
         self._message_logger = message_logger
         self._owns_token_manager = bool(owns_token_manager)
         try:
-            cache_ttl = int(
-                config.get(cache_ttl_config_key, default_cache_ttl) or default_cache_ttl
-            )
+            if cache_ttl_config_key:
+                cache_ttl = int(
+                    config.get(cache_ttl_config_key, default_cache_ttl)
+                    or default_cache_ttl
+                )
+            else:
+                cache_ttl = default_cache_ttl
         except (TypeError, ValueError):
             cache_ttl = default_cache_ttl
         self._cache_ttl = max(1, cache_ttl)

--- a/core/network/http/eqsc_http_client.py
+++ b/core/network/http/eqsc_http_client.py
@@ -27,6 +27,9 @@ from .eqsc_token_manager import EqscTokenManager
 class EqscHttpClient:
     """EQSC HTTP 客户端基类。"""
 
+    # EQSC API 基础地址（硬编码，不再暴露为用户配置项）。
+    EQSC_BASE_URL = "https://equake.top"
+
     def __init__(
         self,
         token_manager: EqscTokenManager,
@@ -49,7 +52,7 @@ class EqscHttpClient:
             cache_ttl_config_key: 从 config 读取 TTL 的键名。
         """
         self._token_manager = token_manager
-        self._base_url = str(config.get("base_url", "") or "").strip().rstrip("/")
+        self._base_url = self.EQSC_BASE_URL
         self._message_logger = message_logger
         self._owns_token_manager = bool(owns_token_manager)
         try:

--- a/core/network/http/eqsc_token_manager.py
+++ b/core/network/http/eqsc_token_manager.py
@@ -22,13 +22,16 @@ from astrbot.api import logger
 class EqscTokenManager:
     """EQSC API 令牌管理器。"""
 
+    # EQSC API 基础地址（硬编码，不再暴露为用户配置项）。
+    EQSC_BASE_URL = "https://equake.top"
+
     def __init__(self, config: dict[str, Any]):
         """初始化令牌管理器。
 
         Args:
-            config: EQSC 配置字典，包含 base_url、refresh_token 等字段。
+            config: EQSC 配置字典，包含 refresh_token 等字段。
         """
-        self._base_url = str(config.get("base_url", "")).strip().rstrip("/")
+        self._base_url = self.EQSC_BASE_URL
         self._refresh_token = str(config.get("refresh_token", "")).strip()
         self._access_token: str = ""
         self._access_token_expires_at: float = 0.0

--- a/core/network/http/eqsc_tsunami_client.py
+++ b/core/network/http/eqsc_tsunami_client.py
@@ -19,6 +19,9 @@ from .eqsc_token_manager import EqscTokenManager
 class EqscTsunamiClient(EqscHttpClient):
     """EQSC JMA 海啸数据 HTTP 客户端。"""
 
+    # 海啸快照内存缓存有效期（秒），用于短时并发复用；轮询本身会绕过缓存强制刷新。
+    TSUNAMI_CACHE_TTL = 60
+
     def __init__(
         self,
         token_manager: EqscTokenManager,
@@ -41,9 +44,9 @@ class EqscTsunamiClient(EqscHttpClient):
             config,
             message_logger=message_logger,
             owns_token_manager=owns_token_manager,
-            # 海啸上游更新不频繁；默认 60 秒缓存，减少重复请求
-            default_cache_ttl=60,
-            cache_ttl_config_key="tsunami_cache_ttl",
+            # 海啸上游更新不频繁；硬编码 60 秒缓存，减少重复请求
+            default_cache_ttl=self.TSUNAMI_CACHE_TTL,
+            cache_ttl_config_key="__tsunami_cache_ttl_hardcoded__",
         )
         # 最新快照缓存：(data, expires_at)
         self._latest_cache: tuple[dict[str, Any], float] | None = None

--- a/core/network/http/eqsc_tsunami_client.py
+++ b/core/network/http/eqsc_tsunami_client.py
@@ -44,9 +44,10 @@ class EqscTsunamiClient(EqscHttpClient):
             config,
             message_logger=message_logger,
             owns_token_manager=owns_token_manager,
-            # 海啸上游更新不频繁；硬编码 60 秒缓存，减少重复请求
+            # 海啸上游更新不频繁；硬编码 60 秒缓存，减少重复请求。
+            # 传入 None 完全禁用配置读取，避免任何残留键覆盖默认值。
             default_cache_ttl=self.TSUNAMI_CACHE_TTL,
-            cache_ttl_config_key="__tsunami_cache_ttl_hardcoded__",
+            cache_ttl_config_key=None,
         )
         # 最新快照缓存：(data, expires_at)
         self._latest_cache: tuple[dict[str, Any], float] | None = None

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -31,7 +31,7 @@ class EqscTyphoonClient(EqscHttpClient):
 
         Args:
             token_manager: EQSC 令牌管理器实例。
-            config: EQSC 配置字典，包含 cache_ttl 等字段。
+            config: EQSC 配置字典（缓存 TTL 已硬编码，不再读取 cache_ttl）。
             message_logger: 可选原始消息记录器；启用后会落盘 EQSC HTTP 响应。
             owns_token_manager: close() 时是否关闭 token_manager。
         """
@@ -40,8 +40,10 @@ class EqscTyphoonClient(EqscHttpClient):
             config,
             message_logger=message_logger,
             owns_token_manager=owns_token_manager,
+            # cache_ttl 配置项已从配置契约移除：硬编码 300 秒缓存，
+            # 与海啸客户端（TSUNAMI_CACHE_TTL）保持一致，避免 schema 漂移。
             default_cache_ttl=300,
-            cache_ttl_config_key="cache_ttl",
+            cache_ttl_config_key="__eqsc_cache_ttl_hardcoded__",
         )
         # 缓存结构: {typhoon_id: (data, expires_at)}
         self._cache: dict[str, tuple[dict[str, Any], float]] = {}

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -41,9 +41,9 @@ class EqscTyphoonClient(EqscHttpClient):
             message_logger=message_logger,
             owns_token_manager=owns_token_manager,
             # cache_ttl 配置项已从配置契约移除：硬编码 300 秒缓存，
-            # 与海啸客户端（TSUNAMI_CACHE_TTL）保持一致，避免 schema 漂移。
+            # 传入 None 完全禁用配置读取，避免任何残留键覆盖默认值。
             default_cache_ttl=300,
-            cache_ttl_config_key="__eqsc_cache_ttl_hardcoded__",
+            cache_ttl_config_key=None,
         )
         # 缓存结构: {typhoon_id: (data, expires_at)}
         self._cache: dict[str, tuple[dict[str, Any], float]] = {}

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -705,6 +705,8 @@ class ConfigValidator:
 
         # 展示开关与过滤逻辑解耦：关闭后消息不暴露本地距离/逼近文案。
         ConfigValidator._ensure_bool(cfg, "show_local_estimation", False)
+        # 台风路径图附件开关：必须为布尔值，避免历史/手工配置写入异常类型。
+        ConfigValidator._ensure_bool(cfg, "include_track_map", True)
 
         typhoon_filter = cfg.get("typhoon_filter", {})
         if not isinstance(typhoon_filter, dict):
@@ -1033,6 +1035,10 @@ class ConfigValidator:
                 logger.warning("[灾害预警] 配置警告: 浏览器池大小过大，已限制为 10。")
                 cfg["browser_pool_size"] = 10
 
+        # 是否忽略 HTTPS 证书错误：TLS 安全控制，必须为布尔值。
+        # 若手工配置为字符串 "false"，bool("false") 为 True 会错误启用证书忽略。
+        ConfigValidator._ensure_bool(cfg, "browser_ignore_https_errors", False)
+
         # 地图源校验（通用地图 / 台风路径图共用选项表）
         valid_source_ids = set(MAP_TILE_SOURCES.keys())
         valid_source_names = set(MAP_SOURCE_NAME_TO_ID.keys())
@@ -1311,6 +1317,8 @@ class ConfigValidator:
         # S-Net 轮询间隔校验
         snet_cfg = cfg.get("snet")
         if isinstance(snet_cfg, dict):
+            # 测站分布图附件开关：必须为布尔值，避免异常类型被保留并写回。
+            ConfigValidator._ensure_bool(snet_cfg, "include_station_map", True)
             poll_interval = snet_cfg.get("poll_interval_seconds")
             if isinstance(poll_interval, int):
                 if poll_interval < 30:

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -17,7 +17,6 @@ from ....utils.map_tile_sources import (
     MAP_TILE_SOURCES,
     normalize_map_source,
 )
-from ..eqsc.eqsc_typhoon_poll_service import EqscTyphoonPollService
 from ..snet.snet_filter_constants import (
     DEFAULT_MIN_SHINDO,
     DEFAULT_MIN_TRIGGERED_STATIONS,
@@ -959,15 +958,6 @@ class ConfigValidator:
             )
             cfg["log_downgrade_behavior"] = "降级为DEBUG"
 
-        # 原始消息日志路径校验
-        if "raw_message_log_path" in cfg and not isinstance(
-            cfg["raw_message_log_path"], str
-        ):
-            logger.warning(
-                "[灾害预警] 配置警告: 原始消息日志路径类型错误，已重置为 raw_messages.log。"
-            )
-            cfg["raw_message_log_path"] = "raw_messages.log"
-
         # 布尔值校验
         ConfigValidator._ensure_bool(cfg, "enable_raw_message_logging", False)
         ConfigValidator._ensure_bool(cfg, "filter_heartbeat_messages", True)
@@ -1354,18 +1344,7 @@ class ConfigValidator:
                 fan_studio_cfg["fssn_cmt"] = True
             ConfigValidator._ensure_bool(fan_studio_cfg, "fssn_cmt", True)
 
-            # app_id / api_key：WebSocket 建连后发送 {"type":"auth","appId","key"}
-            app_id = fan_studio_cfg.get("app_id")
-            if app_id is None:
-                fan_studio_cfg["app_id"] = "97b68b51-ec96-42c3-80d7-83d2bff70d99"
-            elif not isinstance(app_id, str):
-                logger.warning(
-                    "[灾害预警] 配置警告: FAN Studio app_id 类型错误，已重置为默认应用 ID。"
-                )
-                fan_studio_cfg["app_id"] = "97b68b51-ec96-42c3-80d7-83d2bff70d99"
-            else:
-                fan_studio_cfg["app_id"] = app_id.strip()
-
+            # api_key：WebSocket 建连后发送 {"type":"auth","appId","key"}
             api_key = fan_studio_cfg.get("api_key")
             if api_key is None:
                 fan_studio_cfg["api_key"] = ""
@@ -1383,14 +1362,6 @@ class ConfigValidator:
             ):
                 logger.warning(
                     "[灾害预警] 配置警告: FAN Studio 数据源已启用但未配置 api_key，"
-                    "WebSocket 鉴权将无法完成，相关连接会被跳过。"
-                )
-            if (
-                fan_studio_cfg.get("enabled")
-                and not str(fan_studio_cfg.get("app_id", "")).strip()
-            ):
-                logger.warning(
-                    "[灾害预警] 配置警告: FAN Studio 数据源已启用但未配置 app_id，"
                     "WebSocket 鉴权将无法完成，相关连接会被跳过。"
                 )
 
@@ -1415,23 +1386,6 @@ class ConfigValidator:
                 )
             ConfigValidator._ensure_bool(eqsc_cfg, "china_cenc_intensity_report", False)
 
-            # Base URL 校验：确保为非空字符串且去除尾部斜杠
-            base_url = eqsc_cfg.get("base_url")
-            if isinstance(base_url, str):
-                base_url = base_url.strip().rstrip("/")
-                if base_url:
-                    eqsc_cfg["base_url"] = base_url
-                else:
-                    logger.warning(
-                        "[灾害预警] 配置警告: EQSC base_url 为空，已重置为默认值。"
-                    )
-                    eqsc_cfg["base_url"] = "https://equake.top"
-            elif base_url is not None:
-                logger.warning(
-                    "[灾害预警] 配置警告: EQSC base_url 类型错误，已重置为默认值。"
-                )
-                eqsc_cfg["base_url"] = "https://equake.top"
-
             # RefreshToken 校验：确保为字符串类型
             refresh_token = eqsc_cfg.get("refresh_token")
             if refresh_token is not None and not isinstance(refresh_token, str):
@@ -1440,90 +1394,26 @@ class ConfigValidator:
                 )
                 eqsc_cfg["refresh_token"] = ""
 
-            # 缓存 TTL 校验：确保为合理范围内的整数
-            cache_ttl = eqsc_cfg.get("cache_ttl")
-            if isinstance(cache_ttl, int):
-                if cache_ttl < 60:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 缓存 TTL {cache_ttl} 过小，已修正为 60。"
-                    )
-                    eqsc_cfg["cache_ttl"] = 60
-                elif cache_ttl > 3600:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 缓存 TTL {cache_ttl} 过大，已修正为 3600。"
-                    )
-                    eqsc_cfg["cache_ttl"] = 3600
-            elif cache_ttl is not None:
-                logger.warning(
-                    "[灾害预警] 配置警告: EQSC 缓存 TTL 类型错误，已重置为 300。"
-                )
-                eqsc_cfg["cache_ttl"] = 300
-
-            # 台风轮询间隔（边界与默认值复用 EqscTyphoonPollService 常量）
-            typhoon_min = EqscTyphoonPollService.MIN_INTERVAL_SECONDS
-            typhoon_max = EqscTyphoonPollService.MAX_INTERVAL_SECONDS
-            typhoon_default = EqscTyphoonPollService.DEFAULT_INTERVAL_SECONDS
-            typhoon_poll_interval = eqsc_cfg.get("typhoon_poll_interval_seconds")
-            # bool 是 int 子类，不能当作合法间隔。
-            if isinstance(typhoon_poll_interval, int) and not isinstance(
-                typhoon_poll_interval, bool
-            ):
-                if typhoon_poll_interval < typhoon_min:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 台风轮询间隔 {typhoon_poll_interval} 过短，已修正为 {typhoon_min}。"
-                    )
-                    eqsc_cfg["typhoon_poll_interval_seconds"] = typhoon_min
-                elif typhoon_poll_interval > typhoon_max:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 台风轮询间隔 {typhoon_poll_interval} 过长，已修正为 {typhoon_max}。"
-                    )
-                    eqsc_cfg["typhoon_poll_interval_seconds"] = typhoon_max
-            elif typhoon_poll_interval is not None:
-                logger.warning(
-                    f"[灾害预警] 配置警告: EQSC 台风轮询间隔类型错误，已重置为 {typhoon_default}。"
-                )
-                eqsc_cfg["typhoon_poll_interval_seconds"] = typhoon_default
-            elif "typhoon_poll_interval_seconds" not in eqsc_cfg:
-                eqsc_cfg["typhoon_poll_interval_seconds"] = typhoon_default
-
-            # 海啸轮询间隔
-            poll_interval = eqsc_cfg.get("jma_tsunami_poll_interval_seconds")
-            # bool 是 int 子类，不能当作合法间隔。
+            # 统一轮询间隔校验
+            poll_interval = eqsc_cfg.get("poll_interval_seconds")
             if isinstance(poll_interval, int) and not isinstance(poll_interval, bool):
-                if poll_interval < 15:
+                if poll_interval < 30:
                     logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 海啸轮询间隔 {poll_interval} 过短，已修正为 15。"
+                        f"[灾害预警] 配置警告: EQSC 轮询间隔 {poll_interval} 过短，已修正为 30。"
                     )
-                    eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 15
-                elif poll_interval > 300:
+                    eqsc_cfg["poll_interval_seconds"] = 30
+                elif poll_interval > 600:
                     logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 海啸轮询间隔 {poll_interval} 过长，已修正为 300。"
+                        f"[灾害预警] 配置警告: EQSC 轮询间隔 {poll_interval} 过长，已修正为 600。"
                     )
-                    eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 300
+                    eqsc_cfg["poll_interval_seconds"] = 600
             elif poll_interval is not None:
                 logger.warning(
-                    "[灾害预警] 配置警告: EQSC 海啸轮询间隔类型错误，已重置为 60。"
+                    "[灾害预警] 配置警告: EQSC 轮询间隔类型错误，已重置为 120。"
                 )
-                eqsc_cfg["jma_tsunami_poll_interval_seconds"] = 60
-
-            # 海啸快照缓存 TTL
-            tsunami_cache_ttl = eqsc_cfg.get("tsunami_cache_ttl")
-            if isinstance(tsunami_cache_ttl, int):
-                if tsunami_cache_ttl < 15:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 海啸缓存 TTL {tsunami_cache_ttl} 过小，已修正为 15。"
-                    )
-                    eqsc_cfg["tsunami_cache_ttl"] = 15
-                elif tsunami_cache_ttl > 300:
-                    logger.warning(
-                        f"[灾害预警] 配置警告: EQSC 海啸缓存 TTL {tsunami_cache_ttl} 过大，已修正为 300。"
-                    )
-                    eqsc_cfg["tsunami_cache_ttl"] = 300
-            elif tsunami_cache_ttl is not None:
-                logger.warning(
-                    "[灾害预警] 配置警告: EQSC 海啸缓存 TTL 类型错误，已重置为 60。"
-                )
-                eqsc_cfg["tsunami_cache_ttl"] = 60
+                eqsc_cfg["poll_interval_seconds"] = 120
+            elif "poll_interval_seconds" not in eqsc_cfg:
+                eqsc_cfg["poll_interval_seconds"] = 120
 
             # EQSC 启用但缺少 RefreshToken 时输出警告
             if (

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -1403,8 +1403,18 @@ class ConfigValidator:
                 eqsc_cfg["refresh_token"] = ""
 
             # 统一轮询间隔校验
+            # 缺失（键不存在）与显式 None 都视为未配置，统一回退默认 120，
+            # 避免 None 原样保留导致下游轮询调度收到无效间隔。
             poll_interval = eqsc_cfg.get("poll_interval_seconds")
-            if isinstance(poll_interval, int) and not isinstance(poll_interval, bool):
+            if poll_interval is None:
+                if "poll_interval_seconds" not in eqsc_cfg:
+                    logger.debug("[灾害预警] EQSC 未配置轮询间隔，已填充默认值 120。")
+                else:
+                    logger.warning(
+                        "[灾害预警] 配置警告: EQSC 轮询间隔为 null，已重置为 120。"
+                    )
+                eqsc_cfg["poll_interval_seconds"] = 120
+            elif isinstance(poll_interval, int) and not isinstance(poll_interval, bool):
                 if poll_interval < 30:
                     logger.warning(
                         f"[灾害预警] 配置警告: EQSC 轮询间隔 {poll_interval} 过短，已修正为 30。"
@@ -1415,12 +1425,10 @@ class ConfigValidator:
                         f"[灾害预警] 配置警告: EQSC 轮询间隔 {poll_interval} 过长，已修正为 600。"
                     )
                     eqsc_cfg["poll_interval_seconds"] = 600
-            elif poll_interval is not None:
+            else:
                 logger.warning(
                     "[灾害预警] 配置警告: EQSC 轮询间隔类型错误，已重置为 120。"
                 )
-                eqsc_cfg["poll_interval_seconds"] = 120
-            elif "poll_interval_seconds" not in eqsc_cfg:
                 eqsc_cfg["poll_interval_seconds"] = 120
 
             # EQSC 启用但缺少 RefreshToken 时输出警告

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -21,6 +21,9 @@ class ConnectionPlanBuilder:
     负责把已启用的数据源目录项转换为运行时可直接消费的连接计划。
     """
 
+    # FAN Studio 应用 ID（硬编码，不再暴露为用户配置项）。
+    FAN_STUDIO_APP_ID = "97b68b51-ec96-42c3-80d7-83d2bff70d99"
+
     @staticmethod
     def _resolve_connection_plan(
         entry: SourceEntry,
@@ -41,14 +44,17 @@ class ConnectionPlanBuilder:
 
     @staticmethod
     def _resolve_fan_studio_auth(config: dict[str, Any]) -> tuple[str, str]:
-        """从全局配置解析 FAN Studio 鉴权字段。"""
+        """从全局配置解析 FAN Studio 鉴权字段。
+
+        app_id 已硬编码为类常量，仅从配置读取 api_key。
+        """
         data_sources = config.get("data_sources")
         fan_cfg: dict[str, Any] = {}
         if isinstance(data_sources, dict):
             raw = data_sources.get("fan_studio")
             if isinstance(raw, dict):
                 fan_cfg = raw
-        app_id = str(fan_cfg.get("app_id") or "").strip()
+        app_id = ConnectionPlanBuilder.FAN_STUDIO_APP_ID
         api_key = str(fan_cfg.get("api_key") or "").strip()
         return app_id, api_key
 

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -30,9 +30,11 @@ class EqscCencIntensityPollService:
     """EQSC CENC 烈度速报 HTTP 轮询服务。"""
 
     SOURCE_ID = "cenc_ir_eqsc"
-    DEFAULT_INTERVAL_SECONDS = 90
+    DEFAULT_INTERVAL_SECONDS = 120
     MIN_INTERVAL_SECONDS = 30
     MAX_INTERVAL_SECONDS = 600
+    # 统一轮询间隔配置键（与台风、海啸共用同一配置项）
+    POLL_INTERVAL_CONFIG_KEY = "poll_interval_seconds"
     DEFAULT_LIST_LIMIT = 5
     MIN_LIST_LIMIT = 1
     MAX_LIST_LIMIT = 20
@@ -70,7 +72,8 @@ class EqscCencIntensityPollService:
 
     def _resolve_interval(self) -> int:
         cfg = self._eqsc_config()
-        raw = cfg.get("cenc_ir_poll_interval_seconds", self.DEFAULT_INTERVAL_SECONDS)
+        raw = cfg.get(self.POLL_INTERVAL_CONFIG_KEY, self.DEFAULT_INTERVAL_SECONDS)
+        # bool 是 int 子类，不能当作合法间隔。
         if isinstance(raw, bool) or not isinstance(raw, int):
             interval = self.DEFAULT_INTERVAL_SECONDS
         else:

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -31,9 +31,11 @@ class EqscTsunamiPollService:
     """EQSC JMA 海啸轮询服务。"""
 
     SOURCE_ID = "jma_tsunami_eqsc"
-    DEFAULT_INTERVAL_SECONDS = 60
-    MIN_INTERVAL_SECONDS = 15
-    MAX_INTERVAL_SECONDS = 300
+    DEFAULT_INTERVAL_SECONDS = 120
+    MIN_INTERVAL_SECONDS = 30
+    MAX_INTERVAL_SECONDS = 600
+    # 统一轮询间隔配置键（与台风、烈度速报共用同一配置项）
+    POLL_INTERVAL_CONFIG_KEY = "poll_interval_seconds"
 
     def __init__(self, service):
         self.service = service
@@ -63,14 +65,12 @@ class EqscTsunamiPollService:
 
     def _resolve_interval(self) -> int:
         cfg = self._eqsc_config()
-        try:
-            interval = int(
-                cfg.get(
-                    "jma_tsunami_poll_interval_seconds", self.DEFAULT_INTERVAL_SECONDS
-                )
-            )
-        except (TypeError, ValueError):
+        raw = cfg.get(self.POLL_INTERVAL_CONFIG_KEY, self.DEFAULT_INTERVAL_SECONDS)
+        # bool 是 int 子类，不能当作合法间隔。
+        if isinstance(raw, bool) or not isinstance(raw, int):
             interval = self.DEFAULT_INTERVAL_SECONDS
+        else:
+            interval = raw
         return max(self.MIN_INTERVAL_SECONDS, min(interval, self.MAX_INTERVAL_SECONDS))
 
     def _resolve_include_training(self) -> bool:

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -33,6 +33,8 @@ class EqscTyphoonPollService:
     DEFAULT_INTERVAL_SECONDS = 120
     MIN_INTERVAL_SECONDS = 30
     MAX_INTERVAL_SECONDS = 600
+    # 统一轮询间隔配置键（与海啸、烈度速报共用同一配置项）
+    POLL_INTERVAL_CONFIG_KEY = "poll_interval_seconds"
 
     def __init__(self, service):
         self.service = service
@@ -71,7 +73,7 @@ class EqscTyphoonPollService:
 
     def _resolve_interval(self) -> int:
         cfg = self._eqsc_config()
-        raw = cfg.get("typhoon_poll_interval_seconds", self.DEFAULT_INTERVAL_SECONDS)
+        raw = cfg.get(self.POLL_INTERVAL_CONFIG_KEY, self.DEFAULT_INTERVAL_SECONDS)
         # bool 是 int 子类，不能当作合法间隔。
         if isinstance(raw, bool) or not isinstance(raw, int):
             interval = self.DEFAULT_INTERVAL_SECONDS

--- a/core/services/health/connection_health_service.py
+++ b/core/services/health/connection_health_service.py
@@ -67,7 +67,7 @@ RESOLVE_INCIDENT_SECONDS = 120
 FLAP_IGNORE_SECONDS = 60
 
 # 高延迟视为 degraded 的阈值（ms）
-HIGH_LATENCY_MS = 1500
+HIGH_LATENCY_MS = 2000
 
 # 服务启动/重载后的建连宽限期：此期间「已启用但未连通」记为降级(连接中)，
 # 避免插件重载后几十秒内整页被误判为「核心通道中断」。

--- a/core/services/simulation/simulation_service.py
+++ b/core/services/simulation/simulation_service.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from ...domain.earthquake.cmt_normalize import parse_nodal_plane
 from ...domain.event_identity import EventIdentity
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...domain.event_payload import SourcePayload
@@ -304,8 +305,6 @@ def build_earthquake_simulation(
                 "is_supplement_product": True,
             }
         )
-        from ...domain.earthquake.cmt_normalize import parse_nodal_plane
-
         metadata["nodal_plane1"] = parse_nodal_plane(metadata["nodal_plane1"])
         metadata["nodal_plane2"] = parse_nodal_plane(metadata["nodal_plane2"])
         earthquake.metadata = dict(metadata)

--- a/core/storage/backup_manager.py
+++ b/core/storage/backup_manager.py
@@ -6,6 +6,8 @@ import io
 import json
 import os
 import shutil
+import sqlite3
+import tempfile
 import zipfile
 from datetime import datetime
 
@@ -62,9 +64,6 @@ class BackupService:
 
             # 2. 写入 events.db
             if "db" in targets and self.db_path.exists():
-                import sqlite3
-                import tempfile
-
                 temp_db_fd, temp_db_path = tempfile.mkstemp(suffix=".db")
                 os.close(temp_db_fd)
                 try:
@@ -149,8 +148,6 @@ class BackupService:
 
             try:
                 if has_db_in_zip and self.db_path.exists():
-                    import sqlite3
-
                     bak_path = self.db_path.with_suffix(self.db_path.suffix + ".bak")
                     src = sqlite3.connect(str(self.db_path))
                     dst = sqlite3.connect(str(bak_path))

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -17,8 +17,8 @@ import aiosqlite
 from astrbot.api import logger
 
 from ...utils.time_converter import TimeConverter
-from ..domain.typhoon.typhoon_levels import level_weight
 from ..domain.typhoon.typhoon_ids import to_eqsc_id, to_fan_id
+from ..domain.typhoon.typhoon_levels import level_weight
 from ..domain.typhoon.typhoon_peaks import resolve_storage_peak_fields
 from ..services.identity.event_classifier import (
     MAJOR_EARTHQUAKE_MAGNITUDE_THRESHOLD,

--- a/core/storage/database_manager.py
+++ b/core/storage/database_manager.py
@@ -8,6 +8,7 @@ Schema v2：
 """
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,7 @@ import aiosqlite
 from astrbot.api import logger
 
 from ...utils.time_converter import TimeConverter
+from ..domain.typhoon.typhoon_levels import level_weight
 from ..domain.typhoon.typhoon_ids import to_eqsc_id, to_fan_id
 from ..domain.typhoon.typhoon_peaks import resolve_storage_peak_fields
 from ..services.identity.event_classifier import (
@@ -1387,8 +1389,6 @@ class DatabaseManager:
         - 跌破阈值后再次进入重大区间。
         连续相同等级的观测不重复生成点。
         """
-        from ..domain.typhoon.typhoon_levels import level_weight
-
         cursor = await self.connection.cursor()
         await cursor.execute(
             """
@@ -2265,8 +2265,6 @@ class DatabaseManager:
                 if not raw_time:
                     continue
                 try:
-                    from datetime import datetime, timezone
-
                     normalized_time = str(raw_time).replace("Z", "+00:00")
                     event_time = datetime.fromisoformat(normalized_time)
                     if event_time.tzinfo is None:

--- a/core/storage/session_config_manager.py
+++ b/core/storage/session_config_manager.py
@@ -51,19 +51,17 @@ class SessionConfigManager:
     }
 
     # 仅允许全局配置修改的嵌套路径（会话 override 写入时强制剥离）。
-    # S-Net 轮询间隔、EQSC 通道鉴权/轮询参数影响全局运行态；
-    # typhoon / jma_tsunami 允许会话差异（部分会话可单独关闭推送）。
     GLOBAL_ONLY_NESTED_PATHS: tuple[tuple[str, ...], ...] = (
         ("data_sources", "snet", "poll_interval_seconds"),
-        ("data_sources", "eqsc", "enabled"),
-        ("data_sources", "eqsc", "base_url"),
         ("data_sources", "eqsc", "refresh_token"),
-        ("data_sources", "eqsc", "cache_ttl"),
-        ("data_sources", "eqsc", "tsunami_cache_ttl"),
-        ("data_sources", "eqsc", "jma_tsunami_poll_interval_seconds"),
+        # EQSC 统一轮询间隔影响全局运行态，不允许会话级覆写。
+        ("data_sources", "eqsc", "poll_interval_seconds"),
         # FAN Studio 鉴权影响全局 WebSocket 建连，不允许会话级覆写。
-        ("data_sources", "fan_studio", "app_id"),
         ("data_sources", "fan_studio", "api_key"),
+        # 浏览器页面池大小影响全局运行态，不允许会话级覆写。
+        ("message_format", "browser_pool_size"),
+        # 是否忽略 HTTPS 证书错误是浏览器启动级配置（context 全局创建），不允许会话级覆写
+        ("message_format", "browser_ignore_https_errors"),
     )
 
     def __init__(self, default_config_ref: dict[str, Any]):

--- a/plugin/plugin_lifecycle_service.py
+++ b/plugin/plugin_lifecycle_service.py
@@ -204,9 +204,7 @@ class PluginLifecycleService:
         try:
             await close_geoip_session()
         except Exception as geoip_err:
-            logger.debug(
-                f"[灾害预警] 关闭 GeoIP 会话时出错（已忽略）: {geoip_err}"
-            )
+            logger.debug(f"[灾害预警] 关闭 GeoIP 会话时出错（已忽略）: {geoip_err}")
 
         # 所有资源（含浏览器、后台延迟检测与 Web 管理端）均已完成回收后，
         # 才打印停止汇总大屏，确保面板上的回收状态与实际运行态一致。

--- a/plugin/plugin_lifecycle_service.py
+++ b/plugin/plugin_lifecycle_service.py
@@ -13,9 +13,11 @@ import time
 
 from astrbot.api import logger
 
+from ..core.app.disaster_service import stop_disaster_service
 from ..core.services.config.config_validation_service import ConfigValidator
 from ..core.services.telemetry.telemetry_service import TelemetryManager
 from ..utils.banner import print_stop_summary
+from ..utils.geolocation import close_geoip_session
 from ..utils.version import get_plugin_version
 
 
@@ -137,8 +139,6 @@ class PluginLifecycleService:
             except asyncio.CancelledError:
                 pass
 
-        from ..core.app.disaster_service import stop_disaster_service
-
         await stop_disaster_service()
 
         if (
@@ -198,6 +198,15 @@ class PluginLifecycleService:
         if self.plugin.web_server:
             # 最后停止管理端 Web 服务器，避免外部仍尝试进行网络交互
             await self.plugin.web_server.stop()
+
+        # 兜底关闭 GeoIP 共享会话：close_geoip_session() 目前由 web_server.stop() 触发，
+        # 但为避免 web_admin 未启用或未来其他路径使用 GeoIP 时残留模块级会话，此处再兜底一次。
+        try:
+            await close_geoip_session()
+        except Exception as geoip_err:
+            logger.debug(
+                f"[灾害预警] 关闭 GeoIP 会话时出错（已忽略）: {geoip_err}"
+            )
 
         # 所有资源（含浏览器、后台延迟检测与 Web 管理端）均已完成回收后，
         # 才打印停止汇总大屏，确保面板上的回收状态与实际运行态一致。


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [ ] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

简化多个 EQSC 和 FAN Studio 配置选项，同时增加浏览器 HTTPS 错误容忍度并改进日志噪音控制。

新功能：
- 添加一个全局选项，用于在本地 Playwright 模式下忽略浏览器 HTTPS 证书错误，并将该设置在渲染、缓存和引导逻辑中传递使用。
- 引入基于配置的开关，用于控制 S-Net 站点地图和台风路径地图，使这些可视化内容能够按会话选择性启用。

缺陷修复：
- 通过降低重复资源错误日志级别并将其聚合为摘要条目，防止地图瓦片请求失败时产生重复且过于详细的日志。
- 确保在插件关闭期间，即使 Web 管理服务器被禁用或未使用，GeoIP 共享会话也能被正确关闭。

功能增强：
- 优化 EQSC 轮询配置，通过统一台风、海啸和震度服务的轮询间隔设置，并更新默认值，同时更加严格地只允许全局配置。
- 将 EQSC 基础 URL、EQSC 主机解析、FAN Studio 应用 ID、海啸缓存 TTL 以及原始消息日志文件名进行硬编码并集中管理，以移除不必要的用户侧配置并提升健壮性。
- 调整浏览器上下文处理逻辑，在页面之间共享单一 Playwright 上下文，并支持像忽略 HTTPS 错误这类的上下文级设置。
- 放宽连接健康检查中的高延迟阈值，并改进管理端模式/UI 对 EQSC 刷新令牌等敏感字段的处理。
- 清理各服务、存储、HTTP 客户端和展示层中的导入及小工具，减少重复并提升可维护性。

文档：
- 在 README 的配置章节中记录新的 `browser_ignore_https_errors` 选项及其安全影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify several EQSC and FAN Studio configuration options while adding browser HTTPS error tolerance and improving logging noise control.

New Features:
- Add a global option to ignore browser HTTPS certificate errors in local Playwright mode and propagate it through rendering, caching, and bootstrap logic.
- Introduce configuration-driven toggles for S-Net station maps and typhoon track maps so these visuals can be selectively enabled per session.

Bug Fixes:
- Prevent duplicate and overly verbose logging for map tile request failures by downgrading repetitive resource error logs and aggregating them into summarized entries.
- Ensure GeoIP shared sessions are properly closed during plugin shutdown even when the web admin server is disabled or not used.

Enhancements:
- Refine EQSC polling configuration by unifying poll interval settings across typhoon, tsunami, and intensity services with updated defaults and stricter global-only handling.
- Hardcode and centralize EQSC base URL, EQSC host resolution, FAN Studio app ID, tsunami cache TTL, and raw message log file name to remove unnecessary user-facing configuration and improve robustness.
- Adjust browser context handling to share a single Playwright context across pages and support context-level settings such as HTTPS error ignore.
- Relax connection health high-latency thresholds and improve admin schema/UI handling of sensitive fields like EQSC refresh tokens.
- Clean up imports and minor utilities across services, storage, HTTP clients, and presenters to reduce duplication and improve maintainability.

Documentation:
- Document the new browser_ignore_https_errors option and its security implications in the README configuration section.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持配置是否附加 S-Net 测站分布图和台风路径图。
  * 本地浏览器模式支持忽略 HTTPS 证书错误，并提示安全风险。
* **配置优化**
  * EQSC 统一使用轮询间隔配置，默认值及校验范围调整。
  * 简化数据源和调试日志配置，原始消息日志统一保存为固定文件名。
* **改进**
  * 地图缓存按渲染设置区分，减少错误复用。
  * 优化地图渲染失败提示及资源清理。
  * 高延迟连接判定阈值调整为 2000 毫秒。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->