### PR TITLE
chore: 优化全链路日志输出策略，削减高频 DEBUG 刷屏

### DIFF
--- a/core/app/disaster_service.py
+++ b/core/app/disaster_service.py
@@ -298,12 +298,6 @@ class DisasterWarningService:
             logger.warning(
                 f"[灾害预警] 以下数据源缺少 SOURCE_CATALOG.source_enum 定义: {missing_source_enum}"
             )
-        if (
-            not unresolved_presenters
-            and not missing_text_presenters
-            and not missing_source_enum
-        ):
-            logger.debug("[灾害预警] source catalog / presenter 注册完整性自检通过")
 
     def set_telemetry(self, telemetry: Optional["TelemetryManager"]):
         """设置遥测管理器引用。"""

--- a/core/app/pipeline/event_pipeline.py
+++ b/core/app/pipeline/event_pipeline.py
@@ -260,14 +260,13 @@ class EventPipeline:
         target_sessions = (
             self.service.session_config_manager.list_target_sessions()
         )  # 获取所有目标会话
-        push_result = await self.service.message_manager.push_event(
+        # 未推送不一定代表异常，常见原因包括规则过滤未命中、会话未订阅，或事件被静默策略抑制。
+        # 未推送明细由 _log_filter_summary 的 INFO 汇总（会话筛选结果）承担，此处不再单独兜底。
+        await self.service.message_manager.push_event(
             event,
             target_sessions=target_sessions,
             session_config_getter=self.service.session_config_manager.get_effective_config,
         )
-        if not push_result:
-            # 未推送不一定代表异常，常见原因包括规则过滤未命中、会话未订阅，或事件被静默策略抑制。
-            logger.debug(f"[灾害预警] 事件未产生实际推送: {envelope.id}")
 
     async def _flush_weather_buffer(
         self,

--- a/core/message/logging/filters/message_log_dedup_service.py
+++ b/core/message/logging/filters/message_log_dedup_service.py
@@ -34,7 +34,6 @@ class MessageLogDedupService:
         try:
             new_content_clean = self.extract_content_without_timestamp(new_log_content)
             if new_content_clean in self.logger.recent_raw_logs:
-                logger.debug("[灾害预警] 发现内容完全重复的日志（内存缓存），跳过写入")
                 return True
 
             self.logger.recent_raw_logs.append(new_content_clean)

--- a/core/message/logging/filters/raw_message_filter.py
+++ b/core/message/logging/filters/raw_message_filter.py
@@ -102,11 +102,6 @@ class RawMessageFilter:
             )
             return ""
 
-        msg_type = data.get("type", "")
-        logger.debug(
-            f"[灾害预警] 消息记录器 - 检查消息过滤，来源: {source_id}, 类型: {msg_type}, 数据长度: {len(payload_data)}"
-        )
-
         # 字符串入口同样执行 OpenQuakeAPI 业务类型检查，
         # 与字典入口保持一致，避免 tsunami/station/status 等字符串消息绕过过滤。
         reason = self._check_openquake_api_type(data, source_id)
@@ -131,10 +126,6 @@ class RawMessageFilter:
 
     def _handle_dict_message(self, payload_data: dict[str, Any], source_id: str) -> str:
         """处理字典形态的原始消息。"""
-        msg_type = payload_data.get("type", "")
-        logger.debug(
-            f"[灾害预警] 消息记录器 - 检查字典类型消息，来源: {source_id}, 类型: {msg_type}"
-        )
         return self._handle_common_dict_checks(payload_data, source_id)
 
     def _handle_inner_dict_checks(
@@ -163,7 +154,6 @@ class RawMessageFilter:
         # 保证统计口径稳定且便于理解每条消息被过滤的首要原因。
         if msg_type and msg_type.lower() in self.filter_types:
             self.filter_stats["heartbeat_filtered"] += 1
-            logger.debug(f"[灾害预警] 消息记录器 - 消息类型过滤: {msg_type}")
             return f"消息类型过滤: {msg_type}"
 
         if self.filter_p2p_areas and self._is_p2p_areas_message(data):
@@ -175,18 +165,13 @@ class RawMessageFilter:
             is_duplicate = self._is_duplicate_event(data, source_id)
             if is_duplicate:
                 self.filter_stats["duplicate_events_filtered"] += 1
-                logger.debug(
-                    f"[灾害预警] 消息记录器 - 重复事件过滤，哈希: {event_hash}"
-                )
                 return f"重复事件 (哈希: {event_hash})"
             elif event_hash:
-                logger.debug(
-                    f"[灾害预警] 消息记录器 - 事件哈希生成: {event_hash}, 允许记录"
-                )
+                # 哈希生成/允许记录为每条消息常态，无需逐一记录
+                pass
 
         if self.filter_connection_status and self._is_connection_status_message(data):
             self.filter_stats["connection_status_filtered"] += 1
-            logger.debug("[灾害预警] 消息记录器 - 连接状态消息过滤")
             return "连接状态消息"
 
         return ""

--- a/core/message/logging/stores/raw_message_logging_service.py
+++ b/core/message/logging/stores/raw_message_logging_service.py
@@ -142,15 +142,13 @@ class RawMessageLoggingService:
         filter_reason: str,
     ) -> None:
         """处理被过滤消息的统计与日志输出。"""
+        # 心跳/类型/P2P/重复事件等高频过滤逐条打日志会刷屏，统计由 filter_stats 汇总承担；
+        # 仅对低频过滤原因留一条 debug 便于排障。
         is_high_frequency = any(
             keyword in filter_reason
             for keyword in ["消息类型过滤", "P2P节点状态", "心跳", "重复事件"]
         )
-        if is_high_frequency:
-            logger.debug(
-                f"[灾害预警] 过滤消息 - 来源: {source}, 类型: {message_type}, 原因: {filter_reason}"
-            )
-        else:
+        if not is_high_frequency:
             logger.debug(
                 f"[灾害预警] 过滤日志消息 - 来源: {source}, 类型: {message_type}, 原因: {filter_reason}"
             )

--- a/core/message/logging/support/p2p_area_mapping_loader.py
+++ b/core/message/logging/support/p2p_area_mapping_loader.py
@@ -36,9 +36,6 @@ class P2PAreaMappingLoader:
                         except (ValueError, IndexError):
                             continue
 
-                logger.debug(
-                    f"[灾害预警] 成功加载 {len(area_mapping)} 个P2P区域代码映射"
-                )
             else:
                 logger.warning("[灾害预警] 未找到epsp-area.csv文件，请检查资源完整性")
         except Exception as e:

--- a/core/message/message_logger.py
+++ b/core/message/message_logger.py
@@ -136,12 +136,6 @@ class MessageLogger:
         self._earthquake_list_summary_service = EarthquakeListSummaryService(self)
 
         logger.debug("[灾害预警] 消息记录器初始化完成")
-        if self.filter_heartbeat:
-            logger.debug("[灾害预警] 消息过滤配置已启用:")
-            logger.debug(f"[灾害预警] - 基础类型过滤: {self.filter_types}")
-            logger.debug(f"[灾害预警] - P2P节点状态过滤: {self.filter_p2p_areas}")
-            logger.debug(f"[灾害预警] - 重复事件过滤: {self.filter_duplicate_events}")
-            logger.debug(f"[灾害预警] - 连接状态过滤: {self.filter_connection_status}")
 
     def set_silence_checker(self, checker) -> None:
         """注入启动静默判定回调（通常绑定主服务 is_silencing）。"""

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -1193,7 +1193,6 @@ class MessageBuildService:
             if appended:
                 return
 
-
     async def _append_tsunami_media_if_needed(
         self,
         chain: MessageChain,

--- a/core/message/push/message_build_service.py
+++ b/core/message/push/message_build_service.py
@@ -561,9 +561,6 @@ class MessageBuildService:
                 or normalized_url.startswith("https://")
             )
         ):
-            logger.debug(
-                f"[灾害预警] 跳过非 HTTP 图片链接 ({media_label}): {normalized_url}"
-            )
             return False
 
         # 调用抓取服务拉取远程图片二进制数据
@@ -587,16 +584,11 @@ class MessageBuildService:
         if fetch_result:
             error_msg = str(fetch_result.get("error") or "")
             # 特征识别：气象预警图标接口返回伪图片（HTML 错误页伪装为 image/png），
-            # 这类失败稳定触发，降级为 DEBUG 避免控制台刷屏。
+            # 这类失败稳定触发、会走本地回退，不再逐条打 DEBUG 避免刷屏。
             is_pseudo_image = media_label == "气象预警图标" and any(
                 marker in error_msg for marker in self._PSEUDO_IMAGE_ERROR_MARKERS
             )
