### PR TITLE
fix(typhoon): 无名低压生成可读回退名称，恢复推送正文名称行

### DIFF
--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -228,11 +228,14 @@ class TyphoonEnrichmentService:
         eqsc_name_en = clean_text(eqsc_typhoon.get("nameEN")) or clean_text(
             eqsc_typhoon.get("name_en")
         )
-        # 覆盖判断同样基于清洗值：FAN 侧可能残留占位字符串（如 "None"），
-        # 若仅判断 truthy 会阻断 EQSC 有效名称的覆盖。
-        if eqsc_name_cn and not clean_text(typhoon_event.name):
+        # 先回写清洗后的名称：FAN 侧可能残留占位字符串（如 "None"），
+        # 若不清洗保存，占位文本会继续进入后续数据和通知。
+        typhoon_event.name = clean_text(typhoon_event.name)
+        typhoon_event.name_en = clean_text(typhoon_event.name_en)
+        # EQSC 提供有效名称且当前名称为空（清洗后）时覆盖。
+        if eqsc_name_cn and not typhoon_event.name:
             typhoon_event.name = eqsc_name_cn
-        if eqsc_name_en and not clean_text(typhoon_event.name_en):
+        if eqsc_name_en and not typhoon_event.name_en:
             typhoon_event.name_en = eqsc_name_en
 
         # EQSC 的 isActive 字段

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -232,20 +232,24 @@ class TyphoonEnrichmentService:
         # 若不清洗保存，占位文本会继续进入后续数据和通知。
         typhoon_event.name = clean_text(typhoon_event.name)
         typhoon_event.name_en = clean_text(typhoon_event.name_en)
-        # 当前名称是否为回退生成：是则 EQSC 有效名称可覆盖，
-        # 避免 parser 侧生成的占位回退名阻断真实名称写入。
-        name_is_fallback = bool((envelope.metadata or {}).get("name_is_fallback"))
-        # EQSC 提供有效名称且当前名称为空（清洗后）或为回退名时覆盖。
-        if eqsc_name_cn and (not typhoon_event.name or name_is_fallback):
+        # 按语言分别跟踪回退标记：EQSC 提供对应语言的有效名称且该语言
+        # 名称为空（清洗后）或为回退名时覆盖；单语言覆盖不影响另一语言，
+        # 避免残留回退名无法被后续富化覆盖。
+        metadata = envelope.metadata if isinstance(envelope.metadata, dict) else {}
+        name_is_fallback_cn = bool(metadata.get("name_is_fallback_cn"))
+        name_is_fallback_en = bool(metadata.get("name_is_fallback_en"))
+        if eqsc_name_cn and (not typhoon_event.name or name_is_fallback_cn):
             typhoon_event.name = eqsc_name_cn
-        if eqsc_name_en and (not typhoon_event.name_en or name_is_fallback):
+            name_is_fallback_cn = False
+        if eqsc_name_en and (not typhoon_event.name_en or name_is_fallback_en):
             typhoon_event.name_en = eqsc_name_en
-        # 覆盖完成后清理标记，避免下游误判名称仍为回退态。
-        if (envelope.metadata or {}).get("name_is_fallback"):
-            envelope.metadata = {
-                **envelope.metadata,
-                "name_is_fallback": False,
-            }
+            name_is_fallback_en = False
+        # 覆盖完成后回写按语言拆分的标记，避免下游误判名称仍为回退态。
+        envelope.metadata = {
+            **metadata,
+            "name_is_fallback_cn": name_is_fallback_cn,
+            "name_is_fallback_en": name_is_fallback_en,
+        }
 
         # EQSC 的 isActive 字段
         eqsc_is_active = eqsc_typhoon.get("isActive")

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -228,9 +228,11 @@ class TyphoonEnrichmentService:
         eqsc_name_en = clean_text(eqsc_typhoon.get("nameEN")) or clean_text(
             eqsc_typhoon.get("name_en")
         )
-        if eqsc_name_cn and not typhoon_event.name:
+        # 覆盖判断同样基于清洗值：FAN 侧可能残留占位字符串（如 "None"），
+        # 若仅判断 truthy 会阻断 EQSC 有效名称的覆盖。
+        if eqsc_name_cn and not clean_text(typhoon_event.name):
             typhoon_event.name = eqsc_name_cn
