### PR TITLE
fix(typhoon): 修复无名低压同源台风重复推送、消息正文裸 None 与编号截断问题

### DIFF
--- a/admin/js/views/SimulationView.jsx
+++ b/admin/js/views/SimulationView.jsx
@@ -696,7 +696,7 @@ function SimulationView() {
             {/* 保存草稿对话框 */}
             <Dialog open={saveDialogOpen} onClose={() => setSaveDialogOpen(false)} maxWidth="xs" fullWidth>
                 <DialogTitle>保存模拟流草稿</DialogTitle>
-                <DialogContent>
+                <DialogContent style={{ paddingTop: '16px' }}>
                     <TextField
                         fullWidth
                         size="small"

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -220,11 +220,13 @@ class TyphoonEnrichmentService:
         # 如果 EQSC 提供了更丰富的名称信息，补充到事件中。
         # 必须使用 clean_text 清洗，避免 EQSC 返回字符串 "None"/"NULL" 时
         # 被 str(... or "") 误当成有效名称写入事件，导致推送正文出现裸 "None"。
-        eqsc_name_cn = clean_text(
-            eqsc_typhoon.get("nameCN") or eqsc_typhoon.get("name")
+        # 注意先分别清洗每个候选值再取非空：避免 nameCN 为占位字符串
+        # （如 "NULL"）时屏蔽有效的 name 备用值。
+        eqsc_name_cn = clean_text(eqsc_typhoon.get("nameCN")) or clean_text(
+            eqsc_typhoon.get("name")
         )
-        eqsc_name_en = clean_text(
-            eqsc_typhoon.get("nameEN") or eqsc_typhoon.get("name_en")
+        eqsc_name_en = clean_text(eqsc_typhoon.get("nameEN")) or clean_text(
+            eqsc_typhoon.get("name_en")
         )
         if eqsc_name_cn and not typhoon_event.name:
             typhoon_event.name = eqsc_name_cn

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -24,6 +24,7 @@ from typing import Any
 from ....utils.plugin_logger import plugin_logger as logger
 from ...domain.event_models import EventEnvelope, TyphoonEvent
 from ...domain.typhoon import (
+    clean_text,
     clean_wind_circle,
     constrain_wind_circle_by_fan_radius,
     to_eqsc_id,
@@ -216,9 +217,15 @@ class TyphoonEnrichmentService:
         typhoon_event.future_track = track_data["future_track"]
         typhoon_event.wind_circle = track_data["wind_circle"]
 
-        # 如果 EQSC 提供了更丰富的名称信息，补充到事件中
-        eqsc_name_cn = str(eqsc_typhoon.get("nameCN", "") or "").strip()
-        eqsc_name_en = str(eqsc_typhoon.get("nameEN", "") or "").strip()
+        # 如果 EQSC 提供了更丰富的名称信息，补充到事件中。
+        # 必须使用 clean_text 清洗，避免 EQSC 返回字符串 "None"/"NULL" 时
+        # 被 str(... or "") 误当成有效名称写入事件，导致推送正文出现裸 "None"。
+        eqsc_name_cn = clean_text(
+            eqsc_typhoon.get("nameCN") or eqsc_typhoon.get("name")
+        )
+        eqsc_name_en = clean_text(
+            eqsc_typhoon.get("nameEN") or eqsc_typhoon.get("name_en")
+        )
         if eqsc_name_cn and not typhoon_event.name:
             typhoon_event.name = eqsc_name_cn
         if eqsc_name_en and not typhoon_event.name_en:

--- a/core/domain/typhoon/typhoon_display_format.py
+++ b/core/domain/typhoon/typhoon_display_format.py
@@ -174,6 +174,61 @@ def get_typhoon_level_emoji(typhoon_type: str | None) -> str:
     return typhoon_level_emoji(typhoon_type)
 
 
+def format_typhoon_short_id(*candidates: object) -> str:
+    """统一输出台风短编号，规则与前端 formatTyphoonShortId 对齐。
+
+    - 纯数字官方编号：202609 / 2609 -> 2609
+    - NAMELESS 无名低压：NAMELESS_2604 / NAMELESS_07 -> TD04 / TD07
+      （避免与正式编号 2604 冲突；07 与 EQSC 侧 TD07 归一到同一展示格式）
+    - 其他非标准编号：原样返回，不从混合文本硬抠数字
+
+    供推送 Presenter 与查询 Presenter 共用，避免展示逻辑分叉。
+    """
+    for candidate in candidates:
+        text = str(candidate or "").strip()
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in {"unknown", "未知"}:
+            continue
+
+        if text.isdigit() and len(text) >= 4:
+            return text[-4:]
+
+        upper = text.upper()
+        # 裸 NAMELESS / NAMELESS_03 / NAMELESS_2604 均统一为 TD + 两位短编号
+        if (
+            upper == "NAMELESS"
+            or upper.startswith("NAMELESS_")
+            or upper.startswith("NAMELESS-")
+        ):
+            if upper == "NAMELESS":
+                return "TD"
+            suffix = (
+                text.split("_", 1)[1].strip()
+                if "_" in text
+                else text.split("-", 1)[1].strip()
+                if "-" in text
+                else text[8:].lstrip("_-")
+            )
+            suffix = suffix.strip()
+            if not suffix:
+                return "TD"
+            digits = "".join(char for char in suffix if char.isdigit())
+            if digits:
+                # 统一 TD + 两位短编号（如 NAMELESS_2604 -> TD04）
+                return f"TD{digits[-2:]}"
+            if suffix.upper().startswith("TD"):
+                return suffix.upper()
+            return f"TD{suffix}"
+
+        if upper.startswith("TD"):
+            return "TD" + text[2:].lstrip("_-")
+
+        return text
+    return ""
+
+
 def format_move_direction(direction: str | None) -> str:
     """把源侧移动方向本地化为日常可读写法（仅展示层）。"""
     text = clean_text(direction)
@@ -191,6 +246,7 @@ __all__ = [
     "TYPHOON_LEVEL_EMOJI",
     "format_coordinates",
     "format_move_direction",
+    "format_typhoon_short_id",
     "format_wind_circle",
     "format_wind_speed",
     "get_typhoon_level_emoji",

--- a/core/domain/typhoon/typhoon_display_format.py
+++ b/core/domain/typhoon/typhoon_display_format.py
@@ -10,6 +10,7 @@ import math
 from typing import Any
 
 from ....utils.severity_emoji import TYPHOON_LEVEL_EMOJI, typhoon_level_emoji
+from .typhoon_ids import extract_td_short_id
 from .typhoon_values import clean_text, to_float
 
 # 移动方向展示映射：仅用于展示本地化，不改动原始业务字段。
@@ -196,34 +197,12 @@ def format_typhoon_short_id(*candidates: object) -> str:
             return text[-4:]
 
         upper = text.upper()
-        # 裸 NAMELESS / NAMELESS_03 / NAMELESS_2604 均统一为 TD + 两位短编号
-        if (
-            upper == "NAMELESS"
-            or upper.startswith("NAMELESS_")
-            or upper.startswith("NAMELESS-")
-        ):
-            if upper == "NAMELESS":
-                return "TD"
-            suffix = (
-                text.split("_", 1)[1].strip()
-                if "_" in text
-                else text.split("-", 1)[1].strip()
-                if "-" in text
-                else text[8:].lstrip("_-")
-            )
-            suffix = suffix.strip()
-            if not suffix:
-                return "TD"
-            digits = "".join(char for char in suffix if char.isdigit())
-            if digits:
-                # 统一 TD + 两位短编号（如 NAMELESS_2604 -> TD04）
-                return f"TD{digits[-2:]}"
-            if suffix.upper().startswith("TD"):
-                return suffix.upper()
-            return f"TD{suffix}"
-
-        if upper.startswith("TD"):
-            return "TD" + text[2:].lstrip("_-")
+        # NAMELESS/TD 无名低压统一复用共享提取逻辑（与去重键同规则）
+        if upper.startswith("NAMELESS") or upper.startswith("TD"):
+            short_id = extract_td_short_id(text)
+            if short_id:
+                return short_id
+            continue
 
         return text
     return ""

--- a/core/domain/typhoon/typhoon_display_format.py
+++ b/core/domain/typhoon/typhoon_display_format.py
@@ -197,12 +197,13 @@ def format_typhoon_short_id(*candidates: object) -> str:
             return text[-4:]
 
         upper = text.upper()
-        # NAMELESS/TD 无名低压统一复用共享提取逻辑（与去重键同规则）
+        # NAMELESS/TD 无名低压统一复用共享提取逻辑（与去重键同规则）。
+        # 提取失败（格式不合法）时原样返回当前编号，不丢弃非标准编号。
         if upper.startswith("NAMELESS") or upper.startswith("TD"):
             short_id = extract_td_short_id(text)
             if short_id:
                 return short_id
-            continue
+            return text
 
         return text
     return ""

--- a/core/domain/typhoon/typhoon_event_adapter.py
+++ b/core/domain/typhoon/typhoon_event_adapter.py
@@ -133,12 +133,10 @@ def build_typhoon_event_envelope(
 
     # 对外领域身份继续使用 6 位编号，便于跨源去重与查询。
     fan_id = to_fan_id(eqsc_id)
-    name_cn = clean_text(raw.get("nameCN") or raw.get("name"))
-    name_en = clean_text(raw.get("nameEN") or raw.get("name_en"))
-    if name_cn.upper() in {"NONE", "NULL"}:
-        name_cn = ""
-    if name_en.upper() in {"NONE", "NULL"}:
-        name_en = ""
+    # 先分别清洗每个候选值，再取第一个非空结果：
+    # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
+    name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
+    name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
     history_track = raw.get("historyTrack") or raw.get("history_track") or []
     future_track = raw.get("futureTrack") or raw.get("future_track") or []
     if not isinstance(history_track, list):

--- a/core/domain/typhoon/typhoon_event_adapter.py
+++ b/core/domain/typhoon/typhoon_event_adapter.py
@@ -135,6 +135,10 @@ def build_typhoon_event_envelope(
     fan_id = to_fan_id(eqsc_id)
     name_cn = clean_text(raw.get("nameCN") or raw.get("name"))
     name_en = clean_text(raw.get("nameEN") or raw.get("name_en"))
+    if name_cn.upper() in {"NONE", "NULL"}:
+        name_cn = ""
+    if name_en.upper() in {"NONE", "NULL"}:
+        name_en = ""
     history_track = raw.get("historyTrack") or raw.get("history_track") or []
     future_track = raw.get("futureTrack") or raw.get("future_track") or []
     if not isinstance(history_track, list):

--- a/core/domain/typhoon/typhoon_ids.py
+++ b/core/domain/typhoon/typhoon_ids.py
@@ -42,7 +42,8 @@ def extract_td_short_id(typhoon_id: object) -> str:
 
     仅接受完整合法格式（NAMELESS / TD + 可选分隔符 + 数字后缀）：
     - NAMELESS / TD（裸）-> TD
-    - NAMELESS_07 / TD07 / TD_07 / NAMELESS07 -> TD07
+    - NAMELESS_07 / TD07 / TD_07 / NAMELESS07 / TD7 / NAMELESS_7 -> TD07
+      （末两位统一补零，保证 TD7 与 TD07 归一到同一去重键）
     - NAMELESS_2604 -> TD04（仅取两位短编号，避免与正式编号 2604 混淆）
 
     格式不匹配（如 NAMELESSNESS_07 / TDX_07）时返回空字符串，
@@ -59,7 +60,8 @@ def extract_td_short_id(typhoon_id: object) -> str:
         return "TD"
     digits = "".join(char for char in raw if char.isdigit())
     if digits:
-        return f"TD{digits[-2:]}"
+        # 末两位统一补零：TD7 / NAMELESS_7 / NAMELESS_2607 均归一到 TD07。
+        return f"TD{digits[-2:].zfill(2)}"
     return "TD"
 
 

--- a/core/domain/typhoon/typhoon_ids.py
+++ b/core/domain/typhoon/typhoon_ids.py
@@ -27,6 +27,36 @@ def to_fan_id(typhoon_id: object) -> str:
     return text
 
 
+def extract_td_short_id(typhoon_id: object) -> str:
+    """从 NAMELESS/TD 前缀的无名低压编号中提取 TD + 两位短编号。
+
+    - NAMELESS / TD（裸）-> TD
+    - NAMELESS_07 / TD07 / TD_07 -> TD07
+    - NAMELESS_2604 -> TD04（仅取两位短编号，避免与正式编号 2604 混淆）
+
+    供去重键（normalize_typhoon_id）与展示格式（format_typhoon_short_id）
+    共用，避免两处规则在未来产生差异。
+    """
+    raw = _clean_id(typhoon_id)
+    if not raw:
+        return ""
+    upper = raw.upper()
+    if upper == "NAMELESS" or upper == "TD":
+        return "TD"
+    if upper.startswith("NAMELESS"):
+        remainder = raw[len("NAMELESS") :].lstrip("_-")
+    elif upper.startswith("TD"):
+        remainder = raw[2:].lstrip("_-")
+    else:
+        return ""
+    if not remainder:
+        return "TD"
+    digits = "".join(char for char in remainder if char.isdigit())
+    if digits:
+        return f"TD{digits[-2:]}"
+    return "TD"
+
+
 def normalize_typhoon_id(typhoon_id: object) -> str:
     """返回用于缓存、去重和跨来源匹配的稳定编号。
 
@@ -41,15 +71,11 @@ def normalize_typhoon_id(typhoon_id: object) -> str:
     if not raw:
         return ""
     upper = raw.upper()
-    digits = "".join(char for char in raw if char.isdigit())
-
-    # NAMELESS / TD 前缀的无名低压：统一为 TD + 两位短编号
+    # 无名低压统一键
     if upper.startswith("NAMELESS") or upper.startswith("TD"):
-        if digits:
-            return f"TD{digits[-2:]}"
-        # 无数字可提取（如裸 TD / NAMELESS）：保持前缀本身
-        if upper.startswith("NAMELESS"):
-            return "TD"
-        return "TD"
-
-    return digits[-4:] if len(digits) >= 4 else raw
+        return extract_td_short_id(raw)
+    # 纯数字官方编号统一为 4 位短编号
+    if raw.isdigit():
+        return raw[-4:]
+    # 如果有其他非标准编号，原样返回，避免不同 ID 因硬抠数字而误共享同一去重键。
+    return raw

--- a/core/domain/typhoon/typhoon_ids.py
+++ b/core/domain/typhoon/typhoon_ids.py
@@ -28,9 +28,28 @@ def to_fan_id(typhoon_id: object) -> str:
 
 
 def normalize_typhoon_id(typhoon_id: object) -> str:
-    """返回用于缓存、去重和跨来源匹配的稳定 4 位编号。"""
+    """返回用于缓存、去重和跨来源匹配的稳定编号。
+
+    规则：
+    - 纯数字编号（202607 / 2607）：统一为 4 位年份短编号（2607）；
+    - NAMELESS 无名低压（NAMELESS_07 / NAMELESS-2604 / TD07）：
+      统一为 TD + 两位短编号（TD07 / TD04），
+      与 FAN Studio 侧 TDxx 编号归一到同一去重键，避免同源台风重复推送；
+    - 其他非标准编号：原样返回，不从混合文本硬抠数字。
+    """
     raw = _clean_id(typhoon_id)
     if not raw:
         return ""
+    upper = raw.upper()
     digits = "".join(char for char in raw if char.isdigit())
+
+    # NAMELESS / TD 前缀的无名低压：统一为 TD + 两位短编号
+    if upper.startswith("NAMELESS") or upper.startswith("TD"):
+        if digits:
+            return f"TD{digits[-2:]}"
+        # 无数字可提取（如裸 TD / NAMELESS）：保持前缀本身
+        if upper.startswith("NAMELESS"):
+            return "TD"
+        return "TD"
+
     return digits[-4:] if len(digits) >= 4 else raw

--- a/core/domain/typhoon/typhoon_ids.py
+++ b/core/domain/typhoon/typhoon_ids.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+import re
+
+# 无名低压合法格式：NAMELESS / TD 前缀 + 可选分隔符（_/-）+ 1~4 位数字后缀。
+# 完整匹配，拒绝 NAMELESSNESS_07 / TDX_07 等仅以关键词开头的非标准编号，
+# 避免去重键误合并不同系统。
+_TD_FORMAT = re.compile(
+    r"^(?:NAMELESS|TD)(?:[_-]?\d{1,4})?$",
+    re.IGNORECASE,
+)
+
 
 def _clean_id(typhoon_id: object) -> str:
     return str(typhoon_id or "").strip()
@@ -28,30 +38,26 @@ def to_fan_id(typhoon_id: object) -> str:
 
 
 def extract_td_short_id(typhoon_id: object) -> str:
-    """从 NAMELESS/TD 前缀的无名低压编号中提取 TD + 两位短编号。
+    """从 NAMELESS/TD 无名低压编号中提取 TD + 两位短编号。
 
+    仅接受完整合法格式（NAMELESS / TD + 可选分隔符 + 数字后缀）：
     - NAMELESS / TD（裸）-> TD
-    - NAMELESS_07 / TD07 / TD_07 -> TD07
+    - NAMELESS_07 / TD07 / TD_07 / NAMELESS07 -> TD07
     - NAMELESS_2604 -> TD04（仅取两位短编号，避免与正式编号 2604 混淆）
+
+    格式不匹配（如 NAMELESSNESS_07 / TDX_07）时返回空字符串，
+    由调用方回退到原编号，避免去重键误合并不同系统。
 
     供去重键（normalize_typhoon_id）与展示格式（format_typhoon_short_id）
     共用，避免两处规则在未来产生差异。
     """
     raw = _clean_id(typhoon_id)
-    if not raw:
+    if not raw or not _TD_FORMAT.match(raw):
         return ""
     upper = raw.upper()
     if upper == "NAMELESS" or upper == "TD":
         return "TD"
-    if upper.startswith("NAMELESS"):
-        remainder = raw[len("NAMELESS") :].lstrip("_-")
-    elif upper.startswith("TD"):
-        remainder = raw[2:].lstrip("_-")
-    else:
-        return ""
-    if not remainder:
-        return "TD"
-    digits = "".join(char for char in remainder if char.isdigit())
+    digits = "".join(char for char in raw if char.isdigit())
     if digits:
         return f"TD{digits[-2:]}"
     return "TD"
@@ -62,7 +68,7 @@ def normalize_typhoon_id(typhoon_id: object) -> str:
 
     规则：
     - 纯数字编号（202607 / 2607）：统一为 4 位年份短编号（2607）；
-    - NAMELESS 无名低压（NAMELESS_07 / NAMELESS-2604 / TD07）：
+    - 无名低压（NAMELESS_07 / NAMELESS-2604 / TD07 等合法格式）：
       统一为 TD + 两位短编号（TD07 / TD04），
       与 FAN Studio 侧 TDxx 编号归一到同一去重键，避免同源台风重复推送；
     - 其他非标准编号：原样返回，不从混合文本硬抠数字。
@@ -70,10 +76,11 @@ def normalize_typhoon_id(typhoon_id: object) -> str:
     raw = _clean_id(typhoon_id)
     if not raw:
         return ""
-    upper = raw.upper()
-    # 无名低压统一键
-    if upper.startswith("NAMELESS") or upper.startswith("TD"):
-        return extract_td_short_id(raw)
+    # 无名低压统一键：仅当格式完全合法时归一化，
+    # 否则（如 NAMELESSNESS_07 / TDX_07）回退原编号，避免误合并去重键。
+    td_short = extract_td_short_id(raw)
+    if td_short:
+        return td_short
     # 纯数字官方编号统一为 4 位短编号
     if raw.isdigit():
         return raw[-4:]

--- a/core/message/presenters/typhoon_presenter.py
+++ b/core/message/presenters/typhoon_presenter.py
@@ -17,6 +17,7 @@ from ...domain.event_context import TyphoonDisplayContext
 from ...domain.typhoon.typhoon_display_format import (
     format_coordinates,
     format_move_direction,
+    format_typhoon_short_id,
     format_wind_circle,
     format_wind_speed,
     get_typhoon_level_emoji,
@@ -139,9 +140,11 @@ class TyphoonPresenter(BasePresenter):
         # 编号
         id_display = display_context.typhoon_id or ""
         if id_display:
-            # 按模板展示为 4 位编号（如 2609）
-            short_id = id_display[-4:] if len(id_display) >= 4 else id_display
-            lines.append(f"📌编号：{short_id}")
+            # 统一短编号格式：纯数字官方编号取 4 位（2609），
+            # NAMELESS 无名低压取 TD + 两位短编号（TD07），避免出现 S_07 这类截断。
+            short_id = format_typhoon_short_id(id_display)
+            if short_id:
+                lines.append(f"📌编号：{short_id}")
 
         # 等级（后附圆形颜色emoji指示器）
         if display_context.typhoon_type:

--- a/core/services/display/builders/typhoon_context_builder.py
+++ b/core/services/display/builders/typhoon_context_builder.py
@@ -27,6 +27,7 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
                 projection_view.get("typhoon_id"),
                 "",
             )
+            or ""
         ).strip(),
         "name": str(
             first_non_empty(
@@ -34,6 +35,7 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
                 projection_view.get("name"),
                 "",
             )
+            or ""
         ).strip(),
         "name_en": str(
             first_non_empty(
@@ -41,6 +43,7 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
                 projection_view.get("name_en"),
                 "",
             )
+            or ""
         ).strip(),
         "typhoon_type": str(
             first_non_empty(
@@ -48,6 +51,7 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
                 projection_view.get("typhoon_type"),
                 "",
             )
+            or ""
         ).strip(),
         "is_active": bool(
             first_non_empty(

--- a/core/services/display/builders/typhoon_context_builder.py
+++ b/core/services/display/builders/typhoon_context_builder.py
@@ -5,9 +5,26 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ....domain.display_models import TyphoonDisplayModel
 from ....domain.event_context import TyphoonDisplayContext
+from ....domain.typhoon.typhoon_values import clean_text
 from .common import build_projection_view, coerce_dict, first_non_empty
+
+
+def _pick_cleaned_text(*values: Any) -> str:
+    """先分别清洗各文本候选，再取第一个非空结果。
+
+    first_non_empty 只跳过 None 和空白字符串，会把 "None"/"NULL"/"无数据"
+    等占位字符串当作有效值；这里统一用 clean_text 清洗后再选值，
+    避免展示层输出裸 "None" 等占位文本。
+    """
+    for value in values:
+        cleaned = clean_text(value)
+        if cleaned:
+            return cleaned
+    return ""
 
 
 def _extract_typhoon_projection_details(metadata, source_payload, domain_event=None):
@@ -21,38 +38,22 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
         metadata=metadata,
     )
     return {
-        "typhoon_id": str(
-            first_non_empty(
-                getattr(domain_event, "typhoon_id", None),
-                projection_view.get("typhoon_id"),
-                "",
-            )
-            or ""
-        ).strip(),
-        "name": str(
-            first_non_empty(
-                getattr(domain_event, "name", None),
-                projection_view.get("name"),
-                "",
-            )
-            or ""
-        ).strip(),
-        "name_en": str(
-            first_non_empty(
-                getattr(domain_event, "name_en", None),
-                projection_view.get("name_en"),
-                "",
-            )
-            or ""
-        ).strip(),
-        "typhoon_type": str(
-            first_non_empty(
-                getattr(domain_event, "typhoon_type", None),
-                projection_view.get("typhoon_type"),
-                "",
-            )
-            or ""
-        ).strip(),
+        "typhoon_id": _pick_cleaned_text(
+            getattr(domain_event, "typhoon_id", None),
+            projection_view.get("typhoon_id"),
+        ),
+        "name": _pick_cleaned_text(
+            getattr(domain_event, "name", None),
+            projection_view.get("name"),
+        ),
+        "name_en": _pick_cleaned_text(
+            getattr(domain_event, "name_en", None),
+            projection_view.get("name_en"),
+        ),
+        "typhoon_type": _pick_cleaned_text(
+            getattr(domain_event, "typhoon_type", None),
+            projection_view.get("typhoon_type"),
+        ),
         "is_active": bool(
             first_non_empty(
                 getattr(domain_event, "is_active", None)
@@ -92,13 +93,10 @@ def _extract_typhoon_projection_details(metadata, source_payload, domain_event=N
             else None,
             projection_view.get("power"),
         ),
-        "move_direction": str(
-            first_non_empty(
-                getattr(domain_event, "move_direction", None),
-                projection_view.get("move_direction"),
-                "",
-            )
-        ).strip(),
+        "move_direction": _pick_cleaned_text(
+            getattr(domain_event, "move_direction", None),
+            projection_view.get("move_direction"),
+        ),
         "move_speed": first_non_empty(
             getattr(domain_event, "move_speed", None)
             if domain_event is not None and hasattr(domain_event, "move_speed")
@@ -219,20 +217,12 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
         event_id=envelope.id,
         source_id=resolved_source_id,
         title=title,
-        typhoon_id=(
-            getattr(domain_event, "typhoon_id", None)
-            or payload_details["typhoon_id"]
-            or ""
-        ),
-        name=(getattr(domain_event, "name", None) or payload_details["name"] or ""),
-        name_en=(
-            getattr(domain_event, "name_en", None) or payload_details["name_en"] or ""
-        ),
-        typhoon_type=(
-            getattr(domain_event, "typhoon_type", None)
-            or payload_details["typhoon_type"]
-            or ""
-        ),
+        typhoon_id=(payload_details["typhoon_id"] or ""),
+        # 文本字段一律使用 payload_details 已清洗结果，
+        # 避免 domain_event 原始占位值（如 "None"）绕过清洗进入展示。
+        name=(payload_details["name"] or ""),
+        name_en=(payload_details["name_en"] or ""),
+        typhoon_type=(payload_details["typhoon_type"] or ""),
         is_active=bool(
             getattr(domain_event, "is_active", True)
             if hasattr(domain_event, "is_active")
@@ -263,11 +253,7 @@ def build_typhoon_display_context(projection: dict, options: dict | None = None)
             if hasattr(domain_event, "power")
             else payload_details["power"]
         ),
-        move_direction=(
-            getattr(domain_event, "move_direction", None)
-            or payload_details["move_direction"]
-            or ""
-        ),
+        move_direction=(payload_details["move_direction"] or ""),
         move_speed=(
             getattr(domain_event, "move_speed", None)
             if hasattr(domain_event, "move_speed")

--- a/core/services/query/typhoon_data_adapter.py
+++ b/core/services/query/typhoon_data_adapter.py
@@ -200,8 +200,10 @@ def normalize_eqsc_typhoon(
         return None
 
     fan_id = to_fan_id(eqsc_id)
-    name_cn = clean_text(raw.get("nameCN") or raw.get("name"))
-    name_en = clean_text(raw.get("nameEN") or raw.get("name_en"))
+    # 先分别清洗每个候选值，再取第一个非空结果：
+    # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
+    name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
+    name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
     # EQSC 历史轨迹顺序不保证：先按时间升序，再取最新观测。
     history_track = sort_history_track(
         raw.get("historyTrack") or raw.get("history_track") or []

--- a/core/services/query/typhoon_query_presenter.py
+++ b/core/services/query/typhoon_query_presenter.py
@@ -12,6 +12,7 @@ from typing import Any
 from ...domain.typhoon.typhoon_display_format import (
     format_coordinates,
     format_move_direction,
+    format_typhoon_short_id,
     format_wind_circle,
     format_wind_speed,
     get_typhoon_level_emoji,
@@ -20,55 +21,8 @@ from ...domain.typhoon.typhoon_display_format import (
 from ..geo.region_service import region_service
 from .typhoon_query_parser import DETAIL_CURRENT, DETAIL_FULL
 
-
-def _format_typhoon_short_id(*candidates: object) -> str:
-    """统一输出台风短编号，规则与前端 formatTyphoonShortId 对齐。
-
-    - 纯数字官方编号：202609 / 2609 -> 2609
-    - NAMELESS 无名低压：NAMELESS_2604 -> TD2604（避免与正式编号 2604 冲突）
-    - 其他非标准编号：原样返回，不从混合文本硬抠数字
-    """
-    for candidate in candidates:
-        text = str(candidate or "").strip()
-        if not text:
-            continue
-        lowered = text.lower()
-        if lowered in {"unknown", "未知"}:
-            continue
-
-        if text.isdigit() and len(text) >= 4:
-            return text[-4:]
-
-        upper = text.upper()
-        # 裸 NAMELESS / NAMELESS_03 / NAMELESS_2604 均统一为 TD 前缀
-        if (
-            upper == "NAMELESS"
-            or upper.startswith("NAMELESS_")
-            or upper.startswith("NAMELESS-")
-        ):
-            if upper == "NAMELESS":
-                return "TD"
-            suffix = (
-                text.split("_", 1)[1].strip()
-                if "_" in text
-                else text.split("-", 1)[1].strip()
-                if "-" in text
-                else text[8:].lstrip("_-")
-            )
-            suffix = suffix.strip()
-            if not suffix:
-                return "TD"
-            if suffix.isdigit():
-                return f"TD{suffix}"
-            if suffix.upper().startswith("TD"):
-                return suffix.upper()
-            return f"TD{suffix}"
-
-        if upper.startswith("TD"):
-            return "TD" + text[2:].lstrip("_-")
-
-        return text
-    return ""
+# 统一短编号格式化复用公共展示工具，避免展示逻辑分叉。
+_format_typhoon_short_id = format_typhoon_short_id
 
 
 def _format_reference_place(latitude: Any, longitude: Any) -> str:

--- a/core/services/telemetry/telemetry_service.py
+++ b/core/services/telemetry/telemetry_service.py
@@ -384,7 +384,7 @@ class TelemetryManager:
                             self._last_429_time is None
                             or (now - self._last_429_time).total_seconds() > 600
                         ):
-                            logger.debug("[灾害预警] 遥测请求频率超限")
+                            logger.warning("[灾害预警] 遥测请求频率超限")
                             self._last_429_time = now
                     else:
                         logger.debug(

--- a/resources/card_templates/Aurora/global_quake.html
+++ b/resources/card_templates/Aurora/global_quake.html
@@ -191,11 +191,12 @@
         .intensity-mini {
             margin-top: 10px;
             background: rgba(255, 255, 255, 0.35);
-            padding: 4px 12px;
+            padding: 4px 10px;
             border-radius: 8px;
             font-size: 13px;
             font-weight: 800;
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+            white-space: nowrap;
         }
 
         .key-data-list {

--- a/resources/card_templates/DarkNight/global_quake.html
+++ b/resources/card_templates/DarkNight/global_quake.html
@@ -80,7 +80,7 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            padding: 15px 10px;
+            padding: 15px 6px;
             border-right: 1px solid var(--border);
             gap: 8px;
         }
@@ -100,11 +100,13 @@
 
         .intensity-badge {
             background: var(--color-intensity);
-            font-size: 0.75rem;
-            padding: 2px 8px;
+            font-size: 0.72rem;
+            padding: 2px 6px;
             border-radius: 4px;
             font-weight: bold;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+            white-space: nowrap;
+            text-align: center;
         }
 
         /* 右侧：详细数据 */


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复未命名低压台风（低压系统）的标识与展示逻辑，防止重复通知以及消息内容格式错误。

Bug Fixes:
- 通过统一规范有效的 `NAMELESS/TD` 标识，防止同一未命名低压系统在不同数据源之间产生重复通知。
- 防止占位值（例如 `"None"` 和 `"NULL"`）出现在台风名称和消息内容中。
- 在显示短 ID 时保留完整的未命名低压标识，而不是错误地截断。

Enhancements:
- 将台风短 ID 的格式化逻辑集中管理，并在去重、查询和通知中复用相同的规范化规则。
- 改进台风名称字段的回退处理逻辑，当首选数据源的值为空或为占位符时能更好地处理。
- 调整卡片布局间距，防止强度标签发生换行。

Chores:
- 将遥测（telemetry）限流日志级别从 debug 提升为 warning。
- 为模拟草稿对话框内容增加间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unnamed low-pressure typhoon identity and presentation handling to prevent duplicate notifications and malformed message content.

Bug Fixes:
- Prevent duplicate notifications for the same unnamed low-pressure system across data sources by normalizing valid NAMELESS/TD identifiers consistently.
- Prevent placeholder values such as "None" and "NULL" from appearing in typhoon names and message content.
- Preserve complete unnamed low-pressure identifiers in displayed short IDs instead of truncating them incorrectly.

Enhancements:
- Centralize typhoon short-ID formatting and reuse the same normalization rules across deduplication, queries, and notifications.
- Improve fallback handling for typhoon name fields when preferred source values are empty or placeholders.
- Adjust card layout spacing and prevent intensity labels from wrapping.

Chores:
- Increase telemetry rate-limit logging from debug to warning.
- Add spacing to the simulation draft dialog content.

</details>

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 统一台风及低压编号展示格式，支持纯数字、无名台风及缺失编号。
  - 优化非标准编号识别，减少异常或空白编号显示。
  - 改进中英文名称选择，自动忽略 `None`、`NULL` 等无效占位内容。
  - 清理台风详情中的标识、名称、类型和移动方向，提升信息准确性。

- **界面优化**
  - 优化模拟流草稿对话框间距。
  - 调整地震卡片强度标签样式，确保内容单行显示并改善对齐效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->