-            if is_pseudo_image:
-                logger.debug(
-                    f"[灾害预警] 气象预警图标接口返回伪图片，将走本地回退: "
-                    f"编码相关 URL：{normalized_url}, 错误信息：{error_msg}"
-                )
-            else:
+            if not is_pseudo_image:
                 logger.warning(
                     "[灾害预警] 远程图片抓取失败 "
                     f"({media_label}): source={fetch_result.get('source_url')}, final={fetch_result.get('final_url')}, "
@@ -742,7 +734,6 @@ class MessageBuildService:
                 session_log = self.manager._get_session_log_str(session)
                 try:
                     await self.manager.session_sender.send(session, map_message)
-                    logger.debug(f"[灾害预警] 分离地图已发送到 {session_log}")
                 except Exception as e:
                     logger.error(f"[灾害预警] 分离地图发送到 {session_log} 失败: {e}")
         except Exception as e:
@@ -883,7 +874,6 @@ class MessageBuildService:
             with open(out, "rb") as f:
                 b64_data = base64.b64encode(f.read()).decode()
             chain.chain.append(Comp.Image.fromBase64(b64_data))
-            logger.debug("[灾害预警] 已附加 S-Net 测站分布图")
             # 不删除 out：交给 RenderImageCache / 临时目录清理服务回收
         except Exception as e:
             logger.error(f"[灾害预警] S-Net 测站图渲染失败: {e}")
@@ -957,7 +947,6 @@ class MessageBuildService:
             with open(out, "rb") as f:
                 b64_data = base64.b64encode(f.read()).decode()
             chain.chain.append(Comp.Image.fromBase64(b64_data))
-            logger.debug("[灾害预警] 已附加台风路径图")
         except Exception as e:
             logger.error(f"[灾害预警] 台风路径图渲染失败: {e}")
 
@@ -1005,7 +994,6 @@ class MessageBuildService:
                 with open(map_image_path, "rb") as f:
                     b64_data = base64.b64encode(f.read()).decode()
                 chain.chain.append(Comp.Image.fromBase64(b64_data))
-                logger.debug("[灾害预警] 已附加地图图片 (Base64模式)")
             except Exception as b64_err:
                 logger.error(f"[灾害预警] 地图图片转Base64失败: {b64_err}")
         except Exception as e:
@@ -1152,7 +1140,6 @@ class MessageBuildService:
                 with open(local_icon_path, "rb") as f:
                     b64_data = base64.b64encode(f.read()).decode()
                 chain.chain.append(Comp.Image.fromBase64(b64_data))
-                logger.debug(f"[灾害预警] 已附加本地气象预警图标: {local_icon_path}")
                 return
             except Exception as e:
                 logger.warning(
@@ -1186,10 +1173,7 @@ class MessageBuildService:
                 with open(fallback_path, "rb") as f:
                     b64_data = base64.b64encode(f.read()).decode()
                 chain.chain.append(Comp.Image.fromBase64(b64_data))
-                logger.debug(
-                    f"[灾害预警] 本地具体图标缺失，已回退到本地通用颜色图标: "
-                    f"预警编码为 {raw_weather_code}, 解析码为 {icon_code}"
-                )
+                # 本地颜色回退成功为常态路径，不再逐条打日志
                 return
             except Exception as e:
                 logger.warning(
@@ -1207,13 +1191,8 @@ class MessageBuildService:
                 allow_url_fallback=False,
             )
             if appended:
-                logger.debug(f"[灾害预警] 已附加气象预警图标: {icon_url}")
                 return
 
-        logger.debug(
-            f"[灾害预警] 气象预警图标下载失败且无可用回退图标，已跳过: "
-            f"原始编码={raw_weather_code}, 解析码={icon_code}"
-        )
 
     async def _append_tsunami_media_if_needed(
         self,

--- a/core/message/push/push_execution_service.py
+++ b/core/message/push/push_execution_service.py
@@ -348,14 +348,10 @@ class PushExecutionService:
                         )
                     return False, session, None, "发送前复核未通过"
 
-                logger.debug(
-                    f"[灾害预警] 事件 {event.id} 通过 {session_log} 的发送前复核，准备发送消息"
-                )
                 # 获取复用或动态渲染的图片/卡片消息链
                 message = await get_or_build_message(runtime_config)
                 # 调用底座 Session 发送器下发消息
                 await self.manager.session_sender.send(session, message)
-                logger.debug(f"[灾害预警] 事件 {event.id} 已推送到 {session_log}")
                 return True, session, runtime_config.get("message_format", {}), None
             except Exception as e:
                 error_name = type(e).__name__

--- a/core/message/render/render_cache.py
+++ b/core/message/render/render_cache.py
@@ -58,7 +58,6 @@ class RenderImageCache:
                 _, image_path = cached_item
                 # 若文件还存在于磁盘上，则直接复用
                 if os.path.exists(image_path):
-                    logger.debug(f"[灾害预警] 命中渲染缓存: {cache_key}")
                     return image_path
 
             # 同一 cache_key 若已有渲染中的任务，后续调用直接等待该任务，

--- a/core/message/render/render_cache.py
+++ b/core/message/render/render_cache.py
@@ -10,8 +10,6 @@ import os
 import time
 from collections.abc import Awaitable, Callable
 
-from astrbot.api import logger
-
 
 class RenderImageCache:
     """渲染图片缓存器。"""

--- a/core/message/runtime/browser_manager.py
+++ b/core/message/runtime/browser_manager.py
@@ -366,7 +366,6 @@ class BrowserManager:
         try:
             if await self._ensure_local_browser_ready():
                 page = await self._create_local_page()
-                logger.debug("[灾害预警] 页面池暂无可用页，已直接创建应急页面")
                 return page
         except Exception as create_err:
             logger.error(f"[灾害预警] 创建应急页面失败: {create_err}")
@@ -388,9 +387,6 @@ class BrowserManager:
                     if not await self._put_page_into_pool(new_page):
                         # 池已满：停止补充
                         break
-                    logger.debug(
-                        f"[灾害预警] 已补充页面，当前池大小: {self._page_pool.qsize()}/{self.pool_size}"
-                    )
                 except Exception as recover_err:
                     logger.error(f"[灾害预警] 页面恢复失败: {recover_err}")
                     break
@@ -577,7 +573,6 @@ class BrowserManager:
                 page = await asyncio.wait_for(context.new_page(), timeout=10.0)
                 if not await self._put_page_into_pool(page):
                     break
-                logger.debug(f"[灾害预警] 页面 {i + 1}/{self.pool_size} 已创建")
             except asyncio.TimeoutError:
                 logger.error(f"[灾害预警] 创建页面 {i + 1} 超时")
                 if i == 0:
@@ -594,15 +589,12 @@ class BrowserManager:
         try:
             # browserless CDP：必须使用默认 context
             contexts = self._browser.contexts
-            logger.debug(f"[灾害预警] 发现 {len(contexts)} 个现有 context")
 
             if contexts:
                 # 使用第一个 context（browserless 的默认 context）
                 self._context = contexts[0]
-                logger.debug("[灾害预警] 使用现有 context")
             else:
                 # 没有现有 context，创建新的
-                logger.debug("[灾害预警] 创建新 context")
                 self._context = await asyncio.wait_for(
                     self._browser.new_context(
                         viewport=dict(self.DEFAULT_VIEWPORT),
@@ -619,7 +611,6 @@ class BrowserManager:
                     )
                     if not await self._put_page_into_pool(page):
                         break
-                    logger.debug(f"[灾害预警] 页面 {i + 1}/{self.pool_size} 已创建")
                 except asyncio.TimeoutError:
                     logger.error(f"[灾害预警] 创建页面 {i + 1} 超时")
                     if i == 0:
@@ -757,11 +748,9 @@ class BrowserManager:
                                     )
                                 )
                             )
-                            if is_dup_resource_log:
-                                logger.debug(
-                                    f"[灾害预警] 忽略与资源请求失败重复的控制台日志: {entry}"
-                                )
-                            else:
+                            # 与资源请求失败重复的控制台日志仅追加，不逐条打日志；
+                            # 渲染结束时由汇总逻辑统一输出，避免每条瓦片刷两条日志。
+                            if not is_dup_resource_log:
                                 logger.warning(f"[灾害预警] 页面控制台{entry}")
                         except Exception as hook_err:
                             logger.debug(f"[灾害预警] 记录控制台日志失败: {hook_err}")
@@ -803,18 +792,13 @@ class BrowserManager:
                                 failure_text=failure_text,
                                 resource_type=resource_type,
                             ):
+                                # 良性中止仅收集计数，渲染结束时统一汇总，避免逐条刷屏。
                                 benign_request_failures.append(entry)
-                                logger.debug(
-                                    f"[灾害预警] 忽略可预期的资源中止: {entry}"
-                                )
                                 return
                             # 方案A：瓦片类失败（如证书过期等真实错误）一律降级为 debug，
                             # 仅在末尾统一去重汇总一条，避免每张瓦片刷屏。
                             if is_tile:
                                 tile_request_failures.append(entry)
-                                logger.debug(
-                                    f"[灾害预警] 瓦片资源请求失败(已降级为debug): {entry}"
-                                )
                                 return
                             request_failures.append(entry)
                             logger.warning(f"[灾害预警] 页面资源请求失败: {entry}")
@@ -829,10 +813,6 @@ class BrowserManager:
                     # 大尺寸卡片（如 S-Net）临时放大视口，截图后在 finally 中恢复默认
                     if resolved_viewport:
                         await page.set_viewport_size(resolved_viewport)
-                        logger.debug(
-                            f"[灾害预警] 临时视口已设为 "
-                            f"{resolved_viewport['width']}x{resolved_viewport['height']}"
-                        )
 
                     # 本地模式：使用 file:// 协议（支持相对路径资源）
                     temp_html = None
@@ -880,7 +860,6 @@ class BrowserManager:
                             await page.wait_for_selector(
                                 ".map-ready", state="attached", timeout=10000
                             )
-                            logger.debug("[灾害预警] 地图渲染标记已就绪")
                         except Exception:
                             logger.warning(
                                 f"[灾害预警] {label}等待 .map-ready 标记超时，地图可能未完全加载"
@@ -907,10 +886,7 @@ class BrowserManager:
                             selector, state="visible", timeout=2000
                         )
                     except Exception:
-                        # 兜底：尝试找常见的类名。该分支在部分模板中属于正常兼容路径，不额外输出诊断日志。
-                        logger.debug(
-                            f"[灾害预警] 选择器 {selector} 未找到，尝试备用选择器"
-                        )
+                        # 兜底：尝试找常见的类名。该分支在部分模板中属于正常兼容路径，不输出诊断日志。
                         selector = ".quake-card"
                         await page.wait_for_selector(
                             selector, state="visible", timeout=1000

--- a/core/network/http/eqsc_cenc_intensity_client.py
+++ b/core/network/http/eqsc_cenc_intensity_client.py
@@ -168,7 +168,6 @@ class EqscCencIntensityClient(EqscHttpClient):
     ) -> list[dict[str, Any]]:
         """获取 CENC 烈度速报列表（规范化后的有序条目）。"""
         if use_cache and self._list_cache and self._is_cache_valid(self._list_cache[1]):