-        if eqsc_name_en and not typhoon_event.name_en:
+        if eqsc_name_en and not clean_text(typhoon_event.name_en):
             typhoon_event.name_en = eqsc_name_en
 
         # EQSC 的 isActive 字段

--- a/core/app/services/typhoon_enrichment_service.py
+++ b/core/app/services/typhoon_enrichment_service.py
@@ -232,11 +232,20 @@ class TyphoonEnrichmentService:
         # 若不清洗保存，占位文本会继续进入后续数据和通知。
         typhoon_event.name = clean_text(typhoon_event.name)
         typhoon_event.name_en = clean_text(typhoon_event.name_en)
-        # EQSC 提供有效名称且当前名称为空（清洗后）时覆盖。
-        if eqsc_name_cn and not typhoon_event.name:
+        # 当前名称是否为回退生成：是则 EQSC 有效名称可覆盖，
+        # 避免 parser 侧生成的占位回退名阻断真实名称写入。
+        name_is_fallback = bool((envelope.metadata or {}).get("name_is_fallback"))
+        # EQSC 提供有效名称且当前名称为空（清洗后）或为回退名时覆盖。
+        if eqsc_name_cn and (not typhoon_event.name or name_is_fallback):
             typhoon_event.name = eqsc_name_cn
-        if eqsc_name_en and not typhoon_event.name_en:
+        if eqsc_name_en and (not typhoon_event.name_en or name_is_fallback):
             typhoon_event.name_en = eqsc_name_en
+        # 覆盖完成后清理标记，避免下游误判名称仍为回退态。
+        if (envelope.metadata or {}).get("name_is_fallback"):
+            envelope.metadata = {
+                **envelope.metadata,
+                "name_is_fallback": False,
+            }
 
         # EQSC 的 isActive 字段
         eqsc_is_active = eqsc_typhoon.get("isActive")

--- a/core/domain/typhoon/__init__.py
+++ b/core/domain/typhoon/__init__.py
@@ -12,7 +12,7 @@ from .typhoon_event_adapter import build_typhoon_event_envelope
 from .typhoon_ids import normalize_typhoon_id, to_eqsc_id, to_fan_id
 from .typhoon_levels import LEVEL_WEIGHTS, compare_levels, level_weight, normalize_level
 from .typhoon_modes import resolve_data_mode
-from .typhoon_names import format_display_name
+from .typhoon_names import build_td_fallback_names, format_display_name
 from .typhoon_peaks import merge_peak_metrics, resolve_storage_peak_fields
 from .typhoon_values import clean_text, is_nullish, to_float, to_int
 from .typhoon_winds import (
@@ -28,6 +28,7 @@ __all__ = [
     "LEVEL_WEIGHTS",
     "WIND_CIRCLE_KEYS",
     "WIND_CIRCLE_LABELS",
+    "build_td_fallback_names",
     "build_typhoon_event_envelope",
     "clean_text",
     "clean_wind_circle",

--- a/core/domain/typhoon/typhoon_event_adapter.py
+++ b/core/domain/typhoon/typhoon_event_adapter.py
@@ -138,15 +138,6 @@ def build_typhoon_event_envelope(
     # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
     name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
     name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
-    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
-    # 基于编号与等级生成与停编条目一致的可读名称（07号热带低压 / TD No.07），
-    # 避免推送正文缺失名称行。
-    if not name_cn and not name_en and eqsc_id:
-        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id)
-        if fallback_cn:
-            name_cn = fallback_cn
-        if fallback_en:
-            name_en = fallback_en
     history_track = raw.get("historyTrack") or raw.get("history_track") or []
     future_track = raw.get("futureTrack") or raw.get("future_track") or []
     if not isinstance(history_track, list):
@@ -214,6 +205,16 @@ def build_typhoon_event_envelope(
         move_speed = to_float(peak_node.get("speed"))
         message_type = "typhoon_history"
         mode_label = "eqsc_rebuild"
+
+    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
+    # 基于编号与实际等级生成与停编条目一致的可读名称（07号热带低压 / TD No.07），
+    # 避免推送正文缺失名称行。
+    if not name_cn and not name_en and eqsc_id:
+        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id, level)
+        if fallback_cn:
+            name_cn = fallback_cn
+        if fallback_en:
+            name_en = fallback_en
 
     # EventEnvelope.metadata 只记录流水线形态，原始 EQSC 字典留在 SourcePayload。
     identity = EventIdentity(

--- a/core/domain/typhoon/typhoon_event_adapter.py
+++ b/core/domain/typhoon/typhoon_event_adapter.py
@@ -11,6 +11,7 @@ from ..event_models import EventEnvelope, TyphoonEvent
 from ..event_payload import SourcePayload
 from .typhoon_ids import to_fan_id
 from .typhoon_levels import level_weight
+from .typhoon_names import build_td_fallback_names
 from .typhoon_values import clean_text, is_nullish, to_float
 from .typhoon_winds import extract_max_radius
 
@@ -137,6 +138,15 @@ def build_typhoon_event_envelope(
     # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
     name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
     name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
+    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
+    # 基于编号与等级生成与停编条目一致的可读名称（07号热带低压 / TD No.07），
+    # 避免推送正文缺失名称行。
+    if not name_cn and not name_en and eqsc_id:
+        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id)
+        if fallback_cn:
+            name_cn = fallback_cn
+        if fallback_en:
+            name_en = fallback_en
     history_track = raw.get("historyTrack") or raw.get("history_track") or []
     future_track = raw.get("futureTrack") or raw.get("future_track") or []
     if not isinstance(history_track, list):

--- a/core/domain/typhoon/typhoon_names.py
+++ b/core/domain/typhoon/typhoon_names.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .typhoon_ids import extract_td_short_id
 from .typhoon_values import clean_text
 
 
@@ -21,3 +22,25 @@ def format_display_name(
             return cn
         return f"{cn}（{en}）"
     return cn or en or tid or fallback
+
+
+def build_td_fallback_names(typhoon_id: object, level: object = "") -> tuple[str, str]:
+    """为无名低压生成可读回退名称（中文名, 英文名）。
+
+    EQSC/FAN 活跃无名低压条目的 nameCN/nameEN 常为占位符（如 "None"），
+    清洗后为空；此处基于编号与等级生成与停编条目一致的展示名：
+
+    - 编号 TD07 / NAMELESS_07 + 等级"热带低压"
+      -> ("07号热带低压", "TD No.07")
+
+    编号不匹配 TD/NAMELESS 合法格式或提取失败时返回空字符串，
+    由调用方保持原样（不臆造名称）。
+    """
+    short_id = extract_td_short_id(typhoon_id)
+    if not short_id or short_id == "TD":
+        return "", ""
+    digits = short_id[2:]
+    if not digits:
+        return "", ""
+    level_cn = clean_text(level) or "热带低压"
+    return f"{digits}号{level_cn}", f"TD No.{digits}"

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -95,16 +95,18 @@ class TyphoonParser(BaseParser):
 
         # FAN 无名低压同样可能只有占位名称：清洗后为空时，基于编号+等级
         # 生成可读回退名，避免 EQSC 不可用或同样返回占位名时推送缺名称。
-        # 回退名打标记：后续 EQSC 富化提供有效名称时允许覆盖回退名。
-        name_is_fallback = False
+        # 回退名按语言分别打标记：后续 EQSC 富化提供对应语言的有效名称时
+        # 允许覆盖该语言的回退名（单语言覆盖不影响另一语言标记）。
+        name_is_fallback_cn = False
+        name_is_fallback_en = False
         if not name and not name_en and typhoon_id:
             fallback_cn, fallback_en = build_td_fallback_names(typhoon_id, typhoon_type)
-            if fallback_cn or fallback_en:
-                name_is_fallback = True
             if fallback_cn:
                 name = fallback_cn
+                name_is_fallback_cn = True
             if fallback_en:
                 name_en = fallback_en
+                name_is_fallback_en = True
 
         # 若名称和类型全部缺失，视为无效数据
         if not name and not name_en and not typhoon_type:
@@ -144,9 +146,11 @@ class TyphoonParser(BaseParser):
             "source_type": source_entry.source_type.value
             if source_entry
             else "typhoon",
-            # 标记名称是否为回退生成的占位名：EQSC 富化提供有效名称时
-            # 允许覆盖，避免回退名阻断真实名称写入。
-            "name_is_fallback": name_is_fallback,
+            # 按语言分别标记名称是否为回退生成的占位名：EQSC 富化提供
+            # 对应语言的有效名称时允许覆盖该语言回退名；单语言覆盖
+            # 不清除另一语言标记，避免残留回退名无法被后续覆盖。
+            "name_is_fallback_cn": name_is_fallback_cn,
+            "name_is_fallback_en": name_is_fallback_en,
         }
 
         # 实例化台风领域模型（唯一业务状态真源）

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -95,8 +95,12 @@ class TyphoonParser(BaseParser):
 
         # FAN 无名低压同样可能只有占位名称：清洗后为空时，基于编号+等级
         # 生成可读回退名，避免 EQSC 不可用或同样返回占位名时推送缺名称。
+        # 回退名打标记：后续 EQSC 富化提供有效名称时允许覆盖回退名。
+        name_is_fallback = False
         if not name and not name_en and typhoon_id:
             fallback_cn, fallback_en = build_td_fallback_names(typhoon_id, typhoon_type)
+            if fallback_cn or fallback_en:
+                name_is_fallback = True
             if fallback_cn:
                 name = fallback_cn
             if fallback_en:
@@ -140,6 +144,9 @@ class TyphoonParser(BaseParser):
             "source_type": source_entry.source_type.value
             if source_entry
             else "typhoon",
+            # 标记名称是否为回退生成的占位名：EQSC 富化提供有效名称时
+            # 允许覆盖，避免回退名阻断真实名称写入。
+            "name_is_fallback": name_is_fallback,
         }
 
         # 实例化台风领域模型（唯一业务状态真源）

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -15,6 +15,7 @@ from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EventEnvelope, TyphoonEvent
 from ..domain.event_payload import SourcePayload
+from ..domain.typhoon.typhoon_values import clean_text
 from ..sources.source_catalog import get_source_entry
 from .base_parser import BaseParser
 
@@ -85,9 +86,11 @@ class TyphoonParser(BaseParser):
             plugin_logger.debug(f"[灾害预警] {self.source_id} 台风消息缺少ID，跳过处理")
             return None
 
-        name = str(typhoon_data.get("name", "") or "").strip()
-        name_en = str(typhoon_data.get("name_en", "") or "").strip()
-        typhoon_type = str(typhoon_data.get("type", "") or "").strip()
+        # 使用 clean_text 清洗名称/类型：无名低压的 name 可能是占位字符串
+        # "None"/"NULL"，若不清洗会写入领域事件，阻断后续富化覆盖有效名称。
+        name = clean_text(typhoon_data.get("name"))
+        name_en = clean_text(typhoon_data.get("name_en"))
+        typhoon_type = clean_text(typhoon_data.get("type"))
 
         # 若名称和类型全部缺失，视为无效数据
         if not name and not name_en and not typhoon_type:

--- a/core/parsers/typhoon_parser.py
+++ b/core/parsers/typhoon_parser.py
@@ -15,6 +15,7 @@ from ...utils.plugin_logger import plugin_logger
 from ..domain.event_identity import EventIdentity
 from ..domain.event_models import EventEnvelope, TyphoonEvent
 from ..domain.event_payload import SourcePayload
+from ..domain.typhoon.typhoon_names import build_td_fallback_names
 from ..domain.typhoon.typhoon_values import clean_text
 from ..sources.source_catalog import get_source_entry
 from .base_parser import BaseParser
@@ -91,6 +92,15 @@ class TyphoonParser(BaseParser):
         name = clean_text(typhoon_data.get("name"))
         name_en = clean_text(typhoon_data.get("name_en"))
         typhoon_type = clean_text(typhoon_data.get("type"))
+
+        # FAN 无名低压同样可能只有占位名称：清洗后为空时，基于编号+等级
+        # 生成可读回退名，避免 EQSC 不可用或同样返回占位名时推送缺名称。
+        if not name and not name_en and typhoon_id:
+            fallback_cn, fallback_en = build_td_fallback_names(typhoon_id, typhoon_type)
+            if fallback_cn:
+                name = fallback_cn
+            if fallback_en:
+                name_en = fallback_en
 
         # 若名称和类型全部缺失，视为无效数据
         if not name and not name_en and not typhoon_type:

--- a/core/services/query/typhoon_data_adapter.py
+++ b/core/services/query/typhoon_data_adapter.py
@@ -205,14 +205,6 @@ def normalize_eqsc_typhoon(
     # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
     name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
     name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
-    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
-    # 基于编号与等级生成可读回退名，与推送路径保持一致。
-    if not name_cn and not name_en and eqsc_id:
-        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id)
-        if fallback_cn:
-            name_cn = fallback_cn
-        if fallback_en:
-            name_en = fallback_en
     # EQSC 历史轨迹顺序不保证：先按时间升序，再取最新观测。
     history_track = sort_history_track(
         raw.get("historyTrack") or raw.get("history_track") or []
@@ -241,6 +233,14 @@ def normalize_eqsc_typhoon(
     typhoon_type = clean_text(
         latest.get("typeNameCN") or latest.get("type") or raw.get("type")
     )
+    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
+    # 基于编号与实际等级生成可读回退名，与推送路径保持一致。
+    if not name_cn and not name_en and eqsc_id:
+        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id, typhoon_type)
+        if fallback_cn:
+            name_cn = fallback_cn
+        if fallback_en:
+            name_en = fallback_en
     radius7_raw = extract_max_radius(wind_circle, "30KTS")
     radius10_raw = extract_max_radius(wind_circle, "50KTS")
     radius7 = int(radius7_raw) if radius7_raw is not None else None

--- a/core/services/query/typhoon_data_adapter.py
+++ b/core/services/query/typhoon_data_adapter.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from ....utils.time_converter import TimeConverter
 from ...domain.typhoon import (
+    build_td_fallback_names,
     clean_text,
     extract_max_radius,
     format_display_name,
@@ -204,6 +205,14 @@ def normalize_eqsc_typhoon(
     # 避免 nameCN 为占位字符串（如 "NULL"）时屏蔽有效的 name 备用值。
     name_cn = clean_text(raw.get("nameCN")) or clean_text(raw.get("name"))
     name_en = clean_text(raw.get("nameEN")) or clean_text(raw.get("name_en"))
+    # EQSC 活跃无名低压的名称常为占位符（如 "None"），清洗后为空。
+    # 基于编号与等级生成可读回退名，与推送路径保持一致。
+    if not name_cn and not name_en and eqsc_id:
+        fallback_cn, fallback_en = build_td_fallback_names(eqsc_id)
+        if fallback_cn:
+            name_cn = fallback_cn
+        if fallback_en:
+            name_en = fallback_en
     # EQSC 历史轨迹顺序不保证：先按时间升序，再取最新观测。
     history_track = sort_history_track(
         raw.get("historyTrack") or raw.get("history_track") or []


### PR DESCRIPTION
## 📝 描述 / Description

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_disaster_warning/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为未命名的热带低压恢复可读的通知名称，并确保后续的富化流程可以用权威数据替换不同语言的回退名称。

Bug Fixes:
- 通过根据标识符和等级生成特定语言的回退名称，为未命名的热带低压在台风通知中恢复可读名称。
- 清理占位符名称值，并允许有效的 EQSC 名称在中文和英文中各自独立地替换回退名称。

Enhancements:
- 在事件元数据中保留回退名称状态，以便后续富化可以在不影响另一种语言的情况下正确替换生成的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore readable notification names for unnamed tropical depressions and ensure later enrichment can replace language-specific fallback names with authoritative values.

Bug Fixes:
- Restore readable names in typhoon notifications for unnamed tropical depressions by generating language-specific fallback names from their identifiers and levels.
- Clean placeholder name values and allow valid EQSC names to replace fallback names independently for Chinese and English.

Enhancements:
- Keep fallback-name state in event metadata so subsequent enrichment can correctly replace generated names without affecting the other language.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 当台风缺少中英文名称时，可根据编号和实际等级自动生成中英文备用名称。
  * 支持更准确地分别处理中文和英文备用名称。

* **问题修复**
  * 有效名称可覆盖空名称或对应语言的回退名称，提升台风事件名称展示准确性。
  * 使用有效名称后，会正确更新相应语言的回退状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->