-            logger.debug("[灾害预警] EQSC CENC 烈度速报列表命中缓存")
             return list(self._list_cache[0])
 
         if not self._base_url:
@@ -201,9 +200,6 @@ class EqscCencIntensityClient(EqscHttpClient):
 
             items = self.normalize_list_payload(data)
             self._list_cache = (items, time.time() + self._cache_ttl)
-            logger.debug(
-                f"[灾害预警] EQSC CENC 烈度速报列表查询成功，共 {len(items)} 条"
-            )
             return list(items)
         except Exception as e:
             logger.error(
@@ -227,9 +223,6 @@ class EqscCencIntensityClient(EqscHttpClient):
         if use_cache:
             cached = self._detail_cache.get(normalized_id)
             if cached and self._is_cache_valid(cached[1]):
-                logger.debug(
-                    f"[灾害预警] EQSC CENC 烈度速报详情 {normalized_id} 命中缓存"
-                )
                 return cached[0]
 
         if not self._base_url:
@@ -252,9 +245,6 @@ class EqscCencIntensityClient(EqscHttpClient):
                 return None
 
             self._store_detail_cache(normalized_id, data)
-            logger.debug(
-                f"[灾害预警] EQSC CENC 烈度速报详情 {normalized_id} 查询成功并已缓存"
-            )
             return data
         except Exception as e:
             logger.error(

--- a/core/network/http/eqsc_token_manager.py
+++ b/core/network/http/eqsc_token_manager.py
@@ -139,17 +139,11 @@ class EqscTokenManager:
         if not force_refresh:
             cached = self._cached_token_if_usable(require_advance_margin=True)
             if cached:
-                logger.debug(
-                    f"[灾害预警] EQSC 复用缓存 AccessToken {self._mask_token(cached)}"
-                )
+                # 有效期内复用为高频常态，无需逐一记录
                 return cached
         elif stale:
             cached = self._cached_token_if_usable(require_advance_margin=False)
             if cached and cached != stale:
-                logger.debug(
-                    "[灾害预警] EQSC 强制刷新前发现已有更新令牌，直接复用 "
-                    f"{self._mask_token(cached)}"
-                )
                 return cached
 
         async with self._lock:
@@ -160,10 +154,6 @@ class EqscTokenManager:
                     current_time=current_time, require_advance_margin=True
                 )
                 if cached:
-                    logger.debug(
-                        "[灾害预警] EQSC 复用缓存 AccessToken "
-                        f"{self._mask_token(cached)}"
-                    )
                     return cached
             else:
                 # 401 并发刷新：若锁内已有可用令牌且不是传入的 stale 令牌，说明别人刚换发成功，复用新令牌。

--- a/core/network/http/eqsc_tsunami_client.py
+++ b/core/network/http/eqsc_tsunami_client.py
@@ -99,7 +99,6 @@ class EqscTsunamiClient(EqscHttpClient):
                 return None
 
             self._latest_cache = (data, time.time() + self._cache_ttl)
-            logger.debug("[灾害预警] EQSC 海啸快照查询成功并已缓存")
             return data
         except Exception as e:
             logger.error(

--- a/core/network/http/eqsc_typhoon_client.py
+++ b/core/network/http/eqsc_typhoon_client.py
@@ -80,7 +80,6 @@ class EqscTyphoonClient(EqscHttpClient):
         if use_cache:
             cached = self._cache.get(typhoon_id)
             if cached and self._is_cache_valid(cached[1]):
-                logger.debug(f"[灾害预警] EQSC 台风 {typhoon_id} 命中缓存")
                 return cached[0]
 
         # 获取 AccessToken
@@ -109,7 +108,6 @@ class EqscTyphoonClient(EqscHttpClient):
             typhoon_data = typhoon_list[0]
             # 写入缓存
             self._cache[typhoon_id] = (typhoon_data, time.time() + self._cache_ttl)
-            logger.debug(f"[灾害预警] EQSC 台风 {typhoon_id} 查询成功并已缓存")
             return typhoon_data
 
         except Exception as e:
@@ -134,7 +132,6 @@ class EqscTyphoonClient(EqscHttpClient):
         """
         # 检查缓存
         if use_cache and self._list_cache and self._is_cache_valid(self._list_cache[1]):
-            logger.debug("[灾害预警] EQSC 台风列表命中缓存")
             return self._list_cache[0]
 
         # 获取 AccessToken
@@ -155,9 +152,6 @@ class EqscTyphoonClient(EqscHttpClient):
             typhoon_list = data.get("typhoon", []) if isinstance(data, dict) else []
             # 写入缓存
             self._list_cache = (typhoon_list, time.time() + self._cache_ttl)
-            logger.debug(
-                f"[灾害预警] EQSC 台风列表查询成功，共 {len(typhoon_list)} 个台风"
-            )
             return typhoon_list
 
         except Exception as e:

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -387,8 +387,6 @@ class SourceMessageRouter:
                             plugin_logger.debug(
                                 f"[灾害预警] FAN initial_all 通知静默协调器失败: {exc}"
                             )
-                processed_count = 0
-
                 # 遍历被分配出来的数据源及负载，分别尝试分发
                 for source, source_id, payload in messages_to_process:
                     if not self._is_source_routable(source_id, source):
@@ -400,7 +398,7 @@ class SourceMessageRouter:
                         event_stream=self._resolve_stream_by_source_id(source_id),
                         is_silent_window=True,
                     )
-                    dispatched = await self._parse_and_dispatch(
+                    await self._parse_and_dispatch(
                         source_id=source_id,
                         source_label=source,
                         parser_input=json.dumps(payload),
@@ -409,14 +407,9 @@ class SourceMessageRouter:
                         source_channel=source,
                         parser_log_label=source,
                     )
-                    if dispatched:
-                        processed_count += 1
 
-                # 没有任何子消息被路由：心跳/未知包均属常态，不再逐条打日志，
+                # 没有任何子消息被路由：心跳/未知包均属常态，无需逐条打日志，
                 # 避免高频未知消息刷屏。真正的异常由上层 error 日志承担。
-                if processed_count == 0 and not messages_to_process:
-                    pass
-
                 return None
 
             except Exception as error:

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -190,13 +190,6 @@ class SourceMessageRouter:
                     event.metadata.setdefault("bootstrap", True)
                     if connection_name and not event.metadata.get("bootstrap_kind"):
                         event.metadata["bootstrap_kind"] = "conn_first_wave"
-            log_label = parser_log_label or source_label or source_id
-            plugin_logger.debug(
-                f"[灾害预警] {log_label} 解析成功: {event.id}",
-                is_event_linked=True,
-                event_stream=self._resolve_stream_by_source_id(source_id),
-            )
-
             # 将解析好的事件丢给分发流水线处理
             await self._dispatch_event(
                 event,
@@ -332,9 +325,6 @@ class SourceMessageRouter:
 
                 # 鉴权成功回执：不进入业务解析
                 if msg_type in {"auth_success", "auth_ok", "authenticated"}:
-                    plugin_logger.debug(
-                        f"[灾害预警] FAN Studio 鉴权成功: {connection_name or 'unknown'}"
-                    )
                     return None
 
                 # FAN Studio 会以业务错误包表达限流/策略拒绝；收到后主动关闭，尽快释放上游配额
@@ -376,12 +366,6 @@ class SourceMessageRouter:
                 if isinstance(data, dict) and self._is_fan_preauth_partial_initial_all(
                     data
                 ):
-                    plugin_logger.debug(
-                        f"[灾害预警] 忽略 FAN 鉴权前半量 initial_all"
-                        f"（连接 {connection_name or 'unknown'}，"
-                        f"源: {self._fan_initial_all_known_source_keys(data)}），"
-                        "等待完整快照"
-                    )
                     return None
 
                 # 先校验路由映射，再把一条总线消息拆成多个候选数据源消息
@@ -428,21 +412,10 @@ class SourceMessageRouter:
                     if dispatched:
                         processed_count += 1
 
-                # 没有任何子消息被路由时，只对真正异常或未识别数据做调试记录，避免心跳刷屏
+                # 没有任何子消息被路由：心跳/未知包均属常态，不再逐条打日志，
+                # 避免高频未知消息刷屏。真正的异常由上层 error 日志承担。
                 if processed_count == 0 and not messages_to_process:
-                    is_heartbeat = (
-                        data.get("type") in ["heartbeat", "ping", "pong"]
-                        or "timestamp" in data
-                        and len(data) <= 3
-                    )
-                    # 过滤心跳包后，对其他未知包进行 debug 日志留存
-                    if not is_heartbeat:
-                        has_data = "Data" in data or "data" in data
-                        is_unhandled_initial = msg_type == "initial_all"
-                        if has_data or is_unhandled_initial:
-                            plugin_logger.debug(
-                                f"[灾害预警] 收到一条尚未处理的消息，连接为 {connection_name}，消息类型为 {msg_type}，来源为 {data.get('source', 'unknown')}，数据摘要：{str(data)[:100]}"
-                            )
+                    pass
 
                 return None
 
@@ -518,15 +491,13 @@ class SourceMessageRouter:
             )
 
             # 启动候选者解析轮询
-            dispatched = await self._parse_candidate_source_ids(
+            await self._parse_candidate_source_ids(
                 source_ids=list(candidate_source_ids),
                 parser_input=message,
                 connection_name=connection_name,
                 connection_info=connection_info,
                 source_channel=code or None,
             )
-            if not dispatched:
-                plugin_logger.debug("[灾害预警] P2P处理器返回None，无有效事件")
 
         return p2p_handler
 
@@ -590,10 +561,6 @@ class SourceMessageRouter:
 
                 if not self._is_source_routable(source_id, msg_type):
                     return None
-
-                plugin_logger.debug(
-                    f"[灾害预警] 将使用 Wolfx 解析器 {source_id} 处理类型为 {msg_type} 的消息"
-                )
                 # 某些 Wolfx 消息在正式解析前需要先触发旁路副作用（比如缓存 eqlist）
                 await self._side_effect_service.process_message(
                     source_id=source_id,
@@ -670,10 +637,7 @@ class SourceMessageRouter:
 
                 raw_text = message if isinstance(message, str) else None
                 if raw_text is None:
-                    plugin_logger.debug(
-                        f"[灾害预警] OpenQuakeAPI 忽略非文本/非二进制消息，"
-                        f"类型为 {type(message).__name__}"
-                    )
+                    # 非文本/非二进制消息为混流常态，不逐一记录
                     return
 
                 try:
@@ -685,7 +649,7 @@ class SourceMessageRouter:
                     return
 
                 if not isinstance(data, dict):
-                    plugin_logger.debug("[灾害预警] OpenQuakeAPI 忽略非对象 JSON 消息")
+                    # 非对象 JSON 消息为混流常态，不逐一记录
                     return
 
                 source_name = str(data.get("source") or "").strip()

--- a/core/network/source_message_router.py
+++ b/core/network/source_message_router.py
@@ -82,6 +82,11 @@ class SourceMessageRouter:
         self._dispatch_service = service.event_ingress_dispatch_service
         self._side_effect_service = service.source_ingress_side_effect_service
         self._source_runtime_query = service.source_runtime_query
+        # Wolfx 未知消息节流：连续未知类型仅首次与每 N 轮各打一次，
+        # 避免极端情况下高频未知类型逐条刷屏，同时保留排查价值。
+        self._wolfx_unknown_logged = False
+        self._wolfx_unknown_rounds = 0
+        self._wolfx_unknown_log_interval = 60
 
     def register_all(self, ws_manager: WebSocketManager):
         """把各连接族处理器注册到 WebSocket 管理器。"""
@@ -547,9 +552,25 @@ class SourceMessageRouter:
                 # 获取 Wolfx 当前子报文类型对应的系统内 source_id
                 source_id = get_wolfx_source_id(msg_type)
                 if source_id is None:
-                    plugin_logger.debug(
-                        f"[灾害预警] Wolfx 消息类型 {msg_type} 暂未识别，来源连接为 {connection_name}"
-                    )
+                    # 未知类型属罕见异常态，但为防极端情况下高频未知类型刷屏，
+                    # 连续未知仅在首次与每 _wolfx_unknown_log_interval 轮各打一次。
+                    if not self._wolfx_unknown_logged:
+                        plugin_logger.debug(
+                            f"[灾害预警] Wolfx 消息类型 {msg_type} 暂未识别，"
+                            f"来源连接为 {connection_name}"
+                        )
+                        self._wolfx_unknown_logged = True
+                    else:
+                        self._wolfx_unknown_rounds += 1
+                        if (
+                            self._wolfx_unknown_rounds
+                            >= self._wolfx_unknown_log_interval
+                        ):
+                            self._wolfx_unknown_rounds = 0
+                            plugin_logger.debug(
+                                f"[灾害预警] Wolfx 连续 {self._wolfx_unknown_log_interval} 轮 "
+                                f"未识别消息类型，最近为 {msg_type}"
+                            )
                     return None
 
                 if not self._is_source_routable(source_id, msg_type):

--- a/core/network/websocket/websocket_dispatch_service.py
+++ b/core/network/websocket/websocket_dispatch_service.py
@@ -71,9 +71,11 @@ class WebSocketDispatchService:
                     # 抛出 socket 传输错误
                     raise msg.data
                 elif msg.type == WSMsgType.CLOSED:
-                    logger.debug(
-                        f"[灾害预警] WebSocket {name} 的连接已收到关闭帧，关闭码为 {websocket.close_code}"
-                    )
+                    # 正常关闭码由 handle_close_code 的 INFO 汇总承担，此处仅保留非正常关闭码明细
+                    if websocket.close_code not in self._NORMAL_CLOSE_CODES:
+                        logger.debug(
+                            f"[灾害预警] WebSocket {name} 的连接已收到关闭帧，关闭码为 {websocket.close_code}"
+                        )
                     break
                 elif msg.type in {WSMsgType.PING, WSMsgType.PONG}:
                     # 保活心跳帧，只需刷新该连接的活跃时间即可

--- a/core/network/websocket/websocket_hub.py
+++ b/core/network/websocket/websocket_hub.py
@@ -111,9 +111,6 @@ class WebSocketHub:
         for websocket in disconnected:
             self.remove(websocket)
 
-        if event_data:
-            logger.debug(f"[灾害预警] 已推送新事件到 {self.count()} 个客户端")
-
     async def close_all(self) -> None:
         """关闭并清空所有连接。"""
         # 遍历所有客户端进行握手关闭

--- a/core/parsers/base_parser.py
+++ b/core/parsers/base_parser.py
@@ -83,14 +83,11 @@ class BaseParser:
         """提取实际业务数据，兼容多种外层包装格式。"""
         # 兼容首字母大写的 "Data" 键
         if "Data" in data:
-            plugin_logger.debug(f"[灾害预警] {self.source_id} 使用 Data 字段获取数据")
             return data["Data"] or {}
         # 兼容小写的 "data" 键
         if "data" in data:
-            plugin_logger.debug(f"[灾害预警] {self.source_id} 使用 data 字段获取数据")
             return data["data"] or {}
         # 无包装时，直接视整个载荷为数据体
-        plugin_logger.debug(f"[灾害预警] {self.source_id} 使用整个消息作为数据")
         return data
 
     def _is_heartbeat_message(self, msg_data: dict[str, Any]) -> bool:

--- a/core/parsers/china_earthquake_parser.py
+++ b/core/parsers/china_earthquake_parser.py
@@ -107,9 +107,6 @@ class CencEarthquakeParser(BaseParser):
 
             # 这类消息至少应具备情报类型与事件标识，否则通常不是正式测定数据
             if "infoTypeName" not in msg_data or "eventId" not in msg_data:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CENC 地震测定数据，跳过"
-                )
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -149,15 +146,10 @@ class CencEarthquakeWolfxParser(BaseParser):
                 for key, value in data.items()
                 if key.startswith("No") and isinstance(value, dict)
             ]
+            # 非 cenc_eqlist 类型与无法识别的列表结构均为混流常态，不逐一记录
             if raw_type and raw_type != "cenc_eqlist":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CENC 地震列表数据，跳过"
-                )
                 return None
             if not raw_type and not no_keys:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 未识别到 Wolfx CENC 列表结构，跳过"
-                )
                 return None
 
             eq_info = None
@@ -252,8 +244,11 @@ class CencEarthquakeWolfxParser(BaseParser):
                 metadata=metadata,
             )
 
-            plugin_logger.debug(
-                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}"
+            plugin_logger.info(
+                f"[灾害预警] 地震数据解析成功: {domain_event.place_name} (M {domain_event.magnitude}), 时间: {domain_event.occurred_at}",
+                is_event_linked=True,
+                event_stream="earthquake",
+                is_silent_window=True,
             )
 
             return envelope

--- a/core/parsers/china_eew_parser.py
+++ b/core/parsers/china_eew_parser.py
@@ -113,7 +113,6 @@ class CEAEEWParser(BaseParser):
 
             # 中国地震预警数据至少应携带预计烈度字段，否则大概率不是目标消息
             if "epiIntensity" not in msg_data:
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 非地震预警数据，跳过")
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -168,9 +167,6 @@ class CEAEEWWolfxParser(BaseParser):
         try:
             # Wolfx 会混发多类消息，这里只接收中国地震预警类型
             if data.get("type") != "cenc_eew":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CENC 地震预警数据，跳过"
-                )
                 return None
 
             raw_report_num = data.get("ReportNum", 1)

--- a/core/parsers/china_intensity_report_eqsc_parser.py
+++ b/core/parsers/china_intensity_report_eqsc_parser.py
@@ -290,9 +290,7 @@ class CencIntensityReportEqscParser(CencIntensityReportParser):
             else:
                 adapted = self.adapt_eqsc_detail_to_fan_shape(raw)
             if not adapted:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 EQSC CENC 烈度速报详情，跳过"
-                )
+                # 非 EQSC CENC 烈度速报详情为混流常态，不逐一记录
                 return None
 
             envelope = self._build_envelope(adapted)

--- a/core/parsers/china_intensity_report_parser.py
+++ b/core/parsers/china_intensity_report_parser.py
@@ -320,9 +320,6 @@ class CencIntensityReportParser(BaseParser):
             info_type_name = str(msg_data.get("infoTypeName") or "").strip()
             # 正式/自动测定报文即使混入速报字段名，也不按烈度速报处理。
             if "[正式测定]" in info_type_name or "[自动测定]" in info_type_name:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 疑似 CENC 测定报文，跳过"
-                )
                 return None
 
             has_report_body = any(
@@ -335,9 +332,7 @@ class CencIntensityReportParser(BaseParser):
                 )
             )
             if not uni_event_id or not has_report_body:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CENC 烈度速报数据，跳过"
-                )
+                # 非烈度速报数据为混流常态，不逐一记录
                 return None
 
             envelope = self._build_envelope(msg_data)

--- a/core/parsers/global_sources_parser.py
+++ b/core/parsers/global_sources_parser.py
@@ -96,14 +96,7 @@ class GlobalQuakeParser(BaseParser):
             if ws_msg.type == MessageType.HEARTBEAT:
                 return None
             if ws_msg.type == MessageType.STATUS:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到状态消息，服务器状态为 {ws_msg.status_data.server_status}"
-                )
                 return None
-
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 收到未知类型的消息，类型值为 {ws_msg.type}"
-            )
             return None
         except Exception as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} Protobuf 解析失败: {exc}")
@@ -114,7 +107,7 @@ class GlobalQuakeParser(BaseParser):
         try:
             data = json.loads(message)
             if not isinstance(data, dict):
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 忽略非对象 JSON 消息")
+                # 非对象 JSON 消息为混流常态，不逐一记录
                 return None
 
             msg_type = str(data.get("type") or "").strip().lower()
@@ -123,24 +116,14 @@ class GlobalQuakeParser(BaseParser):
 
             # 仅处理 Global Quake 路径事件；source 缺失时按历史兼容继续解析。
             if source and source not in {"gq", "global_quake", "globalquake"}:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 已忽略数据源 {source} 的消息"
-                )
                 return None
 
-            # JSON 通道当前主要关心地震消息，其余类型直接忽略。
             if msg_type == "earthquake":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到 JSON 地震消息，动作为 {action}"
-                )
                 if action == "cancelled":
                     return self._parse_earthquake_removal_json(data)
                 # update / archived 均进入统一地震解析；archived 在内部标记最终报
                 return self._parse_earthquake_data(data)
 
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 已忽略类型为 {msg_type or 'unknown'} 的消息"
-            )
             return None
         except json.JSONDecodeError as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
@@ -583,11 +566,6 @@ class GlobalQuakeParser(BaseParser):
             plugin_logger.error(f"[灾害预警] {self.source_id} 解析地震数据失败: {exc}")
             return None
 
-    def _parse_text_message(self, message: str) -> EventEnvelope | None:
-        """保留文本消息兼容处理。"""
-        plugin_logger.debug(f"[灾害预警] {self.source_id} 文本消息: {message}")
-        return None
-
     def _parse_data(self, data: dict[str, Any]) -> EventEnvelope | None:
         """实现基类抽象方法，默认按 JSON 地震数据处理。"""
         return self._parse_earthquake_data(data)
@@ -791,9 +769,6 @@ class ShakeAlertEewParser(BaseParser):
 
             # 与 USGS 区分：ShakeAlert 预警载荷不含官方事件页 url
             if self._get_field(msg_data, "url"):
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 检测到 USGS 特征字段 url，跳过"
-                )
                 return None
 
             # 与 FSSN 区分：共享守卫（ID 前缀 + 特征字段）
@@ -801,9 +776,6 @@ class ShakeAlertEewParser(BaseParser):
                 msg_data,
                 get_value=lambda field: self._get_field(msg_data, field),
             ):
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 检测到 FSSN 特征，跳过"
-                )
                 return None
 
             # 检测关键字段完整度（复用 _get_field，兼容 camelCase / PascalCase）

--- a/core/parsers/japan_earthquake_parser.py
+++ b/core/parsers/japan_earthquake_parser.py
@@ -32,14 +32,8 @@ class JmaEarthquakeP2PParser(BaseParser):
 
             # P2P 中 551 表示日本地震情报，其余业务码直接忽略。
             if code == 551:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到地震情报(code:551)"
-                )
                 return self._parse_earthquake_data(data)
 
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 非地震情报数据，code: {code}"
-            )
             return None
         except json.JSONDecodeError as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
@@ -225,9 +219,6 @@ class JmaEarthquakeWolfxParser(BaseParser):
         try:
             # Wolfx 中只对日本地震列表消息做处理，其余类型直接跳过
             if data.get("type") != "jma_eqlist":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 JMA 地震列表数据，跳过"
-                )
                 return None
 
             eq_info = None

--- a/core/parsers/japan_eew_parser.py
+++ b/core/parsers/japan_eew_parser.py
@@ -113,9 +113,6 @@ class JmaEewFanStudioParser(BaseParser):
 
             # 预计震度与情报类型至少应命中其一，否则通常不是正式预警消息
             if "epiIntensity" not in msg_data and "infoTypeName" not in msg_data:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过"
-                )
                 return None
 
             # 取消报在当前推送链中不作为正式地震事件继续向后处理
@@ -168,21 +165,13 @@ class JmaEewP2PParser(BaseParser):
             data = json.loads(message)
             code = data.get("code")
 
-            # P2P 用业务码区分不同类型，其中 556 才是正式紧急地震速报
+            # P2P 用业务码区分不同类型，其中 556 才是正式紧急地震速报。
+            # 554 发布检测与其余码为混流常态，不逐一记录
             if code == 556:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到紧急地震速报（警报）"
-                )
                 return self._parse_eew_data(data)
             if code == 554:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到紧急地震速报发布检测消息，忽略"
-                )
                 return None
 
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 非地震预警数据，code: {code}"
-            )
             return None
         except json.JSONDecodeError as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")
@@ -485,9 +474,6 @@ class JmaEewWolfxParser(BaseParser):
         try:
             # Wolfx 会混发多类日本消息，这里只接收日本地震预警类型
             if data.get("type") != "jma_eew":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 JMA 地震预警数据，跳过"
-                )
                 return None
 
             report_num = (

--- a/core/parsers/snet_parser.py
+++ b/core/parsers/snet_parser.py
@@ -523,9 +523,6 @@ class SnetParser(BaseParser):
             if float(s.get("shindo", -999.0)) >= fetch_min_shindo
         ]
         if not triggered:
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 无测站达到阈值 ({fetch_min_shindo})"
-            )
             return None
 
         top = triggered[0]

--- a/core/parsers/taiwan_earthquake_parser.py
+++ b/core/parsers/taiwan_earthquake_parser.py
@@ -214,9 +214,6 @@ class CwaReportParser(BaseParser):
 
             # 台湾地震报告类消息至少应具备发震时间与报告图片地址，否则通常不是来自 CWA 的地震报告
             if "shockTime" not in msg_data or "imageURI" not in msg_data:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CWA 地震报告数据，跳过"
-                )
                 return None
 
             envelope = self._build_envelope(msg_data)

--- a/core/parsers/taiwan_eew_parser.py
+++ b/core/parsers/taiwan_eew_parser.py
@@ -133,9 +133,6 @@ class CwaEewParser(BaseParser):
 
             # 报次或事件标识至少应命中其一，否则通常不是正式台湾地震预警消息
             if "updates" not in msg_data and "eventId" not in msg_data:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非CWA地震预警数据(缺少updates/eventId)，跳过"
-                )
                 return None
 
             envelope = self._build_envelope(msg_data)
@@ -163,11 +160,8 @@ class CwaEewWolfxParser(BaseParser):
     def _parse_data(self, data: dict[str, Any]) -> EventEnvelope | None:
         """解析 Wolfx 台湾地震预警数据。"""
         try:
-            # Wolfx 中只接收台湾地震预警类型，其余类型直接忽略。
+            # Wolfx 中只接收台湾地震预警类型，其余类型直接忽略
             if data.get("type") != "cwa_eew":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 非 CWA 地震预警数据，跳过"
-                )
                 return None
 
             raw_origin_time = data.get("OriginTime", "")

--- a/core/parsers/tsunami_parser.py
+++ b/core/parsers/tsunami_parser.py
@@ -212,7 +212,6 @@ class TsunamiParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             if self._is_heartbeat_message(msg_data):
@@ -342,14 +341,10 @@ class JmaTsunamiP2PParser(BaseParser):
             data = json.loads(message)
             code = data.get("code")
 
-            # P2P 中 552 业务码专指日本津波予報（海啸警报），其余直接跳过
+            # P2P 中 552 业务码专指日本津波予報（海啸警报），其余直接跳过。
             if code == 552 or str(code) == "552":
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 收到津波予報(code:552)"
-                )
                 return self._parse_tsunami_data(data)
 
-            plugin_logger.debug(f"[灾害预警] {self.source_id} 非海啸数据，code: {code}")
             return None
         except json.JSONDecodeError as exc:
             plugin_logger.error(f"[灾害预警] {self.source_id} JSON解析失败: {exc}")

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -197,7 +197,6 @@ class TyphoonParser(BaseParser):
         try:
             msg_data = self._extract_data(data)
             if not msg_data:
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 台风数据固定为数组格式
@@ -209,9 +208,7 @@ class TyphoonParser(BaseParser):
                 typhoon_list = [msg_data]
 
             if not typhoon_list:
-                plugin_logger.debug(
-                    f"[灾害预警] {self.source_id} 台风数据为空数组，当前无活跃台风"
-                )
+                # 空数组（当前无活跃台风）为轮询常态，不逐一记录
                 return None
 
             envelopes = []
@@ -228,7 +225,6 @@ class TyphoonParser(BaseParser):
                     envelopes.append(envelope)
 
             if not envelopes:
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 台风数组中无有效数据")
                 return None
 
             return envelopes

--- a/core/parsers/weather_parser.py
+++ b/core/parsers/weather_parser.py
@@ -50,7 +50,6 @@ class WeatherAlarmParser(BaseParser):
                 # 非 RealtimeEvent 结构：回退到 FAN Studio 扁平/嵌套载荷提取
                 msg_data = self._extract_data(data)
             if not msg_data:
-                plugin_logger.debug(f"[灾害预警] {self.source_id} 消息中没有有效数据")
                 return None
 
             # 过滤心跳包
@@ -262,15 +261,8 @@ class WeatherAlarmParser(BaseParser):
 
         # 仅处理气象预警新增事件；其余情况确认是 RealtimeEvent 但直接丢弃
         if msg_type and msg_type != "weather":
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 忽略非 weather 类型的 RealtimeEvent: "
-                f"{msg_type or '未知'}"
-            )
             return None, True
         if action and action not in ("new", ""):
-            plugin_logger.debug(
-                f"[灾害预警] {self.source_id} 忽略非 new 的气象 action: {action}"
-            )
             return None, True
 
         payload = data.get("payload")

--- a/core/services/config/config_validation_service.py
+++ b/core/services/config/config_validation_service.py
@@ -50,8 +50,6 @@ class ConfigValidator:
         返回值：
         - 校验并修正后的配置字典
         """
-        logger.debug("[灾害预警] 正在进行配置校验...")
-
         # 按配置分组依次处理，确保每一类配置都在进入运行态前完成基础修正。
 
         # 1. 本地监控配置校验
@@ -170,7 +168,6 @@ class ConfigValidator:
         # 19. 顶层开关校验
         if "enabled" in config and not isinstance(config["enabled"], bool):
             config["enabled"] = True
-
         logger.debug("[灾害预警] 配置校验完成")
         return config
 
@@ -1408,9 +1405,8 @@ class ConfigValidator:
             # 避免 None 原样保留导致下游轮询调度收到无效间隔。
             poll_interval = eqsc_cfg.get("poll_interval_seconds")
             if poll_interval is None:
-                if "poll_interval_seconds" not in eqsc_cfg:
-                    logger.debug("[灾害预警] EQSC 未配置轮询间隔，已填充默认值 120。")
-                else:
+                # 未配置时静默填充默认值（正常升级路径）；仅 null 显式写入属异常，保留 warning
+                if "poll_interval_seconds" in eqsc_cfg:
                     logger.warning(
                         "[灾害预警] 配置警告: EQSC 轮询间隔为 null，已重置为 120。"
                     )

--- a/core/services/config/connection_plan_builder.py
+++ b/core/services/config/connection_plan_builder.py
@@ -98,17 +98,9 @@ class ConnectionPlanBuilder:
                 plan["fan_api_key"] = fan_api_key
 
             connections[group_key] = plan
-            if group_key == "fan_studio_all":
-                logger.debug("[灾害预警] 已配置 FAN Studio 全量数据连接")
-            elif group_key == "fan_studio_cenc_ir":
-                logger.debug("[灾害预警] 已配置 FAN Studio 烈度速报独立连接")
-            elif group_key == "p2p_main":
-                logger.debug("[灾害预警] 已配置 P2P 地震情报连接")
-            elif group_key == "wolfx_all":
-                logger.debug("[灾害预警] 已配置 Wolfx 全量数据连接")
-            elif group_key == "openquake_api":
-                logger.debug("[灾害预警] 已配置 OpenQuakeAPI 全量数据连接")
-            else:
-                logger.debug(f"[灾害预警] 已配置数据连接，连接分组为 {group_key}")
+
+        if connections:
+            group_list = "、".join(sorted(connections.keys()))
+            logger.debug(f"[灾害预警] 已配置数据连接分组: {group_list}")
 
         return connections

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -206,6 +206,10 @@ class EqscCencIntensityPollService:
                         )
                         self._disabled_logged = True
                     continue
+                if self._disabled_logged:
+                    # 从禁用状态恢复：重置无变化计数器，避免禁用期的旧累计值
+                    # 导致恢复后立即打印"无变化"汇总日志
+                    self._no_change_log_rounds = 0
                 self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -201,7 +201,9 @@ class EqscCencIntensityPollService:
                 if not self.is_enabled():
                     # 仅首次禁用时打一次，避免配置禁用后每轮刷屏
                     if not self._disabled_logged:
-                        logger.debug("[灾害预警] EQSC CENC 烈度速报已禁用，跳过本轮轮询")
+                        logger.debug(
+                            "[灾害预警] EQSC CENC 烈度速报已禁用，跳过本轮轮询"
+                        )
                         self._disabled_logged = True
                     continue
                 self._disabled_logged = False
@@ -388,7 +390,9 @@ class EqscCencIntensityPollService:
             self._no_change_log_rounds += 1
             if self._no_change_log_rounds >= self._no_change_log_interval:
                 self._no_change_log_rounds = 0
-                plugin_logger.debug("[灾害预警] EQSC CENC 烈度速报轮询本轮无变化，跳过推送")
+                plugin_logger.debug(
+                    "[灾害预警] EQSC CENC 烈度速报轮询本轮无变化，跳过推送"
+                )
         return items
 
 

--- a/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
+++ b/core/services/eqsc/eqsc_cenc_intensity_poll_service.py
@@ -54,6 +54,11 @@ class EqscCencIntensityPollService:
         self._client: EqscCencIntensityClient | None = None
         self._owns_token_manager = False
         self._startup_seeded = False
+        # 禁用态日志：仅首次跳过本轮时打一次
+        self._disabled_logged = False
+        # 无变化汇总日志节流：连续 N 轮才打一次，避免无灾害时每轮刷屏
+        self._no_change_log_rounds = 0
+        self._no_change_log_interval = 30
 
     @property
     def running(self) -> bool:
@@ -194,8 +199,12 @@ class EqscCencIntensityPollService:
                 if not getattr(self.service, "running", False):
                     break
                 if not self.is_enabled():
-                    logger.debug("[灾害预警] EQSC CENC 烈度速报已禁用，跳过本轮轮询")
+                    # 仅首次禁用时打一次，避免配置禁用后每轮刷屏
+                    if not self._disabled_logged:
+                        logger.debug("[灾害预警] EQSC CENC 烈度速报已禁用，跳过本轮轮询")
+                        self._disabled_logged = True
                     continue
+                self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:
                 break
@@ -365,14 +374,21 @@ class EqscCencIntensityPollService:
                 emitted += 1
 
         if emitted:
-            plugin_logger.info(
+            self._no_change_log_rounds = 0
+            # 与台风轮询汇总一致降为 DEBUG：无灾害时每轮不刷屏，
+            # 有推送价值的事件由事件级"会话筛选/推送完成" INFO 汇总提供可观测性。
+            plugin_logger.debug(
                 f"[灾害预警] EQSC CENC 烈度速报轮询本轮推送 {emitted} 条",
                 is_event_linked=True,
                 event_stream="earthquake",
                 is_silent_window=True,
             )
         else:
-            plugin_logger.debug("[灾害预警] EQSC CENC 烈度速报轮询本轮无变化，跳过推送")
+            # 无变化为常态，连续 N 轮才打一次，避免无灾害时每轮刷屏
+            self._no_change_log_rounds += 1
+            if self._no_change_log_rounds >= self._no_change_log_interval:
+                self._no_change_log_rounds = 0
+                plugin_logger.debug("[灾害预警] EQSC CENC 烈度速报轮询本轮无变化，跳过推送")
         return items
 
 

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -186,6 +186,10 @@ class EqscTsunamiPollService:
                         logger.debug("[灾害预警] EQSC 海啸已禁用，跳过本轮轮询")
                         self._disabled_logged = True
                     continue
+                if self._disabled_logged:
+                    # 从禁用状态恢复：重置无变化计数器，避免禁用期的旧累计值
+                    # 导致恢复后立即打印"无变化"汇总日志
+                    self._no_change_log_rounds = 0
                 self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:
@@ -244,6 +248,8 @@ class EqscTsunamiPollService:
         if is_training and not self._resolve_include_training():
             # 主动忽略训练报时仍提交指纹，避免每轮重复解析同一训练快照。
             self._last_payload_fingerprint = fingerprint
+            # 新快照（含训练报）到达即视为"有变化"，重置无变化计数器
+            self._no_change_log_rounds = 0
             self._notify_silence_fetch_completed(success=True)
             return raw
 
@@ -258,6 +264,8 @@ class EqscTsunamiPollService:
 
         if not emit_event:
             self._last_payload_fingerprint = fingerprint
+            # 新快照到达即视为"有变化"，重置无变化计数器
+            self._no_change_log_rounds = 0
             self._notify_silence_fetch_completed(success=True)
             return raw
 
@@ -277,6 +285,8 @@ class EqscTsunamiPollService:
             return raw
         self._last_payload_fingerprint = fingerprint
         self._last_event_id = str(event_id) if event_id else None
+        # 新快照成功处理即视为"有变化"，重置无变化计数器
+        self._no_change_log_rounds = 0
         self._notify_silence_fetch_completed(success=True)
         return raw
 

--- a/core/services/eqsc/eqsc_tsunami_poll_service.py
+++ b/core/services/eqsc/eqsc_tsunami_poll_service.py
@@ -47,6 +47,11 @@ class EqscTsunamiPollService:
         self._consecutive_failures = 0
         self._client: EqscTsunamiClient | None = None
         self._owns_token_manager = False
+        # 禁用态日志：仅首次跳过本轮时打一次
+        self._disabled_logged = False
+        # 无变化汇总日志节流：连续 N 轮才打一次，避免无灾害时每轮刷屏
+        self._no_change_log_rounds = 0
+        self._no_change_log_interval = 30
 
     @property
     def running(self) -> bool:
@@ -176,8 +181,12 @@ class EqscTsunamiPollService:
                 if not getattr(self.service, "running", False):
                     break
                 if not self.is_enabled():
-                    logger.debug("[灾害预警] EQSC 海啸已禁用，跳过本轮轮询")
+                    # 仅首次禁用时打一次，避免配置禁用后每轮刷屏
+                    if not self._disabled_logged:
+                        logger.debug("[灾害预警] EQSC 海啸已禁用，跳过本轮轮询")
+                        self._disabled_logged = True
                     continue
+                self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:
                 break
@@ -235,12 +244,15 @@ class EqscTsunamiPollService:
         if is_training and not self._resolve_include_training():
             # 主动忽略训练报时仍提交指纹，避免每轮重复解析同一训练快照。
             self._last_payload_fingerprint = fingerprint
-            logger.debug("[灾害预警] EQSC 海啸训练报已忽略")
             self._notify_silence_fetch_completed(success=True)
             return raw
 
         if fingerprint == self._last_payload_fingerprint:
-            logger.debug("[灾害预警] EQSC 海啸快照内容未变化，跳过推送")
+            # 无变化为常态，连续 N 轮才打一次，避免无灾害时每轮刷屏
+            self._no_change_log_rounds += 1
+            if self._no_change_log_rounds >= self._no_change_log_interval:
+                self._no_change_log_rounds = 0
+                logger.debug("[灾害预警] EQSC 海啸快照内容未变化，跳过推送")
             self._notify_silence_fetch_completed(success=True)
             return raw
 

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -55,6 +55,11 @@ class EqscTyphoonPollService:
         self._owns_client = False
         # 仅在自建 client 且自建 token 时有意义；close 时由 client 内部决定是否关 token
         self._owns_token_manager = False
+        # 禁用态日志：仅首次跳过本轮时打一次
+        self._disabled_logged = False
+        # 无变化汇总日志节流：连续 N 轮才打一次，避免无灾害时每轮刷屏
+        self._no_change_log_rounds = 0
+        self._no_change_log_interval = 30
 
     @property
     def running(self) -> bool:
@@ -210,8 +215,12 @@ class EqscTyphoonPollService:
                 if not getattr(self.service, "running", False):
                     break
                 if not self.is_enabled():
-                    logger.debug("[灾害预警] EQSC 台风已禁用，跳过本轮轮询")
+                    # 仅首次禁用时打一次，避免配置禁用后每轮刷屏
+                    if not self._disabled_logged:
+                        logger.debug("[灾害预警] EQSC 台风已禁用，跳过本轮轮询")
+                        self._disabled_logged = True
                     continue
+                self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:
                 break
@@ -417,6 +426,7 @@ class EqscTyphoonPollService:
         # 有推送价值的事件进入流水线后，会由事件级"会话筛选/推送完成"汇总
         # （INFO 级）提供可观测性。需要查看轮询明细时开启 DEBUG 级别。
         if emitted or filtered:
+            self._no_change_log_rounds = 0
             plugin_logger.debug(
                 f"[灾害预警] EQSC 台风轮询汇总：推送 {emitted} 条更新，"
                 f"跳过 {filtered} 条未变化",
@@ -425,12 +435,16 @@ class EqscTyphoonPollService:
                 is_silent_window=True,
             )
         else:
-            plugin_logger.debug(
-                "[灾害预警] EQSC 台风轮询本轮无变化，跳过推送",
-                is_event_linked=True,
-                event_stream="typhoon",
-                is_silent_window=True,
-            )
+            # 无变化为常态，连续 N 轮才打一次，避免无灾害时每轮刷屏
+            self._no_change_log_rounds += 1
+            if self._no_change_log_rounds >= self._no_change_log_interval:
+                self._no_change_log_rounds = 0
+                plugin_logger.debug(
+                    "[灾害预警] EQSC 台风轮询本轮无变化，跳过推送",
+                    is_event_linked=True,
+                    event_stream="typhoon",
+                    is_silent_window=True,
+                )
         return active_items
 
 

--- a/core/services/eqsc/eqsc_typhoon_poll_service.py
+++ b/core/services/eqsc/eqsc_typhoon_poll_service.py
@@ -220,6 +220,10 @@ class EqscTyphoonPollService:
                         logger.debug("[灾害预警] EQSC 台风已禁用，跳过本轮轮询")
                         self._disabled_logged = True
                     continue
+                if self._disabled_logged:
+                    # 从禁用状态恢复：重置无变化计数器，避免禁用期的旧累计值
+                    # 导致恢复后立即打印"无变化"汇总日志
+                    self._no_change_log_rounds = 0
                 self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:

--- a/core/services/geo/cn_seis_int_loc_loader.py
+++ b/core/services/geo/cn_seis_int_loc_loader.py
@@ -166,10 +166,6 @@ def get_district_points() -> dict[str, list[tuple[float, float]]]:
         district_points = _parse_js_district_points(js_path)
         _cached_district_points = district_points
         _cached_flat_index = _build_flat_index(district_points)
-        logger.debug(
-            f"[灾害预警] CnSeisIntLoc.js 已加载，共 {len(district_points)} 个区县，"
-            f"{len(_cached_flat_index)} 个采样点"
-        )
         return _cached_district_points
     except Exception as exc:
         logger.error(f"[灾害预警] 加载 CnSeisIntLoc.js 失败: {exc}")

--- a/core/services/geo/jma_seis_int_loc_loader.py
+++ b/core/services/geo/jma_seis_int_loc_loader.py
@@ -97,9 +97,6 @@ def get_sect_map() -> dict[str, str]:
 
         sect_map = _parse_js_sect_map(js_path)
         _cached_sect_map = sect_map
-        logger.debug(
-            f"[灾害预警] JmaSeisIntLoc.js 已加载，共 {len(sect_map)} 条町丁目->地域映射"
-        )
         return _cached_sect_map
     except Exception as exc:
         logger.error(f"[灾害预警] 加载 JmaSeisIntLoc.js 失败: {exc}")

--- a/core/services/geo/travel_time_loader.py
+++ b/core/services/geo/travel_time_loader.py
@@ -152,12 +152,6 @@ def _parse_travel_times(js_path: Path) -> dict[str, TravelTimeModel]:
     for name in ("jma2001", "jb"):
         model = _parse_model_block(text, name)
         models[name] = model
-        logger.debug(
-            f"[灾害预警] TravelTimes.js 模型 {name}: "
-            f"depths={len(model.depths)}, distances={len(model.distances)}, "
-            f"p_times={len(model.p_times)}x{len(model.p_times[0]) if model.p_times else 0}, "
-            f"s_times={len(model.s_times)}x{len(model.s_times[0]) if model.s_times else 0}"
-        )
     return models
 
 
@@ -188,7 +182,6 @@ def get_travel_times() -> dict[str, TravelTimeModel]:
 
         models = _parse_travel_times(js_path)
         _cached_travel_times = models
-        logger.debug(f"[灾害预警] TravelTimes.js 已加载，共 {len(models)} 个走时模型")
         return _cached_travel_times
     except Exception as exc:
         logger.error(f"[灾害预警] 加载 TravelTimes.js 失败: {exc}")

--- a/core/services/identity/event_deduplication_service.py
+++ b/core/services/identity/event_deduplication_service.py
@@ -209,14 +209,8 @@ class EventDeduplicationService:
         fingerprint = self._generate_typhoon_fingerprint(typhoon)
         cached_fingerprint = self._typhoon_cache.get(typhoon_id)
         if cached_fingerprint is not None and cached_fingerprint == fingerprint:
-            # 与 push_flow_handler 其他事件流的去重过滤日志保持一致：
-            # 单条过滤仅 DEBUG 级，避免轮询特性导致每轮 INFO 刷屏；
-            plugin_logger.debug(
-                f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
-                is_event_linked=True,
-                event_stream="typhoon",
-                is_silent_window=True,
-            )
+            # 单条过滤不再打日志：轮询侧汇总（"EQSC 台风轮询汇总：跳过 N 条未变化"）
+            # 已承担计数职责，避免轮询驱动下每轮每条台风刷屏。
             return False
         return True
 
@@ -239,14 +233,8 @@ class EventDeduplicationService:
         cached_fingerprint = self._typhoon_cache.get(typhoon_id)
 
         if cached_fingerprint is not None and cached_fingerprint == fingerprint:
-            # 单条过滤仅 DEBUG 级，与 push_flow_handler 其他事件流对齐，
-            # 避免轮询特性导致每轮 INFO 刷屏；汇总由轮询侧日志承担。
-            plugin_logger.debug(
-                f"[灾害预警] 台风 {typhoon_id} 核心参数未变化，过滤重复推送",
-                is_event_linked=True,
-                event_stream="typhoon",
-                is_silent_window=True,
-            )
+            # 单条过滤不再打日志：轮询侧汇总（"EQSC 台风轮询汇总：跳过 N 条未变化"）
+            # 已承担计数职责，避免轮询驱动下每轮每条台风刷屏。
             return False
 
         # 参数有变化（或首次出现），更新缓存并放行
@@ -850,10 +838,6 @@ class EventDeduplicationService:
         event_fingerprint = self.generate_event_fingerprint(event, domain_eq, source_id)
         current_time = self._to_utc(domain_eq.occurred_at, source_id)
 
-        plugin_logger.debug(
-            f"[灾害预警] 检查事件: {source_id}, 指纹: {event_fingerprint}"
-        )
-
         # 指纹命中说明近期已有相近事件，需要进一步区分是重复还是合法更新。
         if event_fingerprint in self.recent_events:
             source_events = self.recent_events[event_fingerprint]
@@ -952,7 +936,6 @@ class EventDeduplicationService:
                 "is_final": bool(metadata.get("is_final", False)),
             }
         }
-        plugin_logger.debug(f"[灾害预警] 事件通过基础去重检查: {source_id}")
         return True
 
     def generate_event_fingerprint(

--- a/core/services/snet/snet_peak_service.py
+++ b/core/services/snet/snet_peak_service.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
-
 from ....utils.converters import ScaleConverter
 from ...domain.event_models import EarthquakeEvent, EventEnvelope
 from ...storage.snet_peak_repository import SnetPeakRepository

--- a/core/services/snet/snet_peak_service.py
+++ b/core/services/snet/snet_peak_service.py
@@ -124,11 +124,6 @@ class SnetPeakService:
             observed_at=observed_at,
             hit_threshold=hit_threshold,
         )
-        logger.debug(
-            "[灾害预警] S-Net 峰值观测完成 processed=%s peak_updates=%s",
-            result.get("processed"),
-            result.get("peak_updates"),
-        )
         return result
 
     async def clear_peaks(self) -> bool:

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -56,6 +56,8 @@ class SnetPollService:
         # 最近一次成功抓取的快照：{timestamp, tiles, stations|None, fetched_at}
         self._latest_snapshot: dict[str, Any] | None = None
         self._fetch_lock = asyncio.Lock()
+        # 禁用态日志：仅首次跳过本轮时打一次
+        self._disabled_logged = False
 
     @property
     def running(self) -> bool:
@@ -171,8 +173,12 @@ class SnetPollService:
                 if not getattr(self.service, "running", False):
                     break
                 if not self.is_enabled():
-                    logger.debug("[灾害预警] S-Net 已禁用，跳过本轮轮询")
+                    # 仅首次禁用时打一次，避免配置禁用后每轮刷屏
+                    if not self._disabled_logged:
+                        logger.debug("[灾害预警] S-Net 已禁用，跳过本轮轮询")
+                        self._disabled_logged = True
                     continue
+                self._disabled_logged = False
                 await self.fetch_once(emit_event=True)
             except asyncio.CancelledError:
                 break
@@ -374,7 +380,6 @@ class SnetPollService:
         async with self._fetch_lock:
             cached = self._snapshot_if_fresh()
             if cached is not None:
-                logger.debug(f"[灾害预警] S-Net 瓦片缓存命中 ts={cached['timestamp']}")
                 return {
                     "timestamp": cached["timestamp"],
                     "tiles": cached["tiles"],
@@ -389,23 +394,29 @@ class SnetPollService:
                     try_ts = now - timedelta(minutes=offset_min)
                     ts = try_ts.strftime("%Y%m%d%H%M00")
                     tiles: dict[str, str] = {}
+                    failed_tiles = 0
                     for tile_name, tile_y in self.TILE_NAMES:
                         url = f"{MSIL_TILE_BASE}/{ts}/{ts}/5/28/{tile_y}.png"
                         try:
                             async with session.get(url) as resp:
                                 if resp.status != 200:
+                                    failed_tiles += 1
                                     continue
                                 content = await resp.read()
                                 if not content:
+                                    failed_tiles += 1
                                     continue
                                 tiles[tile_name] = base64.b64encode(content).decode(
                                     "ascii"
                                 )
-                        except Exception as exc:
-                            logger.debug(f"[灾害预警] S-Net 瓦片请求失败 {url}: {exc}")
+                        except Exception:
+                            failed_tiles += 1
+                    if failed_tiles and len(tiles) < 2:
+                        logger.debug(
+                            f"[灾害预警] S-Net 瓦片获取失败，共 {failed_tiles} 张"
+                        )
                     if len(tiles) >= 2:
                         self._store_snapshot(timestamp=ts, tiles=tiles)
-                        logger.debug(f"[灾害预警] S-Net 瓦片已下载并缓存 ts={ts}")
                         return {"timestamp": ts, "tiles": tiles}
 
             logger.warning("[灾害预警] S-Net 最近 3 分钟均未拿到完整瓦片")
@@ -426,7 +437,6 @@ class SnetPollService:
             and snap.get("timestamp") == ts
             and isinstance(snap.get("stations"), list)
         ):
-            logger.debug(f"[灾害预警] S-Net 测站解码缓存命中 ts={ts}")
             return copy.deepcopy(snap["stations"])
 
         stations = self._decode_stations(tiles)
@@ -511,15 +521,10 @@ class SnetPollService:
             else []
         )
         if not triggered:
-            # 解析器也会在无触发时返回 None；这里提前短路减少噪声
-            logger.debug(
-                f"[灾害预警] S-Net 本轮无测站达到阈值 min_shindo={raw_dict.get('min_shindo')}"
-            )
             return
 
         fingerprint = self._build_push_fingerprint(triggered)
         if fingerprint == self._last_payload_fingerprint:
-            logger.debug("[灾害预警] S-Net Top-5 测站未变化，跳过推送")
             return
 
         message = json.dumps(raw_dict, ensure_ascii=False)

--- a/core/services/snet/snet_poll_service.py
+++ b/core/services/snet/snet_poll_service.py
@@ -395,25 +395,35 @@ class SnetPollService:
                     ts = try_ts.strftime("%Y%m%d%H%M00")
                     tiles: dict[str, str] = {}
                     failed_tiles = 0
+                    # 失败详情仅在"本轮未拿到完整瓦片"时输出，避免成功路径刷屏
+                    failed_details: list[str] = []
                     for tile_name, tile_y in self.TILE_NAMES:
                         url = f"{MSIL_TILE_BASE}/{ts}/{ts}/5/28/{tile_y}.png"
                         try:
                             async with session.get(url) as resp:
                                 if resp.status != 200:
                                     failed_tiles += 1
+                                    failed_details.append(
+                                        f"{tile_name} HTTP {resp.status}"
+                                    )
                                     continue
                                 content = await resp.read()
                                 if not content:
                                     failed_tiles += 1
+                                    failed_details.append(f"{tile_name} 响应为空")
                                     continue
                                 tiles[tile_name] = base64.b64encode(content).decode(
                                     "ascii"
                                 )
-                        except Exception:
+                        except Exception as exc:
                             failed_tiles += 1
+                            failed_details.append(f"{tile_name} 异常: {exc}")
                     if failed_tiles and len(tiles) < 2:
+                        # 本轮未拿到完整瓦片属真实故障：DEBUG 下输出详情便于定位；
+                        # 成功拿到 ≥2 张时不打日志，维持无故障期节流。
                         logger.debug(
-                            f"[灾害预警] S-Net 瓦片获取失败，共 {failed_tiles} 张"
+                            f"[灾害预警] S-Net 瓦片获取失败，共 {failed_tiles} 张，"
+                            f"详情: {'; '.join(failed_details)}"
                         )
                     if len(tiles) >= 2:
                         self._store_snapshot(timestamp=ts, tiles=tiles)

--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ class DisasterWarningPlugin(Star):
         try:
             # 插件一重载即打印组织 ASCII art 横幅（bold_cyan 配色，终端不支持颜色时回退纯文本）。
             print_banner()
-            logger.debug("[灾害预警] 正在初始化灾害预警插件...")
 
             plugin_logger.set_config(self.config)
 
@@ -111,14 +110,10 @@ class DisasterWarningPlugin(Star):
     async def terminate(self):
         """插件销毁时调用"""
         try:
-            logger.debug("[灾害预警] 正在停止灾害预警插件...")
-
             await self._lifecycle_service.stop_heartbeat_task()
             self._lifecycle_service.restore_asyncio_exception_handler()
             await self._cleanup_telemetry_tasks()
             await self._lifecycle_service.shutdown_plugin_resources()
-
-            logger.debug("[灾害预警] 灾害预警插件已停止")
 
         except Exception as e:
             logger.error(f"[灾害预警] 插件停止时出错: {e}")

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -2344,8 +2344,9 @@ class PluginQueryCommandService(CommandTelemetryMixin):
             logger.debug("[灾害预警] 本地监控未启用，本地坐标不可用")
             return None, None, ""
         if lat is None or lon is None:
-            # 与"未启用"保持一致：本地监控未配置是常态，统一 DEBUG 避免每次查询刷 INFO
-            logger.debug("[灾害预警] 本地监控配置缺少经度或纬度，本地坐标不可用")
+            # 已启用但坐标缺失属配置不完整（异常态），用 WARNING 提示以便用户发现；
+            # 与"未启用"（用户主动关闭）的 DEBUG 常态区分开。
+            logger.warning("[灾害预警] 本地监控已启用但缺少经度或纬度，本地坐标不可用")
             return None, None, ""
         try:
             lat_f = float(lat)

--- a/plugin/commands/plugin_query_command_service.py
+++ b/plugin/commands/plugin_query_command_service.py
@@ -2344,7 +2344,8 @@ class PluginQueryCommandService(CommandTelemetryMixin):
             logger.debug("[灾害预警] 本地监控未启用，本地坐标不可用")
             return None, None, ""
         if lat is None or lon is None:
-            logger.info("[灾害预警] 本地监控配置缺少经度或纬度，本地坐标不可用")
+            # 与"未启用"保持一致：本地监控未配置是常态，统一 DEBUG 避免每次查询刷 INFO
+            logger.debug("[灾害预警] 本地监控配置缺少经度或纬度，本地坐标不可用")
             return None, None, ""
         try:
             lat_f = float(lat)


### PR DESCRIPTION
## 📝 描述 / Description

feat #107 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

简化灾害预警的日志策略，在减少高频调试噪音的同时，保持跨解析器、轮询服务和推送管道的关键可观测性。

增强内容：
- 移除或降级网络处理器、解析器和推送执行流程中常规路径和心跳类路径的冗长 DEBUG 日志。
- 为 EQSC 台风、CENC 烈度以及海啸轮询服务引入节流且具状态感知的日志机制，以避免每轮“无变化”带来的刷屏，同时保留周期性汇总日志。
- 优化原始消息和事件去重相关日志，使高频被过滤的条目依赖计数器和汇总信息，而不是针对每条记录日志。
- 将连接配置相关日志整合为单一的汇总输出，并调整各类加载器/初始化器日志，避免重复的启动及缓存命中日志。
- 将成功解析 CENC 地震数据的日志提升为 INFO 级别，并关联事件上下文，在整体减少 debug 的情况下仍保持可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Streamline disaster warning logging strategy to reduce high-frequency debug noise while preserving essential observability across parsers, polling services, and push pipeline.

Enhancements:
- Remove or downgrade verbose DEBUG logs for routine and heartbeat-style paths in network handlers, parsers, and push execution flows.
- Introduce throttled and state-aware logging for EQSC typhoon, CENC intensity, and tsunami polling services to avoid per-round no-change spam while keeping periodic summaries.
- Refine raw message and event deduplication logging so high-frequency filtered items rely on counters and summaries instead of per-item logs.
- Consolidate connection configuration logging into a single grouped summary and adjust various loader/initializer logs to avoid repetitive startup and cache-hit messages.
- Promote successful CENC earthquake data parsing to INFO with linked event context to maintain visibility despite overall debug reduction.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 大幅减少正常运行过程中的冗余调试日志，日志内容更精简、重点更突出。
  - 轮询无变化状态改为定期汇总记录，禁用状态仅在首次出现时提示，降低日志噪声。
  - 网络连接正常关闭时避免重复记录，异常关闭仍保留必要信息。
  - 配置缺失时自动使用默认轮询间隔；显式设置为空值时发出警告并恢复默认值。
  - 保持数据解析、缓存、过滤、推送及异常处理行为不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->